### PR TITLE
chore: 接入 Lean Harness Agent 指导

### DIFF
--- a/.omp/AGENTS.md
+++ b/.omp/AGENTS.md
@@ -1,0 +1,48 @@
+# 107 Workspace OMP 上下文
+
+本项目使用 Lean Harness 作为工程方法与可复用 Skills 的来源。
+
+Lean Harness 固定版本目录：
+
+`~/.local/share/lean-harness/v0.1.0-dogfood`
+
+## 工程原则
+
+对于非简单的工程判断，以 Lean Harness Policy 作为方法指导：
+
+@~/.local/share/lean-harness/v0.1.0-dogfood/policy/index.md
+
+当当前任务与某个 Lean Harness Skill 匹配时，优先使用通过 `.omp/config.yml`
+加载的对应 Skill。
+
+Lean Harness 负责提供通用工程方法、风险判断与可复用能力；
+具体项目规则以本仓库定义为准。
+
+## 项目权威
+
+@../AGENTS.md
+
+## 工作连续性
+
+本仓库拥有自己的持久化工作状态机制。
+
+以下情况使用 `docs/journal/`：
+
+- 工作需要跨会话继续；
+- 存在多人或多个 Agent 并行，需要明确工作归属；
+- 需要暂停、交接或之后恢复；
+- 存在仓库外副作用，需要记录当前真实状态。
+
+GitHub Issue 负责记录任务目标、范围、验收条件和正式任务决策。
+
+Git 负责记录当前仓库和代码的真实状态。
+
+ADR 与产品文档负责记录需要长期保留的设计和产品决策。
+
+不要为同一项工作再建立一套并行的 Lean Harness Continuity 工作日志。
+
+OMP 会话历史和上下文压缩仅属于临时运行时上下文，
+不能作为项目持久状态的事实来源。
+
+Lean Harness Continuity 可以作为工作连续性设计的参考，
+但除非本项目以后明确采用，否则不作为 107 Workspace 的持久工作状态权威。

--- a/.omp/config.yml
+++ b/.omp/config.yml
@@ -15,3 +15,6 @@ autolearn:
 task:
   isolation:
     mode: none
+
+github:
+  enabled: false

--- a/.omp/config.yml
+++ b/.omp/config.yml
@@ -1,0 +1,17 @@
+skills:
+  customDirectories:
+    - ~/.local/share/lean-harness/v0.1.0-dogfood/skills
+
+workspace:
+  additionalDirectories:
+    - ~/.local/share/lean-harness/v0.1.0-dogfood
+
+memory:
+  backend: off
+
+autolearn:
+  enabled: false
+
+task:
+  isolation:
+    mode: none

--- a/.omp/mcp.json
+++ b/.omp/mcp.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "!printf 'Bearer %s' \"$(gh auth token)\"",
+        "X-MCP-Tools": "get_me,issue_read,search_issues,add_issue_comment,pull_request_read,search_pull_requests,create_pull_request,update_pull_request,pull_request_review_write,merge_pull_request,actions_list,actions_get"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,139 +1,125 @@
 # 107 Workspace
 
-面向本科生的算力平台：把 Slurm 的提交-排队-取结果流程，变成 Workspace / Project /
-Run 的可复现工作流。
+本文件是 Coding Agent 在 107 Workspace 中工作的项目入口。
 
-> **这份是宪法：只放不会过期的约束和指针。**
-> 已经有专门文档的东西**一律不在这里重复**，重复的两份一定会有一份过期。
+这里只保存 Agent 的工程行为和仓库级工作边界。
 
-| 想知道 | 看 |
-| --- | --- |
-| 产品能力、**领域语言与规则** | `docs/product/design.md`（现行、已确认）——**术语以它 §3.1 为准** |
-| 分支 / 提交 / PR / Milestone / 标签 / LFS | `docs/contributing/git-workflow.md` |
-| 在途工作、谁在做什么 | `docs/journal/` + `make journal` |
-| 为什么这么设计 | `docs/decisions/` |
-| 容器部署入口与生产边界 | `deploy/README.md` + `docs/operations/deployment.md` |
-| 前后端 API 机器契约 | `contracts/README.md` + `make contract` |
-| 测试粒度、目录与重构期基线 | `docs/testing/README.md` |
+产品规则、领域模型、测试规范、部署语义和长期设计决定等已经有权威文档的内容，
+不要复制到本文件。
 
