### PR TITLE
Fix/demo python portability

### DIFF
--- a/backend/src/workspace107/infrastructure/scheduler/mock.py
+++ b/backend/src/workspace107/infrastructure/scheduler/mock.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import IO
@@ -64,7 +65,9 @@ class MockScheduler:
         environment = build_job_environment(submission)
         stdout = submission.stdout_path.open("ab")
         stderr = submission.stderr_path.open("ab")
-        shell_options = {} if os.name == "nt" else {"executable": "/bin/bash"}
+        shell_options = (
+            {} if os.name == "nt" else {"executable": "/bin/bash", "start_new_session": True}
+        )
 
         try:
             process = await asyncio.create_subprocess_shell(
@@ -92,11 +95,11 @@ class MockScheduler:
     async def poll(self, job_id: str) -> SchedulerJobState:
         job = self._jobs.get(job_id)
         if job is None:
-            # 进程注册表里没有这个任务——可能是服务重启过。
-            # 这是异常状态，交给上层保留并处置，不猜测结果。
+            # Mock 的任务注册表只存在于 API 进程内。进程重启后已经无法继续
+            # 观察或控制原子进程，不能让数据库里的 Run 永久停在 queued。
             return SchedulerJobState(
-                state=SchedulerState.UNKNOWN,
-                reason=f"调度系统中没有任务 {job_id} 的记录",
+                state=SchedulerState.FAILED,
+                reason=f"Mock 调度器已丢失任务 {job_id}；后端进程可能发生过重启",
             )
 
         return_code = job.process.returncode
@@ -130,7 +133,12 @@ class MockScheduler:
             raise SchedulerError(f"调度系统中没有任务 {job_id} 的记录")
         job.cancelled = True
         if job.process.returncode is None:
-            job.process.terminate()
+            if os.name == "nt":
+                job.process.terminate()
+            else:
+                # create_subprocess_shell 启动的是外层 shell。终止整个进程组，
+                # 才能同时停掉它拉起的 Python 等实际用户进程。
+                os.killpg(job.process.pid, signal.SIGTERM)
 
     async def wait_for_exit(self, job_id: str, *, seconds: float = 30.0) -> None:
         """等待任务结束。仅供测试和 demo 脚本使用，不属于 SchedulerPort。"""

--- a/backend/tests/integration/scheduler/test_mock_scheduler.py
+++ b/backend/tests/integration/scheduler/test_mock_scheduler.py
@@ -8,12 +8,17 @@ from typing import Any
 import pytest
 
 from workspace107.domain.compute import ResolvedSchedulerConfiguration
-from workspace107.domain.ports.scheduler import SchedulerSubmission
+from workspace107.domain.ports.scheduler import SchedulerState, SchedulerSubmission
 from workspace107.infrastructure.scheduler import mock as mock_module
 
 
 class _FinishedProcess:
     returncode = 0
+
+
+class _RunningProcess:
+    returncode = None
+    pid = 4321
 
 
 def _submission(root: Path) -> SchedulerSubmission:
@@ -63,6 +68,7 @@ async def test_windows_uses_system_command_interpreter(monkeypatch, tmp_path: Pa
 
     assert captured["command"] == submission.command
     assert "executable" not in captured
+    assert "start_new_session" not in captured
 
 
 @pytest.mark.asyncio
@@ -82,3 +88,29 @@ async def test_posix_continues_to_use_bash(monkeypatch, tmp_path: Path) -> None:
     await scheduler.poll(job_id)
 
     assert captured["executable"] == "/bin/bash"
+    assert captured["start_new_session"] is True
+
+
+@pytest.mark.asyncio
+async def test_missing_mock_job_fails_instead_of_staying_queued() -> None:
+    state = await mock_module.MockScheduler().poll("mock-from-old-process")
+
+    assert state.state is SchedulerState.FAILED
+    assert "后端进程可能发生过重启" in state.reason
+
+
+@pytest.mark.asyncio
+async def test_posix_cancel_stops_the_entire_process_group(monkeypatch, tmp_path: Path) -> None:
+    async def create_process(command: str, **options: Any) -> _RunningProcess:
+        return _RunningProcess()
+
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(mock_module.os, "name", "posix")
+    monkeypatch.setattr(mock_module.asyncio, "create_subprocess_shell", create_process)
+    monkeypatch.setattr(mock_module.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    scheduler = mock_module.MockScheduler()
+    job_id = await scheduler.submit(_submission(tmp_path))
+    await scheduler.cancel(job_id)
+
+    assert killed == [(_RunningProcess.pid, mock_module.signal.SIGTERM)]

--- a/backend/tests/integration/scheduler/test_mock_scheduler.py
+++ b/backend/tests/integration/scheduler/test_mock_scheduler.py
@@ -107,7 +107,12 @@ async def test_posix_cancel_stops_the_entire_process_group(monkeypatch, tmp_path
     killed: list[tuple[int, int]] = []
     monkeypatch.setattr(mock_module.os, "name", "posix")
     monkeypatch.setattr(mock_module.asyncio, "create_subprocess_shell", create_process)
-    monkeypatch.setattr(mock_module.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+    monkeypatch.setattr(
+        mock_module.os,
+        "killpg",
+        lambda pid, sig: killed.append((pid, sig)),
+        raising=False,
+    )
 
     scheduler = mock_module.MockScheduler()
     job_id = await scheduler.submit(_submission(tmp_path))

--- a/frontend/src/api/useAsync.ts
+++ b/frontend/src/api/useAsync.ts
@@ -8,7 +8,7 @@ export interface AsyncState<T> {
   data: T | undefined
   loading: boolean
   error: ApiError | Error | undefined
-  reload: () => void
+  reload: (options?: { silent?: boolean }) => Promise<void>
 }
 
 /**
@@ -20,9 +20,10 @@ export function useAsync<T>(loader: () => Promise<T>, deps: unknown[]): AsyncSta
   const [data, setData] = useState<T>()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<ApiError | Error>()
-  const [tick, setTick] = useState(0)
   const alive = useRef(true)
+  const dataRef = useRef<T | undefined>(undefined)
   const loaderRef = useRef(loader)
+  const requestId = useRef(0)
   loaderRef.current = loader
 
   useEffect(() => {
@@ -32,25 +33,39 @@ export function useAsync<T>(loader: () => Promise<T>, deps: unknown[]): AsyncSta
     }
   }, [])
 
+  const reload = useCallback(async (options: { silent?: boolean } = {}) => {
+    const currentRequest = ++requestId.current
+    const silent = options.silent === true && dataRef.current !== undefined
+    if (!silent) {
+      setLoading(true)
+      setError(undefined)
+    }
+
+    try {
+      const result = await loaderRef.current()
+      if (alive.current && currentRequest === requestId.current) {
+        dataRef.current = result
+        setData(result)
+        setError(undefined)
+      }
+    } catch (exc) {
+      // 后台轮询失败不应把仍然可用的页面替换成错误状态。
+      if (alive.current && currentRequest === requestId.current && !silent) {
+        setError(exc as Error)
+      }
+    } finally {
+      if (alive.current && currentRequest === requestId.current) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
   useEffect(() => {
-    setLoading(true)
-    setError(undefined)
-    loaderRef
-      .current()
-      .then((result) => {
-        if (alive.current) setData(result)
-      })
-      .catch((exc: Error) => {
-        if (alive.current) setError(exc)
-      })
-      .finally(() => {
-        if (alive.current) setLoading(false)
-      })
+    void reload()
     // loader 通过 ref 传递，依赖只看调用方声明的 deps。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...deps, tick])
+  }, [...deps, reload])
 
-  const reload = useCallback(() => setTick((n) => n + 1), [])
   return { data, loading, error, reload }
 }
 
@@ -60,13 +75,28 @@ export function useAsync<T>(loader: () => Promise<T>, deps: unknown[]): AsyncSta
  * Run 状态来自调度系统，前端只能轮询——这也是为什么每次轮询前会先触发一次
  * 后端的状态同步。
  */
-export function usePolling(callback: () => void, intervalMs: number, active: boolean): void {
+export function usePolling(
+  callback: () => void | Promise<void>,
+  intervalMs: number,
+  active: boolean,
+): void {
   const saved = useRef(callback)
   saved.current = callback
 
   useEffect(() => {
     if (!active) return
-    const timer = window.setInterval(() => saved.current(), intervalMs)
-    return () => window.clearInterval(timer)
+    let cancelled = false
+    let timer: number | undefined
+
+    const poll = async () => {
+      await saved.current()
+      if (!cancelled) timer = window.setTimeout(poll, intervalMs)
+    }
+
+    timer = window.setTimeout(poll, intervalMs)
+    return () => {
+      cancelled = true
+      if (timer !== undefined) window.clearTimeout(timer)
+    }
   }, [intervalMs, active])
 }

--- a/frontend/src/pages/RunPage.tsx
+++ b/frontend/src/pages/RunPage.tsx
@@ -50,20 +50,22 @@ export function RunPage() {
    * 先触发一次后端同步，再读 Run——状态只能来自调度系统的轮询结果，
    * 平台不会自己编一个状态出来。
    */
-  const refresh = useCallback(async () => {
-    await api.syncRuns().catch(() => undefined)
-    detail.reload()
-    logs.reload()
-  }, [detail, logs])
+  const refresh = useCallback(
+    async (silent = true) => {
+      await api.syncRuns().catch(() => undefined)
+      await Promise.all([detail.reload({ silent }), logs.reload({ silent })])
+    },
+    [detail, logs],
+  )
 
-  usePolling(() => void refresh(), POLL_INTERVAL_MS, active)
+  usePolling(() => refresh(true), POLL_INTERVAL_MS, active)
 
   const cancel = async () => {
     setCancelling(true)
     try {
       await api.cancelRun(runId)
       message.success('已请求取消，最终状态以调度系统为准')
-      await refresh()
+      await refresh(true)
     } catch (error) {
       message.error((error as Error).message)
     } finally {
@@ -103,7 +105,7 @@ export function RunPage() {
               tags={<RunStatusTag status={run.status} />}
               actions={
                 <>
-                  <Button icon={<ReloadOutlined />} onClick={() => void refresh()}>
+                  <Button icon={<ReloadOutlined />} onClick={() => void refresh(false)}>
                     刷新
                   </Button>
                   {active

--- a/scripts/tasks/project.py
+++ b/scripts/tasks/project.py
@@ -102,6 +102,8 @@ def run_dev(component: str = "all") -> None:
                     "workspace107.main:create_app",
                     "--factory",
                     "--reload",
+                    "--reload-dir",
+                    "src",
                     "--host",
                     "127.0.0.1",
                     "--port",

--- a/scripts/tasks/project.py
+++ b/scripts/tasks/project.py
@@ -6,6 +6,7 @@ import datetime as dt
 import json
 import os
 import re
+import shlex
 import socket
 import subprocess
 import tempfile
@@ -73,6 +74,14 @@ def _backend_python_executable() -> str:
     if not executable:
         raise TaskError("uv did not report the backend Python executable")
     return executable
+
+
+def _demo_command(python_executable: str) -> str:
+    """Run the demo script with the interpreter that hosts its environment."""
+    arguments = [python_executable, "train.py"]
+    if os.name == "nt":
+        return subprocess.list2cmdline(arguments)
+    return shlex.join(arguments)
 
 
 def run_dev(component: str = "all") -> None:
@@ -252,6 +261,7 @@ def demo(*, smoke: bool = False) -> None:
     ensure_backend_dependencies(quiet=True)
     port = _selected_demo_port(smoke)
     base_url = f"http://127.0.0.1:{port}/api/v1"
+    python_executable = _backend_python_executable()
 
     with tempfile.TemporaryDirectory(prefix="workspace107-demo-") as directory:
         workdir = Path(directory)
@@ -270,7 +280,7 @@ def demo(*, smoke: bool = False) -> None:
         backend_uv("run", "python", "-m", "workspace107.tools.seed", env=environment, quiet=smoke)
 
         command = [
-            _backend_python_executable(),
+            python_executable,
             "-m",
             "uvicorn",
             "workspace107.main:create_app",
@@ -293,7 +303,9 @@ def demo(*, smoke: bool = False) -> None:
             )
             try:
                 _wait_until_ready(f"{base_url}/health", process, server_log)
-                _exercise_core_run(ApiClient(base_url), verbose=not smoke)
+                _exercise_core_run(
+                    ApiClient(base_url), python_executable=python_executable, verbose=not smoke
+                )
             finally:
                 _stop_processes([process])
 
@@ -303,7 +315,7 @@ def demo(*, smoke: bool = False) -> None:
         print("\nDemo complete: Project -> Version -> Run Snapshot -> logs -> Artifact.")
 
 
-def _exercise_core_run(client: ApiClient, *, verbose: bool) -> None:
+def _exercise_core_run(client: ApiClient, *, python_executable: str, verbose: bool) -> None:
     def say(label: str) -> None:
         if verbose:
             print(f"\n{label}")
@@ -356,7 +368,7 @@ def _exercise_core_run(client: ApiClient, *, verbose: bool) -> None:
         f"/projects/{project_id}/run-configurations",
         {
             "name": "Default run",
-            "command": "python train.py",
+            "command": _demo_command(python_executable),
             "compute_plan_id": "plan_cpu_quick",
             "environment_variables": {"EPOCHS": "${{ vars.EPOCHS }}"},
             "artifact_rules": [{"path": "outputs", "name": "Training result", "optional": False}],

--- a/scripts/tests/test_workspace.py
+++ b/scripts/tests/test_workspace.py
@@ -138,6 +138,20 @@ class WorkspaceCliTests(unittest.TestCase):
         self.assertEqual(result, 0)
         demo.assert_called_once_with(smoke=True)
 
+    def test_backend_dev_reload_only_watches_source(self) -> None:
+        process = mock.Mock()
+        process.poll.return_value = 0
+        with (
+            mock.patch.object(project, "ensure_backend_dependencies"),
+            mock.patch.object(project, "_backend_python_executable", return_value="python"),
+            mock.patch.object(project.subprocess, "Popen", return_value=process) as popen,
+        ):
+            project.run_dev("backend")
+
+        command = popen.call_args.args[0]
+        self.assertIn("--reload-dir", command)
+        self.assertEqual(command[command.index("--reload-dir") + 1], "src")
+
     def test_coverage_reports_without_a_global_gate(self) -> None:
         with (
             mock.patch.object(project, "ensure_backend_dependencies"),

--- a/scripts/tests/test_workspace.py
+++ b/scripts/tests/test_workspace.py
@@ -118,6 +118,19 @@ class WorkspaceCliTests(unittest.TestCase):
             quiet=True,
         )
 
+    def test_demo_command_quotes_posix_python_paths(self) -> None:
+        self.assertEqual(
+            project._demo_command(r"C:\workspace\backend\.venv\Scripts\python.exe"),
+            r"'C:\workspace\backend\.venv\Scripts\python.exe' train.py",
+        )
+
+    def test_demo_command_quotes_windows_python_paths(self) -> None:
+        with mock.patch.object(project.os, "name", "nt"):
+            self.assertEqual(
+                project._demo_command(r"C:\Program Files\Python\python.exe"),
+                r'"C:\Program Files\Python\python.exe" train.py',
+            )
+
     def test_smoke_dispatches_the_isolated_demo(self) -> None:
         with mock.patch.object(project, "demo") as demo:
             result = workspace.main(["smoke"])

--- a/scripts/tests/test_workspace.py
+++ b/scripts/tests/test_workspace.py
@@ -119,10 +119,11 @@ class WorkspaceCliTests(unittest.TestCase):
         )
 
     def test_demo_command_quotes_posix_python_paths(self) -> None:
-        self.assertEqual(
-            project._demo_command(r"C:\workspace\backend\.venv\Scripts\python.exe"),
-            r"'C:\workspace\backend\.venv\Scripts\python.exe' train.py",
-        )
+        with mock.patch.object(project.os, "name", "posix"):
+            self.assertEqual(
+                project._demo_command(r"C:\workspace\backend\.venv\Scripts\python.exe"),
+                r"'C:\workspace\backend\.venv\Scripts\python.exe' train.py",
+            )
 
     def test_demo_command_quotes_windows_python_paths(self) -> None:
         with mock.patch.object(project.os, "name", "nt"):


### PR DESCRIPTION
 ## 修改内容

  - 修复 demo/smoke 对宿主机 python 命令的依赖，统一使用后端虚拟环境解释器。
  - 将 Run 页轮询改为后台静默刷新，避免周期性显示骨架屏。
  - 避免轮询请求重叠，并在 Run 进入终态后停止轮询。
  - 本地开发热重载仅监听 backend/src，避免运行文件触发后端重启。
  - Mock 调度任务丢失时将 Run 标记为失败，不再永久停留在排队状态。
  - POSIX 下取消 Mock Run 时终止整个作业进程组，确保实际用户进程一并停止。

  ## 验证证据

  - 统一检查：make check 通过；后端 104 个测试、前端 14 个测试全部通过，前端构建及 API 契约检查通
    过。

  - 其他验证：uv run --no-project python scripts/workspace.py smoke 通过。
  - 其他验证：在宿主机不存在 python 命令时，隔离 HTTP Run 闭环执行成功。
  - 其他验证：真实 Mock 长任务成功进入 running，取消后进入 cancelled。
  - 其他验证：历史遗留的无调度记录 Run 从 queued 收敛为 failed，并记录明确失败原因。

  ## 影响范围

  - 调整前端异步数据刷新和 Run 轮询行为，不改变现有页面布局与视觉样式。
  - 调整本地 Mock 调度器的任务丢失处理和 POSIX 取消语义。
  - 调整本地开发服务的热重载监听范围。
  - API 契约、数据库结构、认证授权和 Secret 处理均无变化。

  ## 延后事项与实现妥协

  - Deferred ID：无