### PR TITLE
fix(frontend): recover from unavailable API

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -74,6 +74,19 @@ export class ApiError extends Error {
 }
 
 /**
+ * 底层 fetch 无法建立连接时（后端未启动、代理失败、DNS/网络中断）
+ * 抛出的类型化错误。message 仅供内部调试，UI copy 由 toAsyncError 按上下文决定。
+ */
+export class NetworkError extends Error {
+  readonly code = 'network_unavailable'
+
+  constructor(cause: unknown) {
+    super('Network request failed', { cause })
+    this.name = 'NetworkError'
+  }
+}
+
+/**
  * 为一次提交意图生成幂等键。
  *
  * 重试同一次意图时要复用同一个键；用户真的想再跑一次时才换新键。
@@ -104,7 +117,21 @@ const identity: Middleware = {
   },
 }
 
-const http = createClient<paths>({ baseUrl: '' })
+/**
+ * 包装全局 fetch，把 fetch 层 reject 的异常统一转成 NetworkError。
+ * 收到响应（包括 4xx/5xx）时不进入 catch，交给 openapi-fetch 正常解析；
+ * 任何导致 fetch Promise reject 的底层错误（连接失败、DNS、CORS、中断等）
+ * 都会被捕获并带上原始 cause。
+ */
+const safeFetch: typeof fetch = async (input, init) => {
+  try {
+    return await globalThis.fetch(input, init)
+  } catch (cause) {
+    throw new NetworkError(cause)
+  }
+}
+
+const http = createClient<paths>({ baseUrl: '', fetch: safeFetch })
 http.use(identity)
 
 /** 把 openapi-fetch 的 `{ data, error }` 转成「成功返回值 / 抛 ApiError」。 */

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,53 @@
+import { ApiError, NetworkError } from './client'
+
+/**
+ * 供展示组件消费的归一化错误数据。
+ *
+ * 不暴露原始异常类型、HTTP 状态或底层 transport message；
+ * 只保留「用户可见主要提示」、「可执行下一步」和「次级诊断信息」。
+ */
+export interface AsyncErrorView {
+  message: string
+  problems?: string[]
+  requestId?: string
+}
+
+/**
+ * 把 API client 抛出的错误转成展示层可理解的形状。
+ *
+ * - 结构化 ApiError：保留后端已经写好的用户文案、问题列表和请求标识；
+ * - NetworkError：给出稳定的「加载失败 + 检查网络后重试」文案；
+ * - code === 'http_error' 的非结构化响应：给出中性的「请求失败 + 重试」文案，
+ *   不暴露 HTTP 状态或原始 message，仅保留 requestId；
+ * - 其它未知错误：不伪造原因，只给通用可重试提示。
+ */
+export function toAsyncError(error: Error | undefined): AsyncErrorView | undefined {
+  if (!error) return undefined
+
+  if (error instanceof NetworkError) {
+    return {
+      message: '无法加载内容。',
+      problems: ['请检查网络连接后重试。'],
+    }
+  }
+
+  if (error instanceof ApiError) {
+    if (error.code === 'http_error') {
+      return {
+        message: '请求失败。',
+        problems: ['请重试。'],
+        requestId: error.requestId || undefined,
+      }
+    }
+    return {
+      message: error.message,
+      problems: error.problems.length > 0 ? error.problems : undefined,
+      requestId: error.requestId || undefined,
+    }
+  }
+
+  return {
+    message: '请求失败。',
+    problems: ['请重试。'],
+  }
+}

--- a/frontend/src/components/common/AsyncSection.tsx
+++ b/frontend/src/components/common/AsyncSection.tsx
@@ -1,11 +1,16 @@
-import { Alert, Empty, Skeleton, Typography } from 'antd'
+import { Alert, Button, Empty, Skeleton, Typography } from 'antd'
 import type { ReactNode } from 'react'
 