-`archive/`、`docs/archive/` 和 `docs/references/` 保存历史实现、过程记录与输入材料，
-不是活动规范。与它们冲突时以 `docs/product/design.md` 为准。
+支持 Lean Harness 的运行环境通过 `.omp/AGENTS.md`
+获得完整 Policy 和 Skills。
+
+其他环境至少遵循本文件中的工程原则和项目索引。
+
+## 工程原则
+
+如果当前环境能够使用 Lean Harness，
+以 `.omp/AGENTS.md` 引入的完整 Policy 和 Skills 为准。
+
+否则至少遵循以下原则：
+
+- 优先推进真实、可验证的结果，不用流程、检查或汇报动作本身冒充进度。
+- 实现前先调查现有代码、标准能力、已有依赖和项目模式；
+  优先复用已经正确解决的问题，不重复造轮子。
+- 选择满足当前目标且整体复杂度最低的方案，
+  不为假设中的未来提前建设抽象、兼容层或基础设施。
+- 局部、可逆、影响可控的普通工程决定直接完成。
+  技术未知优先通过代码、文档和实验自行收敛。
+- 用户可见但需求未定义的行为、public contract、权限与安全边界、
+  破坏性持久状态变化、发布部署及其他高影响且难以逆转的决定，
+  请求相应的人类判断。
+- 测试保护值得长期维护的可观察行为、业务规则、契约和重要风险，
+  不保护施工过程或偶然实现细节。
+- 默认需要与风险相称的 fresh evidence，但不默认要求新增永久测试。
+  迁移、旧语义清理和机械重构可以使用 targeted check、搜索、
+  临时脚本或一次性测试完成验证。
+- 检查、Review 和重新确认由真实风险、技术不确定性或决策价值触发。
+  不要在正常推进的每一步机械停下来确认“目前还没出问题”。
+- 完成声明必须与实际证据一致；未验证的部分明确说明。
+
+## 查找项目事实
+
+开始任务后：
+
+1. 根据需要了解项目概况和当前实现；
+2. 查看 `docs/README.md`，找到当前问题对应的权威来源；
+3. 阅读与任务直接相关的文档和当前代码；
+4. 在这些事实基础上继续实现。
+
+不要机械加载所有文档。
+
+`archive/`、`docs/archive/` 和 `docs/references/`
+不是当前产品或实现规则的默认事实来源。
+
+不要因为搜索命中了历史材料，就把它当作当前规范。
+
+## 仓库边界
+
+判断代码位置和职责时，优先阅读当前实现和相关 ADR，
+不要从本文件推导详细架构。
+
+主要工作区域：
+
+- `backend/`
+- `frontend/`
+- `contracts/`
+- `deploy/`
+- `scripts/`
+
+遇到 generated file 时，先找到正式 source-of-truth 和生成入口，
+不要直接修改生成物绕过生成流程。
+
+不得提交 Secret、token、private key 或其他敏感凭据。
+
+涉及 authentication、authorization、ownership、持久状态、
+API contract、scheduler / Slurm、部署或真实共享环境时，
+提高风险判断强度，并先读取对应权威文档。
+
+这些区域本身不是停止工作的理由；
+是否升级取决于实际影响和可逆性。
 
 ## 验证
 
-提交前必须跑：
+完整项目验证入口：
 
-```bash
-make check          # fmt-check + lint + typecheck + test + build + contract
-```
+`make check`
 
-Windows 没有 Make 时运行同一个实现：
+Windows：
 
-```powershell
-uv run --no-project python scripts/workspace.py check
-```
+`uv run --no-project python scripts/workspace.py check`
 
-**不要另外发明检查链**，也不要把直接调用 `pytest` / `pnpm` 的临时命令写进 CI——
-那样 CI 和本地会分叉。声称"做完了"之前跑统一入口，并记录实际结果。
+开发过程中选择能够证明当前 Claim 的最小有效验证，
+不要求每次局部修改都机械运行完整检查。
 
