### PR TITLE
docs(frontend): 收敛 Primer 迁移边界与来源

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | Git、Issue、分支、提交和 PR | [`contributing/git-workflow.md`](contributing/git-workflow.md) |
 | Coding Agent 项目入口、工程原则和工作路由 | [`../AGENTS.md`](../AGENTS.md) |
 | 测试策略、测试粒度和验证边界 | [`testing/`](testing/README.md) |
+| 前端实现、Primer 使用与迁移边界 | [`../frontend/README.md`](../frontend/README.md) |
 | API、生成类型和跨组件机器契约 | [`../contracts/`](../contracts/README.md) |
 | 部署方式与生产边界 | `operations/deployment.md`，可执行清单见 [`../deploy/`](../deploy/README.md) |
 | 长期工程决策及其取舍 | [`decisions/`](decisions/README.md) |

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -7,6 +7,7 @@
 | :--- | :--- |
 | [`platform/`](platform/README.md) | 107 集群与比赛培训的原始 PDF |
 | [`engineering/hpc-helper.md`](engineering/hpc-helper.md) | 外部 `hpc-helper` 的固定来源与吸收边界 |
+| [`engineering/primer.md`](engineering/primer.md) | Primer 官方来源、核验版本与项目吸收边界 |
 
 早期产品愿景、后端初始化指南和派生的平台说明已被现行设计取代，不再保留在活动树；
 取回方式见 [`../archive/README.md`](../archive/README.md)。当前产品事实以