-import { ApiError } from '../../api/client'
+import { ApiError, NetworkError } from '../../api/client'
+import { toAsyncError } from '../../api/errors'
 
 interface Props {
   loading: boolean
   error: Error | undefined
+  /** 错误恢复回调；提供时在错误 Alert 上渲染「重试」主操作。 */
+  onRetry?: () => void
+  /** 网络错误或非结构化 http_error 的上下文主提示；未提供时使用默认 copy。 */
+  errorTitle?: string
   empty?: boolean
   emptyText?: string
   children: ReactNode
@@ -26,7 +31,15 @@ function Padded({ children }: { children: ReactNode }) {
   return <div style={{ padding: 16 }}>{children}</div>
 }
 
-export function AsyncSection({ loading, error, empty, emptyText, children }: Props) {
+export function AsyncSection({
+  loading,
+  error,
+  onRetry,
+  errorTitle,
+  empty,
+  emptyText,
+  children,
+}: Props) {
   if (loading) {
     return (
       <Padded>
@@ -36,14 +49,19 @@ export function AsyncSection({ loading, error, empty, emptyText, children }: Pro
   }
 
   if (error) {
-    const problems = error instanceof ApiError ? error.problems : []
-    const requestId = error instanceof ApiError ? error.requestId : ''
+    const view = toAsyncError(error)
+    if (!view) return null
+    const isUnstructured =
+      error instanceof NetworkError || (error instanceof ApiError && error.code === 'http_error')
+    const message = isUnstructured && errorTitle ? errorTitle : view.message
+    const problems = view.problems ?? []
+    const requestId = view.requestId ?? ''
     return (
       <Padded>
         <Alert
           type="error"
           showIcon
-          message={error.message}
+          message={message}
           description={
             problems.length > 0 || requestId ? (
               <>
@@ -61,6 +79,13 @@ export function AsyncSection({ loading, error, empty, emptyText, children }: Pro
                   </Typography.Text>
                 )}
               </>
+            ) : undefined
+          }
+          action={
+            onRetry ? (
+              <Button type="primary" onClick={onRetry}>
+                重试
+              </Button>
             ) : undefined
           }
         />

--- a/frontend/src/components/common/AsyncState.tsx
+++ b/frontend/src/components/common/AsyncState.tsx
@@ -7,6 +7,8 @@ interface Props {
   loading: boolean
   /** 已经归一化的错误展示数据；组件不依赖 API client，由调用方拆解错误对象。 */
   error?: { message: string; problems?: string[]; requestId?: string }
+  /** 可恢复错误的重试回调；提供时错误态会渲染「重试」主操作。 */
+  onRetry?: () => void
   empty?: boolean
   /** 空态标题；说明缺什么。 */
   emptyText?: string
@@ -39,6 +41,7 @@ function Padded({ children }: { children: ReactNode }) {
 export function AsyncState({
   loading,
   error,
+  onRetry,
   empty,
   emptyText,
   emptyDescription,
@@ -76,6 +79,7 @@ export function AsyncState({
               </Text>
             )}
           </Banner.Description>
+          {onRetry ? <Banner.PrimaryAction onClick={onRetry}>重试</Banner.PrimaryAction> : null}
         </Banner>
       </Padded>
     )

--- a/frontend/src/pages/RunPage.tsx
+++ b/frontend/src/pages/RunPage.tsx
@@ -88,7 +88,12 @@ export function RunPage() {
 
   return (
     <Stack gap="large">
-      <AsyncSection loading={detail.loading} error={detail.error}>
+      <AsyncSection
+        loading={detail.loading}
+        error={detail.error}
+        onRetry={detail.reload}
+        errorTitle="无法加载这个 Run。"
+      >
         {detail.data && run && (
           <>
             <PageHeader
@@ -177,7 +182,12 @@ export function RunPage() {
                   label: '日志',
                   children: (
                     <Card>
-                      <AsyncSection loading={logs.loading} error={logs.error}>
+                      <AsyncSection
+                        loading={logs.loading}
+                        error={logs.error}
+                        onRetry={logs.reload}
+                        errorTitle="无法加载日志。"
+                      >
                         <RunLogPanel chunks={logs.data ?? []} failed={run.status === 'failed'} />
                       </AsyncSection>
                     </Card>

--- a/frontend/tests/component/DesignSystemPage.test.tsx
+++ b/frontend/tests/component/DesignSystemPage.test.tsx
@@ -112,6 +112,7 @@ describe('AsyncState', () => {
   })
 
   it('错误逐条展示问题并次级保留请求标识', () => {
+    const onRetry = vi.fn()
     render(
       <AsyncState
         loading={false}
@@ -120,6 +121,7 @@ describe('AsyncState', () => {
           problems: ['文件 list.txt 已存在', '说明过长'],
           requestId: 'req_01K2ZQ',
         }}
+        onRetry={onRetry}
       >
         内容
       </AsyncState>,
@@ -130,6 +132,9 @@ describe('AsyncState', () => {
     expect(screen.getByText('说明过长')).toBeInTheDocument()
     expect(screen.getByRole('list')).toBeInTheDocument()
     expect(screen.getByText('请求标识 req_01K2ZQ')).toBeInTheDocument()
+    const retry = screen.getByRole('button', { name: '重试' })
+    fireEvent.click(retry)
+    expect(onRetry).toHaveBeenCalledTimes(1)
   })
 
   it('单条下一步说明不渲染为列表', () => {

--- a/frontend/tests/component/RunPage.test.tsx
+++ b/frontend/tests/component/RunPage.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { ConfigProvider } from 'antd'
+import zhCN from 'antd/locale/zh_CN'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+import { api, ApiError } from '../../src/api/client'
+import type { LogChunk, RunDetail, Workspace } from '../../src/api/types'
+import { RunPage } from '../../src/pages/RunPage'
+
+const runDetailFixture = (): RunDetail => ({
+  run: {
+    id: 'run-1',
+    name: 'test-run',
+    project_id: 'project-1',
+    workspace_id: 'workspace-1',
+    project_version_id: 'version-1',
+    project_version_label: 'v1',
+    snapshot_id: 'snapshot-1',
+    source_run_id: null,
+    source_run_configuration_id: null,
+    status: 'succeeded',
+    created_by: 'student',
+    created_at: '2026-08-15T08:00:00Z',
+    submitted_at: '2026-08-15T08:01:00Z',
+    started_at: '2026-08-15T08:02:00Z',
+    finished_at: '2026-08-15T08:10:00Z',
+    scheduler_job_id: null,
+    exit_code: 0,
+    failure_reason: '',
+    queued_seconds: 1,
+    running_seconds: 8,
+  },
+  events: [],
+  artifacts: [],
+  snapshot: {
+    id: 'snapshot-1',
+    command: 'python train.py',
+    environment_image: 'python:3.11',
+    environment_setup_command: '',
+    environment_variables: {},
+    environment_version_id: 'env-1',
+    compute_plan_id: 'plan-1',
+    compute_request: {
+      cpus: 1,
+      gpus: 0,
+      memory_mb: 1024,
+      nodes: 1,
+      time_limit_minutes: 60,
+    },
+    artifact_rules: [],
+    input_bindings: [],
+    created_at: '2026-08-15T08:00:00Z',
+    created_by: 'student',
+    project_id: 'project-1',
+    project_version_id: 'version-1',
+    scheduler: {
+      account: '',
+      cluster: '',
+      cpus: 1,
+      gpus: 0,
+      memory_mb: 1024,
+      nodes: 1,
+      partition: '',
+      qos: '',
+      time_limit_minutes: 60,
+    },
+    secret_references: {},
+    source_run_configuration_id: null,
+    working_directory: '',
+  },
+})
+
+const workspaceFixture = (): Workspace => ({
+  id: 'workspace-1',
+  name: 'test-workspace',
+  kind: 'personal',
+  role: 'owner',
+  description: '',
+  capabilities: ['run.submit', 'run.cancel'],
+  default_environment_version_id: null,
+  created_at: '2026-08-15T08:00:00Z',
+  owner_id: 'student',
+})
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ConfigProvider locale={zhCN}>
+      <MemoryRouter initialEntries={['/runs/run-1']}>
+        <Routes>
+          <Route path="/runs/:runId" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </ConfigProvider>
+  )
+}
+
+describe('RunPage backend unavailable', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('converges from loading to stable error copy with retry, then recovers when API returns', async () => {
+    let getRunCalls = 0
+    vi.spyOn(api, 'getRun').mockImplementation(async () => {
+      getRunCalls++
+      if (getRunCalls === 1) {
+        // 模拟 Vite proxy 把后端 ECONNREFUSED 转成非结构化 HTTP 500 的路径。
+        throw new ApiError(500, 'http_error', '请求失败（HTTP 500）', [], '')
+      }
+      return runDetailFixture()
+    })
+
+    vi.spyOn(api, 'readLogs').mockResolvedValue([] as LogChunk[])
+    vi.spyOn(api, 'getWorkspace').mockResolvedValue(workspaceFixture())
+
+    render(
+      <Wrapper>
+        <RunPage />
+      </Wrapper>,
+    )
+
+    // Loading ends and context-specific error copy appears.
+    await waitFor(() => {
+      expect(screen.getByText('无法加载这个 Run。')).toBeInTheDocument()
+    })
+    expect(screen.getByText('请重试。')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /重\s*试/ })).toBeInTheDocument()
+
+    // Unstructured HTTP 500/proxy wording must not be exposed to users.
+    expect(screen.queryByText(/HTTP 500/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/请求失败（HTTP 500）/i)).not.toBeInTheDocument()
+
+    // Retry re-fetches the run.
+    fireEvent.click(screen.getByRole('button', { name: /重\s*试/ }))
+    await waitFor(() => {
+      expect(getRunCalls).toBe(2)
+    })
+
+    // After recovery the page content appears.
+    await waitFor(() => {
+      expect(screen.queryByText('无法加载这个 Run。')).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('heading', { name: 'test-run' })).toBeInTheDocument()
+  })
+})

--- a/frontend/tests/unit/api/client.test.ts
+++ b/frontend/tests/unit/api/client.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { toApiError } from '../../../src/api/client'
+import { ApiError, toApiError } from '../../../src/api/client'
+import { toAsyncError } from '../../../src/api/errors'
 
 /**
  * 错误信封的解析。
@@ -91,5 +92,58 @@ describe('toApiError', () => {
 
     expect(error.problems).toEqual([])
     expect(error.requestId).toBe('')
+  })
+})
+
+describe('toAsyncError', () => {
+  it('保留结构化 ApiError 的 message、problems 和 requestId', () => {
+    const error = new ApiError(
+      403,
+      'permission_denied',
+      '需要「创建 Project」权限',
+      ['你不是这个 Workspace 的成员'],
+      'req_abc',
+    )
+
+    expect(toAsyncError(error)).toEqual({
+      message: '需要「创建 Project」权限',
+      problems: ['你不是这个 Workspace 的成员'],
+      requestId: 'req_abc',
+    })
+  })
+})
+
+describe('fetch transport wrapper', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('把 fetch 网络失败归一化为 NetworkError 并保留 cause', async () => {
+    const cause = new TypeError('Failed to fetch')
+    const OriginalRequest = globalThis.Request
+    vi.stubGlobal(
+      'Request',
+      class extends OriginalRequest {
+        constructor(input: RequestInfo | URL, init?: RequestInit) {
+          if (typeof input === 'string' && input.startsWith('/') && !input.startsWith('//')) {
+            super(new URL(input, 'http://localhost:5173'), init)
+          } else {
+            super(input, init)
+          }
+        }
+      },
+    )
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(cause))
+
+    // 清除模块缓存，使 client.ts 在 Request stub 生效后重新实例化 openapi-fetch。
+    vi.resetModules()
+    const { api, NetworkError } = await import('../../../src/api/client')
+
+    await expect(api.home()).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof NetworkError)) return false
+      expect(error.code).toBe('network_unavailable')
+      expect(error.cause).toBe(cause)
+      return true
+    })
   })
 })


### PR DESCRIPTION
## 关联 Issue

Closes #29

## 修改内容

- 将 fetch transport rejection 归一化为保留 cause 的 `NetworkError`，并避免向用户暴露非结构化 `http_error` / HTTP 状态文案。
- 为现有 Ant Design `AsyncSection` 增加可选的上下文错误标题与手动重试操作；为 Primer `AsyncState` 同步可选 `onRetry` 契约及测试。
- 在 Run 详情与日志加载失败时提供上下文错误和用户触发的重试，保持 error → loading → error/data 状态收敛。

## 验证证据

- `pnpm vitest run tests/unit/api/client.test.ts tests/component/RunPage.test.tsx tests/component/DesignSystemPage.test.tsx`：3 files / 18 tests passed。
- `make check`：passed；workflow 15、backend 178、frontend 41 tests passed，format/lint/typecheck/build/OpenAPI comparison passed。
- backend 未运行时的 Chromium：1440×1000 与 375×812 均显示稳定上下文错误；键盘可触发重试；无 HTTP/raw transport 文案泄漏或横向溢出。
- backend 未运行时 `/design-system` 可独立加载。
- fresh-context review：PASS。

## 影响范围

- Frontend only；业务页面仅调整 RunPage。
- 不混用 Primer 与 Ant Design provider；不增加 timeout、自动重试、依赖库、proxy 行为或 backend 变更。
- `AsyncSection` / `AsyncState` 新增参数均为可选，现有调用方保持兼容。

## 延后事项与实现妥协

- Deferred ID：无