-```bash
-make dev            # 起后端
-make migrate        # alembic 升到最新
-make migrate-down   # 回滚一步（合并前必须实际验证过）
-make coverage       # 生成后端覆盖率报告
-make journal        # 有没有在途工作、孤儿锁
-make doctor         # 工程基线还缺什么
-```
+测试策略、测试粒度和长期测试资产规则见：
 
-任务逻辑集中在 `scripts/workspace.py` 与 `scripts/tasks/`；`Makefile` 只负责转发。
-平台专属引导脚本只放在 `scripts/platform/` 的对应目录。
+`docs/testing/README.md`
 
-## 目录
+未运行的相关验证必须明确说明。
 
-```text
-backend/src/workspace107/
-├── api/              # 路由与依赖注入 —— 只做协议转换，不写业务判断
-├── application/      # 用例编排、事务边界
-├── domain/           # 业务规则与模型 —— **不 import 任何 IO**
-└── infrastructure/   # db / scheduler / storage 等外部依赖
-backend/tests/        # 测试粒度与目录以 docs/testing/README.md 为准
-frontend/             # React + TypeScript 控制台
-contracts/            # 跨组件机器契约；生成物不得手改
-deploy/               # 可执行部署编排；服务镜像构建文件仍由服务目录维护
-docs/decisions/       # ADR
-docs/journal/         # 在途工作
-```
+## 在途工作
 
-**领域层不依赖基础设施层**，依赖方向永远朝内。做到这一条，业务规则才能用
-毫秒级的纯单元测试密集覆盖。时钟和随机数也算 IO，当参数传进去。
+`docs/journal/` 是本项目的 durable work state。
 
-## 命名
+只有工作确实需要跨会话、并行 ownership、handoff、恢复，
+或存在无法仅通过 Git 安全重建的仓外状态时，才使用 journal。
 
-代码标识符统一使用英文；中文用于注释、文档、日志与面向用户的展示文本，不混入函数名、
-类名或变量名。
+简单、单会话、局部工作不要求创建 journal。
 
-**以 `docs/product/design.md` §3.1 的术语表为唯一事实源**：User / Workspace /
-Membership / Project / Project Version / Run Configuration / Run Snapshot /
-Environment / Shared Resource / Content Version / Input Binding /
-Compute Plan / Resource Entitlement …
+具体格式和生命周期见：
 
-代码标识符、数据库列、接口字段、日志字段全用同一个词。
-**需要新概念时，先往 `docs/product/design.md` §3.1 加一行，再写代码。**
+`docs/journal/README.md`
 
-特别注意几组**容易混**的：
+不要为同一项工作建立平行的项目级持久状态系统。
 
-- `Run Configuration`（可编辑、可复用的方案）≠ `Run Snapshot`（创建后不可变的执行事实）
-- `Environment`（决定代码在什么基础上跑）≠ `Shared Resource`（决定 Run 能读什么内容）
-- `Entitlement Request`（申请记录）≠ `Resource Entitlement`（审批通过后的有效资格）
+## 完成
 
-## 不变量
+完成以当前目标、实际修改和 fresh evidence 为依据。
 
-`docs/product/design.md` §3.3 的 Active GR 和 §3.1 的领域约束是本项目的不变量，
-其中最硬的几条：
+支持 Lean Harness 的环境可以使用其 Review 和 finish 方法增强检查。
 
-- **Run Snapshot 创建后不得修改**；执行时不得重新读取当前 Run Configuration
-- **Run Snapshot / 日志 / 页面不得出现 Secret 明文**，只固定引用表达式
-- Workspace 只能使用其 Resource Entitlement 允许的 Compute Plan
-- 通过 Input Binding 提供的内容**只读**
-- Project Version、Environment Version、Shared Resource Version、Profile Version
-  **发布后不得原地修改**
+如果验证只覆盖 mock、本地或其他受限环境，
+明确说明证据范围。
 