--- a/docs/references/engineering/primer.md
+++ b/docs/references/engineering/primer.md
@@ -1,0 +1,45 @@
+# Primer 来源与吸收边界
+
+本文件记录 107 Workspace 采用 Primer 时核验过的官方来源和吸收边界，不是产品或实现规范。
+产品技术选型以 [`docs/product/design.md`](../../product/design.md) 为准，前端实施规则见
+[`frontend/README.md`](../../../frontend/README.md)。
+
+- 核验日期：2026-08-13
+- 上游维护者：GitHub / Primer
+- 许可证：下列三个 npm 包的核验版本均声明为 MIT
+
+## 官方来源
+
+| 能力 | 官方来源 | 核验时 npm `latest` |
+| :--- | :--- | :--- |
+| React 组件与 ThemeProvider | [Primer React 入门](https://primer.style/product/getting-started/react/)、[`primer/react`](https://github.com/primer/react) | `@primer/react@38.35.1` |
+| 颜色、间距、字体与主题变量 | [`primer/primitives`](https://github.com/primer/primitives) | `@primer/primitives@11.10.0` |
+| React 图标 | [Primer Octicons](https://primer.style/octicons)、[`primer/octicons`](https://github.com/primer/octicons) | `@primer/octicons-react@19.33.0` |
+
+版本号只记录本次核验事实。实际安装版本和完整性由 `frontend/package.json` 与
+`pnpm-lock.yaml` 决定，不从本文推断。
+
+`@primer/react@38.35.1` 的 npm 元数据显示其 React、React DOM 及对应类型 peer dependency
+支持 18.x 或 19.x；这覆盖本仓库当前 React 19。Primer 官方入门要求应用根部使用
+`ThemeProvider` 与 `BaseStyles`，并导入所需的 Primitives 主题 CSS。
+
+## 吸收边界
+
+采用：
+
+- Primer React 的稳定基础组件和主题入口；
+- Primer Primitives 提供的语义化颜色、间距、圆角、字体和亮暗主题变量；
+- Primer Octicons 中与操作含义一致的图标；
+- Primer 的 GitHub 风格信息层级、边框分区和高密度数据展示模式。
+
+不自动采用：
+
+- GitHub 品牌、商标、站点文案或与 107 Workspace 无关的产品导航；
+- 未经真实切片证明需要的 experimental / deprecated 组件；
+- 完整 `@primer/css` 全局样式；官方说明它是可选能力，只有确认不会扩大现有页面的全局样式影响后才引入；
+- Primer 对业务对象的命名或权限假设；Workspace、User Group、Project、Run 等语义只来自当前产品设计和 API 契约；
+- 为每个 Primer 组件再建立一层无业务价值的通用 wrapper。
+
+107 Workspace 特有的文件、版本、Run、日志和 Artifact 布局使用 CSS Modules 实现，
+但不得复制一套与 Primer Primitives 竞争的基础 token。源码直接导入的 Primer 包应声明为
+项目直接依赖，不能只依赖其他包的传递安装结果。

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,8 @@
 # 前端
 
-107 Workspace 控制台。React + TypeScript + Vite，组件库使用 Ant Design。
+107 Workspace 控制台。React + TypeScript + Vite；目标组件系统使用 Primer React、
+Primer Primitives、Primer Octicons 与 CSS Modules。当前 Ant Design 界面是迁移期间的
+旧实现，不是新页面继续扩展的默认方案。
 工具链统一使用 Node.js 24 LTS 与 pnpm 11；版本约束同时记录在 `.node-version`、
 `package.json` 和 CI 中。
 
@@ -41,6 +43,46 @@ tests/
 页面只做编排，数据获取和交互细节都在组件里。跨页面复用的展示逻辑
 （状态标签、加载与错误处理、时长与容量格式化）只定义一次。
 
+## 组件系统与迁移边界
+
+目标前端技术选型以 [`docs/product/design.md`](../docs/product/design.md) 为准。
+Primer 迁移由 [GitHub Issue #16](https://github.com/114August514/107-workspace/issues/16)
+统一跟踪，但迁移进度不改变产品设计或 API 契约。
+
+迁移遵守以下边界：
+
+1. 按完整用户表面迁移，不按 Button、Tag、Modal 等组件类别横切全仓；
+2. 迁移期间允许未迁移页面继续使用 Ant Design，但同一个已迁移表面不得混用两套组件；
+3. 已迁移文件不得继续导入 `antd` 或 `@ant-design/icons`；
+4. 新增页面默认使用 Primer；只在真实切片出现复用需求时提取公共组件；
+5. 视觉迁移不顺便修改领域术语、API、权限判断或状态管理架构；
+6. 最后一个清理切片删除 Ant Design Provider、主题、专属 helper 和直接依赖，不保留兼容别名。
+
+### 样式与组件
+
+- 颜色、间距、圆角和字体优先使用 Primer Primitives，不在项目里复制一套 GitHub 色值；
+- 107 Workspace 特有的高密度文件、版本、Run、日志和 Artifact 布局使用 CSS Modules；
+- 页面不通过行内样式堆叠长期视觉规则，也不使用组件库私有 class；
+- 可交互组件必须覆盖 `default`、`hover`、`active`、`focus`、`disabled`、`loading`、
+  `selected` 和 `error` 中适用的状态；
+- 网络数据必须区分加载、成功但为空、成功有数据和失败，空态和错误态都提供下一步操作；
+- 语义元素、关联表单标签、可见键盘焦点和正文对比度是最低可访问性要求。
+
+迁移基础切片应提供 `/design-system` 页面，展示实际采用的 token、组件状态、数据四态和
+常用文案。该页面是可运行的实现参考，不替代产品设计。
+
+### UI 验证
+
+UI 改动除类型检查和生产构建外，还必须在真实浏览器中检查：
+
+- 桌面宽度和 375 px 窄屏；
+- 键盘完成主要交互且焦点可见；
+- 加载、空数据和请求失败；
+- 发生变更的表单、浮层或下载等关键交互。
+
+PR 提供与改动范围相称的关键状态截图。组件测试断言用户可观察行为，不绑定 Primer 或
+Ant Design 的私有 DOM 和 class。
+
 ## 接口类型来自契约，不是手写的
 
 ```text
@@ -63,8 +105,9 @@ await http.GET('/api/v1/projects/{project_id}/files/content', {
 
 路径写错、路径参数漏传、query 名字拼错、请求体字段不对，都是编译期错误。
 
-表格列名用 `field<T>('exit_code')` 而不是裸字符串——antd 的 `dataIndex`
-声明成 `string`，不检查字段是否存在，字段改名后表格会安静地渲染成空列。
+仍未迁移的 Ant Design 表格列名使用 `field<T>('exit_code')` 而不是裸字符串：
+其 `dataIndex` 声明成 `string`，字段改名后可能安静地渲染成空列。最终删除
+Ant Design 时同时复核并清理这个专属 helper。
 
 仓库的统一检查会重新生成并比对差异，所以前端类型不能悄悄和后端脱节。
 
@@ -97,9 +140,9 @@ pnpm run generate:api     # 仅重新生成类型；平时在根目录用 make c
 
 仓库根目录执行 `make check-frontend` 会跑与 CI 相同的前端检查。
 
-当前 UI 是后续重构的旧实现，因此不保留绑定 Ant Design 组件、私有 class 或视觉偏好的
+当前 Ant Design UI 是后续迁移的旧实现，因此不保留绑定组件库私有 class 或视觉偏好的
 测试。新组件和页面切片进入实现时，按 [`../docs/testing/README.md`](../docs/testing/README.md)
-定义的 unit、component、feature 和 e2e 粒度重新建立测试。
+定义的 unit、component、feature 和 e2e 粒度保护用户可观察行为。
 
 ## 关于展示内容
 


### PR DESCRIPTION
## 目标

在 Primer 实现开始前，收敛当前项目真正采用的前端规则，并把官方来源与项目吸收边界放入现有文档拓扑。

Closes 114August514/107-workspace#17
Refs 114August514/107-frontend#1

## 改动

- 更新 `frontend/README.md`：明确 Primer 目标栈、Ant Design 迁移状态、按用户表面迁移、状态与可访问性要求、浏览器验收和最终清理条件；
- 新增 `docs/references/engineering/primer.md`：记录官方来源、核验版本、MIT 许可证、React 19 兼容性及采用/不采用边界；
- 更新 `docs/README.md` 与 `docs/references/README.md` 索引。

## 验证

- `git diff --check`：PASS
- `make check`：PASS

## 非目标

- 不引入 Primer 依赖或组件实现；
- 不迁移任何页面；
- 不修改 API、权限或产品语义；
- 迁移执行和子任务继续由 114August514/107-frontend#1 跟踪。