-**数据库约束是最后一道防线**，不要因为应用层已经校验过就省掉它。
-
-## 禁止
-
-- 不许改 `migrations/`、认证授权相关代码 —— 先提出来让人决定
-- 不许新增依赖 —— 先说明现有的为什么不够
-- 不许 skip / 注释掉 / 放宽失败的测试。测试红了就是代码错了
-- 不许写只调用不断言的测试，或 mock 掉一切然后断言 mock 被调用了
-- 不许硬编码配置（路径、地址、密钥），从 `WORKSPACE107_*` 环境变量读
-- 不许在 `domain/` 里 import 数据库、HTTP、文件、时钟、随机数
-- 不许把资源查询写成 `WHERE id = ?` —— **必须带归属过滤**（见下）
-
-## 三条顺序不能反
-
-1. **先搜再写** —— 仓库里已经有了吗？标准库有吗？已装的依赖有吗？
-2. **先写测试再写实现**，而且要**亲眼看到它红**
-3. **先在 `docs/journal/` 写意图再动手** —— 会话会死，写完意图那一刻才是可恢复的
-
-## 这个项目特别容易错的三处
-
-**① 越权。** 平台是多用户多 Workspace 的，`WHERE id = ?` 这种查询在功能测试里
-完全正常（你用自己的账号点，看到的都是自己的数据），只有**换个账号带别人的 ID**
-才会暴露。过滤必须落到数据访问层，并且写进方法签名让"忘了传"编译不过。
-重构切片新增、修改或重写资源接口时，每个接口都必须同步补一条「用别人的 ID → 403/404」
-的测试；当前旧 API 的退出测试不作为目标架构已覆盖的证据。
-
-**② 不可变性。** Snapshot / Version 类对象一旦创建就不能改。写更新逻辑前先问：
-这个对象是不是快照？是的话就该创建新的，而不是改旧的。
-
-**③ 日常跑的是 mock。** `WORKSPACE107_SCHEDULER=mock` 会通过宿主机 shell 真实
-执行用户命令，但没有真实 Git、Shared FS、独立 Worker 或 Apptainer。Slurm REST
-适配器存在但尚未在 107 集群验证；本地闭环不等于现行 M1 已完成。
-
-## 汇报
-
-完成时说清六件事：做了什么 / **没做什么** / 怎么验证的（贴 `make check` 输出）/
-**哪里不确定**（写满三条）/ **故意没处理的** / 碰了哪些文件（`git diff --stat`）。
-
-不要用"应该没问题""看起来是对的"收尾。要么验证过并给出证据，要么明说没验证。
+没有验证过的内容不要宣称已经完成。

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,18 +7,32 @@
 | 产品能力、术语、规则和 Roadmap | [`product/design.md`](product/design.md) |
 | 延后但尚未进入正式设计的事项 | [`product/deferred.md`](product/deferred.md) |
 | Git、Issue、分支、提交和 PR | [`contributing/git-workflow.md`](contributing/git-workflow.md) |
-| AI 协作和统一验证入口 | [`../AGENTS.md`](../AGENTS.md) |
-| 部署方式与生产边界 | [`operations/deployment.md`](operations/deployment.md)，可执行清单见 [`../deploy/`](../deploy/README.md) |
-| 测试粒度、目录和重构期基线 | [`testing/`](testing/README.md) |
-| 高影响技术决定 | [`decisions/`](decisions/README.md) |
-| 当前跨会话工作 | [`journal/`](journal/README.md) |
+| Coding Agent 项目入口、工程原则和工作路由 | [`../AGENTS.md`](../AGENTS.md) |
+| 测试策略、测试粒度和验证边界 | [`testing/`](testing/README.md) |
+| API、生成类型和跨组件机器契约 | [`../contracts/`](../contracts/README.md) |
+| 部署方式与生产边界 | `operations/deployment.md`，可执行清单见 [`../deploy/`](../deploy/README.md) |
+| 长期工程决策及其取舍 | [`decisions/`](decisions/README.md) |
+| 在途工作、跨会话恢复、并行协作和交接 | [`journal/`](journal/README.md) |
 
 ## 证据与历史
 
-[`references/`](references/README.md) 只保存仍有价值的外部输入和来源记录，不自动成为
-产品事实。[`archive/`](archive/README.md) 解释已经退出活动文档树的过程材料；源码与
-迁移前实现快照位于仓库根目录的 [`archive/`](../archive/README.md)。
+[`references/`](references/README.md)
+只保存仍有价值的外部输入和来源记录，不自动成为当前产品或工程事实。
 
-历史材料与活动文档冲突时，以 [`product/design.md`](product/design.md) 和活动 ADR 为准。
-跨前后端的生成式 API 契约不属于人工文档，统一保存在
-[`contracts/`](../contracts/README.md)。
+[`archive/`](archive/README.md)
+解释已经退出活动文档树的过程材料；
+
+源码与迁移前实现快照位于仓库根目录的
+[`archive/`](../archive/README.md)。
+
+历史材料不能覆盖当前活动事实。
+
+涉及产品能力、领域术语和业务规则时，
+以当前 `product/design.md` 为权威来源。
+
+涉及已经形成的长期工程决定及其原因时，
+读取当前适用的 [`decisions/`](decisions/README.md)。
+
+跨前后端的生成式 API 契约属于机器契约，
+统一保存在 [`contracts/`](../contracts/README.md)，
+不要从历史文档或手写说明推断其当前形状。

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -11,7 +11,7 @@
 默认要求获得与风险相称的验证证据，
 但不默认要求每次修改都新增测试文件。
 
-尚未实现的能力记录在 Issue/[`product/deferred.md`](product/deferred.md) 中。
+尚未实现的能力记录在 Issue/[`../product/deferred.md`](../product/deferred.md) 中。
 不要为了表达未来计划提交 skip、xfail 或占位测试。
 
 ## 永久测试与一次性验证

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,8 +1,62 @@
 # 测试策略
 
-测试以 `docs/product/design.md` 的目标设计为依据，不把当前旧实现的 API、进程边界、
-权限矩阵或 UI 组件写成未来兼容契约。一个功能切片进入实现时，同步补齐对应粒度的测试；
-尚未实现的能力记录在 Issue 中，不提交 skip、xfail 或占位测试。
+测试服务于需要长期保护的可观察行为、业务规则、契约和重要风险。
+
+测试以 `docs/product/design.md` 的当前目标设计为产品语义依据，
+不把当前旧实现的 API、进程边界、权限矩阵、UI 结构或其他施工状态
+自动固化为未来兼容契约。
+
+实现功能或修改行为时，根据当前变化的实质风险判断是否需要新增永久测试。
+
+默认要求获得与风险相称的验证证据，
+但不默认要求每次修改都新增测试文件。
+
+尚未实现的能力记录在 Issue/[`product/deferred.md`](product/deferred.md) 中。
+不要为了表达未来计划提交 skip、xfail 或占位测试。
+
+## 永久测试与一次性验证
+
+永久测试用于长期防止有价值的行为或风险回归，例如：
+
+- 业务规则和状态转换；
+- 用户可观察行为；
+- public API 和跨组件契约；
+- 权限、安全和数据一致性；
+- 重要失败路径；
+- 已经发生且值得防止再次出现的回归。
+
+新增永久测试前，应先确认：
+
+- 测试保护的是行为或契约，而不是当前实现细节；
+- 该风险没有被现有测试充分覆盖；
+- 测试失败时能够指出有意义的产品或工程回归；
+- 长期维护成本与被保护风险相称。
+
+以下检查通常属于当前工作的验证证据，
+不默认沉淀为永久测试：
+
+- 文档和普通配置修改；
+- 文件移动、重命名和机械重构；
+- 简单 wiring；
+- private helper 或内部调用方式变化；
+- 实现迁移过程中确认旧代码、旧字段、旧入口或旧 fallback 已经清除；
+- 对一次性数据转换或施工状态的检查。
+
+这类工作可以使用：
+
+- targeted test；
+- 搜索；
+- 静态检查；
+- 临时脚本；
+- 一次性测试；
+- 手动或自动的针对性实验。
+
+如果“旧行为不得再次出现”本身属于长期产品契约、安全不变量
+或已经发生且可能复发的重要回归，则应留下行为导向的永久测试，
+而不是测试旧实现文件或旧函数是否存在。
+
+不要为了“更安全”在 unit、integration、system 等多个层级
+重复完整验证同一条规则。
 
 ## 粒度
 
@@ -11,7 +65,7 @@ backend/tests/
 ├── unit/domain/          纯领域规则和不变量
 ├── unit/application/     使用 Fake Port 的用例编排
 ├── unit/observability/   请求上下文和日志格式化
-├── integration/          单个 API、DB、Storage、Scheduler 或 Worker Adapter
+├── integration/          API、DB、Storage、Scheduler 或 Worker Adapter
 ├── contract/             OpenAPI、错误信封和外部协议
 ├── architecture/         依赖方向与仓库治理
 └── system/               少量 API + Worker + PostgreSQL 核心闭环
@@ -23,31 +77,102 @@ frontend/tests/
 └── e2e/                  少量真实浏览器核心闭环
 ```
 
-目录只在有对应测试时创建。安全是测试主题，不是独立粒度；安全断言放在实际执行边界中，
-例如 Domain 不变量、API 集成或系统测试。
+目录只在存在对应长期测试资产时创建。
 
-## 当前基线
+安全是测试主题，不是独立粒度。
+安全断言放在实际规则或执行边界所在的最低有效层级，
+例如 Domain、API integration 或 system test。
 
-当前只保留以下已实现且不绑定旧产品流程的基础保护：
+优先在最接近规则归属、成本最低且稳定的层级保护行为；
+只有跨组件连接本身存在重要风险时，才增加更高层测试。
 
-- 后端单元规则：算力校验、路径规范化、Run Snapshot 序列化与路径约束、Variable 与
-  Secret 解析。
-- 后端横切单元：请求标识上下文与日志格式化。
-- 后端 Adapter：本地存储配置、文件权限和 Mock Scheduler 平台行为。
-- 架构治理：Domain 与 Application 依赖方向，以及活动文档、GR、ADR 和本地链接引用。
-- 前端单元边界：API 错误降级与环境变量引用解析。
+## 当前测试资产
 
-旧 ASGI / SQLite 工作流、进程内 `/runs/sync` 驱动、`X-User` 自动建号、固定 seed 数据、
-旧角色矩阵和 Ant Design 视觉偏好不构成新基线。对应功能按目标架构重新实现时再写测试。
+当前仓库已有测试只代表它们实际保护的行为和工程边界，
+不因为测试已经存在就自动获得永久兼容地位。
+
+当前较稳定的保护包括：
+
+- 后端领域规则：算力校验、路径规范化、Run Snapshot 相关规则、
+  Variable 与 Secret 解析；
+- 后端横切行为：请求标识上下文与日志格式化；
+- Adapter 行为：本地存储、文件权限和 Mock Scheduler；
+- 架构治理：Domain / Application 依赖方向，以及活动文档和引用关系；
+- 前端边界行为：API 错误降级与环境变量引用解析。
+
+旧 ASGI / SQLite 工作流、进程内 `/runs/sync` 驱动、
+`X-User` 自动建号、固定 seed 数据、旧角色矩阵和 Ant Design 视觉实现
+不因历史实现或历史测试而成为新的产品兼容契约。
+
+相关代码发生迁移时，应先明确目标设计和需要长期保护的行为，
+再决定保留、重写或删除对应测试。
+
+删除旧测试前，需要获得足够证据证明：
+
+- 它保护的行为已经失效；或
+- 对应行为已经在新的权威边界得到保护；或
+- 它只是在约束已经被废弃的实现细节。
 
 ## 断言边界
 
-- Unit 不访问真实数据库、HTTP、子进程或共享文件系统。
-- Integration 每次只证明一个真实 Adapter 或入口，不称为端到端测试。
-- Contract 只验证跨组件可观察的形状和语义，不直接调用私有函数。
-- Component 通过可访问角色、可见文案和用户结果断言，不依赖组件库私有 class 或 DOM。
-- System 必须经过独立 API、Worker 和 PostgreSQL；缺少这些边界时不伪造通过。
-- 测试文件围绕一项能力或一个边界组织，不按每个函数机械拆分。
+### Unit
+
+Unit 应聚焦单一规则或局部行为，
+不依赖真实数据库、HTTP、子进程或其他外部服务。
+
+不要为了测试 private implementation 而构造脆弱的调用次数、
+内部函数或 mock interaction 断言。
+
+### Integration
+
+Integration 验证真实 Adapter、持久化边界或协议入口之间的连接行为。
+
+不要因为使用了多个真实组件就自动把它称为端到端测试。
+
+### Contract
+
+Contract 验证跨组件可观察的形状和语义。
+
+不要通过直接调用 private function 来证明 public contract。
+
+### Component
+
+Component 通过用户可观察结果断言：
+
+- 可访问角色；
+- 可见内容；
+- 交互结果；
+- 状态变化。
+
+不要依赖组件库私有 class、内部 DOM 结构或其他实现细节。
+
+### System
+
+System 用于保护少量真正重要的跨进程核心闭环。
+
+需要真实证明 API、Worker 和 PostgreSQL 边界的场景，
+不能通过把这些边界 mock 掉之后宣称 system 行为已经验证。
+
+### 组织
+
+测试文件围绕一项能力、规则或边界组织，
+不按每个函数机械拆分测试文件。
+
+## 验证选择
+
+开发过程中，根据当前 Claim 和风险选择最小有效验证。
+
+例如：
+
+- 修改纯领域规则，优先运行对应 domain tests；
+- 修改某个 Adapter，优先运行相关 integration tests；
+- 修改 OpenAPI 或跨组件接口，运行 contract 验证；
+- 修改前端用户行为，选择最接近该行为的 unit / component / feature 测试；
+- 机械迁移或清理旧实现，可以使用搜索、临时检查或 targeted test；
+- 高风险跨组件流程才需要 system / e2e 级证据。
+
+不要因为“还可以再测一个情况”就持续增加测试。
+当当前 Claim 和实质风险已经获得充分证据时，应停止。
 
 ## 运行
 
@@ -65,8 +190,20 @@ uv run --no-project python scripts/workspace.py check
 uv run --no-project python scripts/workspace.py coverage
 ```
 
-`make coverage` 在测试基线重建期间只生成报告，不设全仓百分比门槛。新模块形成稳定边界后，
-再按模块风险和可测试性建立门槛，不能用旧实现覆盖率代表目标架构质量。
+`make test` 是项目测试套件的统一入口。
 
-仓库根 `pytest.ini` 只收集 `backend/tests/`，防止 IDE 或裸 pytest 把
-`archive/workspace107/` 的来源快照当成活动测试。统一入口仍是协作和 CI 的权威方式。
+`make check` 是完整工程验证入口，
+但开发中的每个局部步骤不要求机械运行完整检查。
+
+`make coverage` 在当前测试基线演进期间只生成报告，
+不设置全仓统一百分比门槛。
+
+如果未来需要 coverage gate，
+应根据模块风险、稳定边界和可测试性决定，
+不能用旧实现的覆盖率代表目标架构质量。
+
+仓库根 `pytest.ini` 只收集 `backend/tests/`，
+避免 IDE 或裸 pytest 把 `archive/workspace107/`
+中的历史来源快照当作活动测试。
+
+协作和 CI 仍使用项目统一任务入口。


### PR DESCRIPTION
## 关联 Issue

无；本 PR 为 Lean Harness dogfood 工程接入。

## 修改内容

- 接入固定版本 Lean Harness 的 Policy 与 Skills
- 配置官方 GitHub MCP 操作面并关闭重复的内置 GitHub 能力
- 重构 Coding Agent 项目入口与项目权威导航
- 明确测试资产、一次性验证与完成证据边界

## 验证证据

- `make check`：全部通过（GitHub MCP 配置加入前）
- Workflow tests：15 passed
- Backend tests：102 passed
- Frontend tests：14 passed，build 通过
- OpenAPI 与前端生成类型：一致
- Fresh-context review：PASS
- GitHub MCP 配置加入后按要求未重复运行本地测试；以本 PR CI 为最终证据

## 影响范围

- 影响 OMP Agent 配置、GitHub Provider 接入与工程指导文档
- 不改变 API、数据库、认证授权、部署或用户界面
