### PR TITLE
refactor(project): 迁移 Project Ownership、Visibility 与访问控制

### DIFF
--- a/backend/migrations/versions/f36a1b2c3d4e_project_ownership_visibility.py
+++ b/backend/migrations/versions/f36a1b2c3d4e_project_ownership_visibility.py
@@ -1,0 +1,86 @@
+"""Give Project an explicit User/User Group owner and visibility.
+
+Issue #36: Project 的归属从 ``workspace_id`` 迁移为显式 User/UserGroup Owner，
+并增加 ``OWNER_SCOPE`` / ``PUBLIC`` Visibility。``workspace_id`` 作为 #37-#42
+迁移窗口内的兼容锚点保留，不再是归属权威。
+
+downgrade 只还原表结构，不回填 owner 列——产品尚未投入使用，本地库直接重建。
+
+Revision ID: f36a1b2c3d4e
+Revises: 4d7a2f91c3e5
+Create Date: 2026-08-24
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f36a1b2c3d4e"
+down_revision: str | None = "4d7a2f91c3e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("owner_user_id", sa.String(40), nullable=True))
+    op.add_column("projects", sa.Column("owner_user_group_id", sa.String(40), nullable=True))
+    op.add_column(
+        "projects",
+        sa.Column("visibility", sa.String(32), nullable=False, server_default="owner_scope"),
+    )
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT p.id, p.workspace_id, w.kind, w.owner_id "
+            "FROM projects p JOIN workspaces w ON w.id = p.workspace_id"
+        )
+    ).mappings()
+    for row in rows:
+        if row["kind"] == "personal":
+            bind.execute(
+                sa.text("UPDATE projects SET owner_user_id = :owner WHERE id = :id"),
+                {"owner": row["owner_id"], "id": row["id"]},
+            )
+        else:
+            bind.execute(
+                sa.text("UPDATE projects SET owner_user_group_id = :owner WHERE id = :id"),
+                {"owner": row["workspace_id"], "id": row["id"]},
+            )
+    op.create_index("ix_projects_owner_user_id", "projects", ["owner_user_id"])
+    op.create_index("ix_projects_owner_user_group_id", "projects", ["owner_user_group_id"])
+    # Keep the old workspace anchor during the bounded #37-#42 migration window.
+    with op.batch_alter_table("projects") as batch:
+        batch.create_foreign_key(
+            "fk_projects_owner_user_id_users",
+            "users",
+            ["owner_user_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+        batch.create_foreign_key(
+            "fk_projects_owner_user_group_id_user_groups",
+            "user_groups",
+            ["owner_user_group_id"],
+            ["id"],
+            ondelete="RESTRICT",
+        )
+        batch.create_check_constraint(
+            "ck_projects_exactly_one_owner",
+            "((owner_user_id IS NOT NULL AND owner_user_group_id IS NULL) "
+            "OR (owner_user_id IS NULL AND owner_user_group_id IS NOT NULL))",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("projects") as batch:
+        batch.drop_constraint("ck_projects_exactly_one_owner", type_="check")
+        batch.drop_constraint("fk_projects_owner_user_group_id_user_groups", type_="foreignkey")
+        batch.drop_constraint("fk_projects_owner_user_id_users", type_="foreignkey")
+    op.drop_index("ix_projects_owner_user_group_id", table_name="projects")
+    op.drop_index("ix_projects_owner_user_id", table_name="projects")
+    op.drop_column("projects", "visibility")
+    op.drop_column("projects", "owner_user_group_id")
+    op.drop_column("projects", "owner_user_id")

--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -104,15 +104,19 @@ def entitlement_out(view: EntitlementView) -> s.EntitlementOut:
     )
 
 
-def project_out(project: Project) -> s.ProjectOut:
+def project_out(project: Project, *, owner: OwnerSummary, owner_scope: bool = True) -> s.ProjectOut:
     return s.ProjectOut(
         id=project.id,
         workspace_id=project.workspace_id,
+        owner=owner_summary_out(owner),
         name=project.name,
         description=project.description,
         status=project.status.value,
-        environment_version_id=project.environment_version_id,
-        default_run_configuration_id=project.default_run_configuration_id,
+        visibility=project.visibility.value,
+        environment_version_id=project.environment_version_id if owner_scope else None,
+        default_run_configuration_id=(
+            project.default_run_configuration_id if owner_scope else None
+        ),
         created_by=project.created_by,
         created_at=project.created_at,
         updated_at=project.updated_at,

--- a/backend/src/workspace107/api/routes/home.py
+++ b/backend/src/workspace107/api/routes/home.py
@@ -16,13 +16,18 @@ async def home(user: CurrentUser, services: ServicesDep) -> s.HomeOut:
     """Return identity, visible User Groups, and recent legacy child-domain objects."""
     user_groups = await services.user_groups.list_for_user(user.id)
     personal_context = await services.legacy_workspaces.find_personal(user.id)
+    projects = await services.projects.list_recent_for_user(user.id, limit=10)
+    owner_summaries = await services.projects.owner_summaries(projects)
     return s.HomeOut(
         user=p.user_out(user),
         user_groups=[p.user_group_out(group) for group in user_groups],
         personal_resource_context_id=personal_context.id if personal_context else None,
         recent_projects=[
-            p.project_out(project)
-            for project in await services.projects.list_recent_for_user(user.id, limit=10)
+            p.project_out(
+                project,
+                owner=owner_summaries[(project.owner.kind, project.owner.id)],
+            )
+            for project in projects
         ],
         recent_runs=[
             p.run_out(run) for run in await services.runs.list_recent_for_user(user.id, limit=10)

--- a/backend/src/workspace107/api/routes/projects.py
+++ b/backend/src/workspace107/api/routes/projects.py
@@ -7,6 +7,7 @@ from fastapi.responses import Response
 
 from ...application.run_configuration_service import RunConfigurationInput
 from ...domain.enums import ProjectStatus
+from ...domain.ownership import OwnerReference
 from .. import presenters as p
 from .. import schemas as s
 from ..deps import CurrentUser, PageDep, ServicesDep
@@ -17,6 +18,44 @@ MAX_TEXT_PREVIEW = 256 * 1024
 
 
 @router.get(
+    "/projects", response_model=s.PageOut[s.ProjectOut], summary="列出当前用户可发现的 Project"
+)
+async def list_discoverable_projects(
+    user: CurrentUser, services: ServicesDep, page: PageDep
+) -> s.PageOut[s.ProjectOut]:
+    """列出当前用户可发现的 Project：自己 / 所属 User Group 拥有的，以及 PUBLIC Project。"""
+    result = await services.projects.list_discoverable_for_user(user.id, page)
+    summaries = await services.projects.owner_summaries(result.items)
+    return p.page_out(
+        result,
+        lambda project: p.project_out(
+            project,
+            owner=summaries[(project.owner.kind, project.owner.id)],
+            owner_scope=False,
+        ),
+    )
+
+
+@router.post(
+    "/projects",
+    response_model=s.ProjectOut,
+    status_code=status.HTTP_201_CREATED,
+    summary="为 User 或 User Group 创建 Project",
+)
+async def create_owned_project(
+    payload: s.ProjectCreateOwnedIn, user: CurrentUser, services: ServicesDep
+) -> s.ProjectOut:
+    project = await services.projects.create_owned(
+        user.id,
+        OwnerReference(kind=payload.owner.kind, id=payload.owner.id),
+        payload.name,
+        payload.description,
+        visibility=payload.visibility,
+    )
+    return p.project_out(project, owner=await services.projects.owner_summary(project))
+
+
+@router.get(
     "/projects/{project_id}",
     response_model=s.ProjectOut,
     summary="获取 Project 详情",
@@ -24,7 +63,11 @@ MAX_TEXT_PREVIEW = 256 * 1024
 async def get_project(project_id: str, user: CurrentUser, services: ServicesDep) -> s.ProjectOut:
     """校验当前用户可查看该 Project 后，返回项目设置与当前状态。"""
     access = await services.projects.get(user.id, project_id)
-    return p.project_out(access.project)
+    return p.project_out(
+        access.project,
+        owner=await services.projects.owner_summary(access.project),
+        owner_scope=access.owner_scope,
+    )
 
 
 @router.patch(
@@ -47,12 +90,13 @@ async def update_project(
         environment_version_id=payload.environment_version_id,
         inherit_workspace_environment=bool(payload.inherit_workspace_environment),
         default_run_configuration_id=payload.default_run_configuration_id,
+        visibility=payload.visibility,
     )
     if payload.status is not None:
         project = await services.projects.set_status(
             user.id, project_id, ProjectStatus(payload.status)
         )
-    return p.project_out(project)
+    return p.project_out(project, owner=await services.projects.owner_summary(project))
 
 
 # -- 文件 -------------------------------------------------------------------
@@ -281,20 +325,29 @@ async def fork_version(
     user: CurrentUser,
     services: ServicesDep,
 ) -> s.ProjectOut:
-    """两侧都会校验：源版本可读、目标空间可写。
+    """两侧都会校验：源版本可读、目标 Owner 下可创建。
 
-    复制内容、运行方案和环境选择；**不复制**权益、凭据、成员权限和 Run 历史
-    （GR-503）。Secret 只复制引用表达式，目标空间缺同名 Secret 时
-    提交前检查会拦下（GR-407）。
+    ``target_workspace_id`` 与 ``target_owner`` 二选一；显式 Owner 形态是
+    #36 的正路，workspace 形态是过渡兼容。复制内容、运行方案和环境选择；
+    **不复制**权益、凭据、成员权限和 Run 历史（GR-503）。Secret 只复制
+    引用表达式，目标空间缺同名 Secret 时提交前检查会拦下（GR-407）。
+
+    PUBLIC 读者只能 Fork 出只含文件与不可变版本的新 Project。
     """
+    target_owner = (
+        OwnerReference(kind=payload.target_owner.kind, id=payload.target_owner.id)
+        if payload.target_owner
+        else None
+    )
     project = await services.projects.fork(
         user.id,
         version_id,
         payload.target_workspace_id,
+        target_owner=target_owner,
         name=payload.name,
         description=payload.description,
     )
-    return p.project_out(project)
+    return p.project_out(project, owner=await services.projects.owner_summary(project))
 
 
 @router.get(

--- a/backend/src/workspace107/api/routes/workspaces.py
+++ b/backend/src/workspace107/api/routes/workspaces.py
@@ -59,7 +59,13 @@ async def list_projects(
     workspace_id: str, user: CurrentUser, services: ServicesDep, page: PageDep
 ) -> s.PageOut[s.ProjectOut]:
     result = await services.projects.list_for_workspace(user.id, workspace_id, page)
-    return p.page_out(result, p.project_out)
+    summaries = await services.projects.owner_summaries(result.items)
+    return p.page_out(
+        result,
+        lambda project: p.project_out(
+            project, owner=summaries[(project.owner.kind, project.owner.id)]
+        ),
+    )
 
 
 @router.post(
@@ -75,9 +81,10 @@ async def create_project(
     user: CurrentUser,
     services: ServicesDep,
 ) -> s.ProjectOut:
-    return p.project_out(
-        await services.projects.create(user.id, workspace_id, payload.name, payload.description)
+    project = await services.projects.create(
+        user.id, workspace_id, payload.name, payload.description
     )
+    return p.project_out(project, owner=await services.projects.owner_summary(project))
 
 
 @router.get(

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ..domain.capabilities import Capability, UserGroupCapability
 from ..domain.enums import (
@@ -23,6 +23,7 @@ from ..domain.enums import (
     MembershipStatus,
     NotificationType,
     ProjectStatus,
+    ProjectVisibility,
     RunEventType,
     RunStatus,
     TargetType,
@@ -145,9 +146,11 @@ class EntitlementOut(Model):
 class ProjectOut(Model):
     id: str
     workspace_id: str
+    owner: OwnerSummaryOut
     name: str
     description: str
     status: ProjectStatus
+    visibility: ProjectVisibility
     environment_version_id: str | None
     default_run_configuration_id: str | None
     created_by: str
@@ -160,6 +163,11 @@ class ProjectCreateIn(Model):
     description: str = ""
 
 
+class ProjectCreateOwnedIn(ProjectCreateIn):
+    owner: OwnerReferenceIn
+    visibility: ProjectVisibility = ProjectVisibility.OWNER_SCOPE
+
+
 class ProjectUpdateIn(Model):
     name: str | None = None
     description: str | None = None
@@ -167,6 +175,7 @@ class ProjectUpdateIn(Model):
     inherit_workspace_environment: bool | None = None
     default_run_configuration_id: str | None = None
     status: ProjectStatus | None = None
+    visibility: ProjectVisibility | None = None
 
 
 class ProjectFileOut(Model):
@@ -620,10 +629,17 @@ class UnreadCountOut(Model):
 
 
 class ForkIn(Model):
-    target_workspace_id: str
+    target_workspace_id: str | None = None
+    target_owner: OwnerReferenceIn | None = None
     name: str = ""
     """留空表示沿用源 Project 的名称。"""
     description: str = ""
+
+    @model_validator(mode="after")
+    def validate_target(self) -> ForkIn:
+        if (self.target_workspace_id is None) == (self.target_owner is None):
+            raise ValueError("Fork 必须且只能指定 target_workspace_id 或 target_owner")
+        return self
 
 
 class ForkSourceOut(Model):

--- a/backend/src/workspace107/application/access.py
+++ b/backend/src/workspace107/application/access.py
@@ -11,7 +11,7 @@ from ..domain.capabilities import (
     describe,
     user_group_capabilities_of,
 )
-from ..domain.enums import MembershipRole
+from ..domain.enums import MembershipRole, ProjectVisibility
 from ..domain.errors import ObjectNotFound, PermissionDenied
 from ..domain.models import (
     Environment,
@@ -66,10 +66,14 @@ class LegacyWorkspaceAccess:
 class ProjectAccess:
     project: Project
     workspace: LegacyWorkspace
-    role: MembershipRole
+    role: MembershipRole | None
+    owner_scope: bool
 
     @property
     def capabilities(self) -> frozenset[Capability]:
+        if self.role is None:
+            # PUBLIC reader: metadata + immutable version read only.
+            return _PUBLIC_READER_CAPABILITIES
         return capabilities_of(self.role)
 
     def can(self, capability: Capability) -> bool:
@@ -77,7 +81,15 @@ class ProjectAccess:
 
     def require(self, capability: Capability) -> None:
         if not self.can(capability):
-            raise PermissionDenied(f"当前角色（{self.role.value}）无权{describe(capability)}")
+            label = "公开读者" if self.role is None else self.role.value
+            raise PermissionDenied(f"当前角色（{label}）无权{describe(capability)}")
+
+    def require_owner_scope(self) -> None:
+        if not self.owner_scope:
+            raise PermissionDenied("当前 Project 仅公开其元数据和不可变版本")
+
+
+_PUBLIC_READER_CAPABILITIES = frozenset({Capability.PROJECT_VIEW})
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,38 +196,70 @@ class AccessGuard:
         return access
 
     async def project(
-        self, user_id: str, project_id: str, *, needs: Capability | None = None
+        self,
+        user_id: str,
+        project_id: str,
+        *,
+        needs: Capability | None = None,
+        owner_scope: bool = False,
     ) -> ProjectAccess:
         project = await self._repos.projects.get(project_id)
         if project is None:
             raise ObjectNotFound("Project", project_id)
-        try:
-            workspace_access = await self.legacy_workspace(user_id, project.workspace_id)
-        except ObjectNotFound as exc:
-            # 归属 Workspace 不可见时，Project 同样视为不存在。
-            raise ObjectNotFound("Project", project_id) from exc
 
+        role: MembershipRole | None = None
+        is_owner = False
+        if project.owner.kind is OwnerKind.USER:
+            if project.owner.id == user_id:
+                is_owner = True
+                role = MembershipRole.OWNER
+        else:
+            membership = await self._repos.memberships.get(project.owner.id, user_id)
+            if membership is not None and membership.is_active:
+                is_owner = True
+                role = membership.role
+
+        if not is_owner:
+            if project.visibility is not ProjectVisibility.PUBLIC:
+                raise ObjectNotFound("Project", project_id)
+            if owner_scope:
+                # Owner-scope operations (working state, runs, configs) never
+                # cross into the public read boundary.
+                raise ObjectNotFound("Project", project_id)
+
+        workspace = await self._compatibility_workspace(project)
         access = ProjectAccess(
-            project=project, workspace=workspace_access.workspace, role=workspace_access.role
+            project=project, workspace=workspace, role=role, owner_scope=is_owner
         )
         if needs is not None:
             access.require(needs)
         return access
+
+    async def _compatibility_workspace(self, project: Project) -> LegacyWorkspace:
+        workspace = await self._repos.legacy_workspaces.get(project.workspace_id)
+        if workspace is None:
+            raise ObjectNotFound("Project", project.id)
+        return workspace
 
     async def run(self, user_id: str, run_id: str, *, needs: Capability | None = None) -> RunAccess:
         run = await self._repos.runs.get(run_id)
         if run is None:
             raise ObjectNotFound("Run", run_id)
         try:
-            project_access = await self.project(user_id, run.project_id)
+            project_access = await self.project(user_id, run.project_id, owner_scope=True)
         except ObjectNotFound as exc:
             raise ObjectNotFound("Run", run_id) from exc
+        # owner_scope=True above guarantees project_access.role is a real membership
+        # role, never the PUBLIC reader's None.
+        role = project_access.role
+        if role is None:  # pragma: no cover - enforced by the guard above
+            raise ObjectNotFound("Run", run_id)
 
         access = RunAccess(
             run=run,
             project=project_access.project,
             workspace=project_access.workspace,
-            role=project_access.role,
+            role=role,
         )
         if needs is not None:
             access.require(needs)

--- a/backend/src/workspace107/application/activity.py
+++ b/backend/src/workspace107/application/activity.py
@@ -129,5 +129,7 @@ class ActivityService:
     async def list_for_project(
         self, user_id: str, project_id: str, page: PageRequest
     ) -> Page[Activity]:
-        await self._guard.project(user_id, project_id, needs=Capability.PROJECT_VIEW)
+        await self._guard.project(
+            user_id, project_id, needs=Capability.PROJECT_VIEW, owner_scope=True
+        )
         return await self._repos.activities.list_for_project(project_id, page)

--- a/backend/src/workspace107/application/project_service.py
+++ b/backend/src/workspace107/application/project_service.py
@@ -124,6 +124,12 @@ class ProjectService:
         access = await self._guard.legacy_workspace(
             user_id, workspace_id, needs=Capability.PROJECT_CREATE
         )
+        # Owner 权威始终从锚点推导；显式传入的 owner 必须与之完全一致。
+        # 锚点镜像不变量被 #37-#42 子域依赖，不能让任何调用方打破——
+        # 否则会变成 DB FK 边界错误或脏数据，而不是干净的 404。
+        canonical_owner = access.workspace.owner_reference
+        if owner is not None and owner != canonical_owner:
+            raise ObjectNotFound("Project Owner", owner.id)
         name = name.strip()
         if not name:
             raise ValidationFailed("Project 名称不能为空")
@@ -135,7 +141,7 @@ class ProjectService:
             id=ids.new_id(ids.PROJECT),
             workspace_id=workspace_id,
             name=name,
-            owner=owner or access.workspace.owner_reference,
+            owner=canonical_owner,
             description=description,
             visibility=visibility,
             created_by=user_id,

--- a/backend/src/workspace107/application/project_service.py
+++ b/backend/src/workspace107/application/project_service.py
@@ -12,16 +12,26 @@ from dataclasses import dataclass
 
 from ..domain import ids
 from ..domain.capabilities import Capability
-from ..domain.enums import ActivityAction, ChangeKind, InputSourceType, ProjectStatus, TargetType
+from ..domain.enums import (
+    ActivityAction,
+    ChangeKind,
+    InputSourceType,
+    LegacyWorkspaceKind,
+    ProjectStatus,
+    ProjectVisibility,
+    TargetType,
+)
 from ..domain.errors import ConflictError, ObjectNotFound, ValidationFailed
 from ..domain.models import (
     ForkRelation,
+    LegacyWorkspace,
     Project,
     ProjectFile,
     ProjectVersion,
     ProjectVersionFile,
     RunConfiguration,
 )
+from ..domain.ownership import OwnerKind, OwnerReference
 from ..domain.pagination import Page, PageRequest
 from ..domain.ports.clock import Clock
 from ..domain.ports.repositories import Repositories
@@ -32,6 +42,8 @@ from .asset_use import (
     environment_version_for_owner_use,
     shared_resource_version_for_owner_use,
 )
+from .ownership import OwnerSummary
+from .ownership import owner_summaries as resolve_owner_summaries
 
 MAX_INLINE_PREVIEW_BYTES = 512 * 1024
 
@@ -93,13 +105,25 @@ class ProjectService:
     async def list_recent_for_user(self, user_id: str, *, limit: int = 10) -> list[Project]:
         return await self._repos.projects.list_for_user(user_id, limit=limit)
 
+    async def list_discoverable_for_user(self, user_id: str, page: PageRequest) -> Page[Project]:
+        return await self._repos.projects.list_discoverable_for_user(user_id, page)
+
     async def get(self, user_id: str, project_id: str) -> ProjectAccess:
         return await self._guard.project(user_id, project_id)
 
     async def create(
-        self, user_id: str, workspace_id: str, name: str, description: str = ""
+        self,
+        user_id: str,
+        workspace_id: str,
+        name: str,
+        description: str = "",
+        *,
+        visibility: ProjectVisibility = ProjectVisibility.OWNER_SCOPE,
+        owner: OwnerReference | None = None,
     ) -> Project:
-        await self._guard.legacy_workspace(user_id, workspace_id, needs=Capability.PROJECT_CREATE)
+        access = await self._guard.legacy_workspace(
+            user_id, workspace_id, needs=Capability.PROJECT_CREATE
+        )
         name = name.strip()
         if not name:
             raise ValidationFailed("Project 名称不能为空")
@@ -111,7 +135,9 @@ class ProjectService:
             id=ids.new_id(ids.PROJECT),
             workspace_id=workspace_id,
             name=name,
+            owner=owner or access.workspace.owner_reference,
             description=description,
+            visibility=visibility,
             created_by=user_id,
             created_at=now,
             updated_at=now,
@@ -128,6 +154,52 @@ class ProjectService:
         )
         return project
 
+    async def create_owned(
+        self,
+        user_id: str,
+        owner: OwnerReference,
+        name: str,
+        description: str = "",
+        *,
+        visibility: ProjectVisibility = ProjectVisibility.OWNER_SCOPE,
+    ) -> Project:
+        """Create under a canonical owner with a bounded child-domain anchor."""
+        if owner.kind is OwnerKind.USER:
+            if owner.id != user_id:
+                raise ObjectNotFound("Project Owner", owner.id)
+            workspace = await self._repos.legacy_workspaces.get_personal(user_id)
+            if workspace is None:
+                now = self._clock.now()
+                workspace = LegacyWorkspace(
+                    id=f"{ids.LEGACY_WORKSPACE}_personal_{user_id}",
+                    kind=LegacyWorkspaceKind.PERSONAL,
+                    name=f"{user_id} Personal",
+                    owner_id=user_id,
+                    created_at=now,
+                )
+                await self._repos.legacy_workspaces.add(workspace)
+        else:
+            workspace = await self._repos.legacy_workspaces.get(owner.id)
+            if workspace is None:
+                raise ObjectNotFound("User Group", owner.id)
+        return await self.create(
+            user_id,
+            workspace.id,
+            name,
+            description,
+            visibility=visibility,
+            owner=owner,
+        )
+
+    async def owner_summary(self, project: Project) -> OwnerSummary:
+        summaries = await resolve_owner_summaries(self._repos, [project.owner])
+        return summaries[(project.owner.kind, project.owner.id)]
+
+    async def owner_summaries(
+        self, projects: list[Project]
+    ) -> dict[tuple[OwnerKind, str], OwnerSummary]:
+        return await resolve_owner_summaries(self._repos, [p.owner for p in projects])
+
     async def update(
         self,
         user_id: str,
@@ -138,6 +210,7 @@ class ProjectService:
         environment_version_id: str | None = None,
         inherit_workspace_environment: bool = False,
         default_run_configuration_id: str | None = None,
+        visibility: ProjectVisibility | None = None,
     ) -> Project:
         access = await self._guard.project(user_id, project_id, needs=Capability.PROJECT_UPDATE)
         project = access.project
@@ -153,6 +226,8 @@ class ProjectService:
             project.name = name
         if description is not None:
             project.description = description
+        if visibility is not None:
+            project.visibility = visibility
         if inherit_workspace_environment:
             project.environment_version_id = None
         elif environment_version_id is not None:
@@ -194,12 +269,12 @@ class ProjectService:
     # -- 文件 -----------------------------------------------------------
 
     async def list_files(self, user_id: str, project_id: str) -> list[ProjectFile]:
-        await self._guard.project(user_id, project_id)
+        await self._guard.project(user_id, project_id, owner_scope=True)
         files = await self._repos.project_files.list_for_project(project_id)
         return sorted(files, key=lambda f: f.path)
 
     async def read_file(self, user_id: str, project_id: str, path: str) -> bytes:
-        await self._guard.project(user_id, project_id)
+        await self._guard.project(user_id, project_id, owner_scope=True)
         normalized = normalize_path(path)
         record = await self._repos.project_files.get(project_id, normalized)
         if record is None:
@@ -313,7 +388,7 @@ class ProjectService:
 
     async def working_changes(self, user_id: str, project_id: str) -> list[WorkingTreeChange]:
         """查看当前未保存的文件变更：工作区与最近一个版本的差异。"""
-        await self._guard.project(user_id, project_id)
+        await self._guard.project(user_id, project_id, owner_scope=True)
         latest = await self._repos.project_versions.latest(project_id)
         baseline = {f.path: f.content_hash for f in latest.files} if latest else {}
         current = {
@@ -429,24 +504,27 @@ class ProjectService:
         self,
         user_id: str,
         version_id: str,
-        target_workspace_id: str,
+        target_workspace_id: str | None,
         *,
+        target_owner: OwnerReference | None = None,
         name: str = "",
         description: str = "",
     ) -> Project:
         """从一个确定版本派生出新 Project。
 
         产生的是**新 Project**，不是源 Project 的分支（设计稿 §3.4.2）。
-        新 Project 归目标 Workspace，从此和源 Project 没有任何持续关系（GR-502）。
+        新 Project 归目标 Owner，从此和源 Project 没有任何持续关系（GR-502）。
 
-        两侧都要校验：源版本可读、目标空间可写。少任何一边都是越权——
+        两侧都要校验：源版本可读、目标 Owner 下可创建。少任何一边都是越权——
         只查源就等于「谁都能往别人空间里塞项目」，只查目标就等于
         「Fork 一下就能读到看不见的内容」。
 
         复制什么、不复制什么见 GR-503，下面按顺序标注了。
-        **权益、凭据、成员权限、Run 历史一律不复制**——那些属于源 Workspace，
+        **权益、凭据、成员权限、Run 历史一律不复制**——那些属于源 Owner，
         跟着复制过来就是越权。
 
+        PUBLIC 读者只能 Fork 出只含文件与不可变版本的新 Project：不读取、不验证、
+        不复制源 Project 的 mutable environment selection、Run Configuration、Secret。
         Secret values are never copied; target exact scopes are re-resolved at preflight.
         """
         # 1. 源版本可读
@@ -455,59 +533,76 @@ class ProjectService:
             user_id, source_version.project_id, needs=Capability.PROJECT_VIEW
         )
 
-        # 2. 目标空间可写
+        # 2. 目标 Owner / 空间可写
+        if target_owner is not None:
+            target_workspace_id = await self._resolve_target_workspace(user_id, target_owner)
+        if target_workspace_id is None:
+            raise ValidationFailed("Fork 必须指定 target_workspace_id 或 target_owner")
         target = await self._guard.legacy_workspace(
             user_id, target_workspace_id, needs=Capability.PROJECT_CREATE
         )
+        owner = target_owner or target.workspace.owner_reference
+        # 锚定必须镜像显式 Owner（保护 ScopedConfigResolver 等 #37-#42 子域）。
+        # 显式检查而非 assert：优化模式不会移除，且涉及持久化边界。
+        if target_owner is not None and target.workspace.owner_reference != target_owner:
+            raise ObjectNotFound("Project Owner", target_owner.id)
 
         name = (name or source_access.project.name).strip()
         if not name:
             raise ValidationFailed("Project 名称不能为空")
-        if await self._repos.projects.name_exists(target_workspace_id, name):
+        if await self._repos.projects.name_exists(target.workspace.id, name):
             raise ConflictError(f"当前 Workspace 中已存在名为「{name}」的 Project")
 
-        target_owner = target.workspace.owner_reference
-        project_environment_id = source_access.project.environment_version_id
-        if (
-            project_environment_id is not None
-            and await environment_version_for_owner_use(
-                self._repos, user_id, project_environment_id, target_owner
-            )
-            is None
-        ):
-            raise ObjectNotFound("Environment Version", project_environment_id)
-
-        configurations = await self._repos.run_configurations.list_for_project(
-            source_version.project_id
-        )
-        for configuration in configurations:
-            configuration_environment_id = configuration.environment_version_id
+        configurations: list[RunConfiguration]
+        if source_access.owner_scope:
+            # Owner-scope forker: 读取并按目标 Owner 做 grant-aware 校验后复制。
+            project_environment_id = source_access.project.environment_version_id
             if (
-                configuration_environment_id is not None
+                project_environment_id is not None
                 and await environment_version_for_owner_use(
-                    self._repos, user_id, configuration_environment_id, target_owner
+                    self._repos, user_id, project_environment_id, owner
                 )
                 is None
             ):
-                raise ObjectNotFound("Environment Version", configuration_environment_id)
-            for binding in configuration.input_bindings:
+                raise ObjectNotFound("Environment Version", project_environment_id)
+
+            configurations = await self._repos.run_configurations.list_for_project(
+                source_version.project_id
+            )
+            for configuration in configurations:
+                configuration_environment_id = configuration.environment_version_id
                 if (
-                    binding.source_type is InputSourceType.SHARED_RESOURCE_VERSION
-                    and await shared_resource_version_for_owner_use(
-                        self._repos, user_id, binding.source_id, target_owner
+                    configuration_environment_id is not None
+                    and await environment_version_for_owner_use(
+                        self._repos, user_id, configuration_environment_id, owner
                     )
                     is None
                 ):
-                    raise ObjectNotFound("Shared Resource Version", binding.source_id)
+                    raise ObjectNotFound("Environment Version", configuration_environment_id)
+                for binding in configuration.input_bindings:
+                    if (
+                        binding.source_type is InputSourceType.SHARED_RESOURCE_VERSION
+                        and await shared_resource_version_for_owner_use(
+                            self._repos, user_id, binding.source_id, owner
+                        )
+                        is None
+                    ):
+                        raise ObjectNotFound("Shared Resource Version", binding.source_id)
+        else:
+            # PUBLIC 读者：根本不进入受保护配置的读取路径。
+            project_environment_id = None
+            configurations = []
 
         now = self._clock.now()
         project = Project(
             id=ids.new_id(ids.PROJECT),
-            workspace_id=target_workspace_id,
+            workspace_id=target.workspace.id,
             name=name,
+            owner=owner,
             description=description or source_access.project.description,
-            # Asset references were validated against the target owner before any writes.
-            environment_version_id=source_access.project.environment_version_id,
+            # Asset references were validated against the target owner before any writes
+            # (owner-scope path). PUBLIC forkers carry no mutable references.
+            environment_version_id=project_environment_id,
             created_by=user_id,
             created_at=now,
             updated_at=now,
@@ -544,6 +639,7 @@ class ProjectService:
         # 4. 运行方案：复制表达式和选择，不复制任何值。
         #    注意这里复制的是源 Project **当前**的运行方案，不是版本快照——
         #    RunConfiguration 挂在 Project 上，版本只固定文件内容。
+        #    PUBLIC 读者 configurations 为空，整段跳过。
         for configuration in configurations:
             await self._repos.run_configurations.add(
                 RunConfiguration(
@@ -589,6 +685,26 @@ class ProjectService:
             detail=f"来自 {source_access.project.name} 的 {source_version.label}",
         )
         return project
+
+    async def _resolve_target_workspace(self, user_id: str, owner: OwnerReference) -> str:
+        """Resolve the bounded compatibility anchor for an explicit target owner."""
+        if owner.kind is OwnerKind.USER:
+            if owner.id != user_id:
+                raise ObjectNotFound("Project Owner", owner.id)
+            personal = await self._repos.legacy_workspaces.get_personal(user_id)
+            if personal is None:
+                now = self._clock.now()
+                personal = LegacyWorkspace(
+                    id=f"{ids.LEGACY_WORKSPACE}_personal_{user_id}",
+                    kind=LegacyWorkspaceKind.PERSONAL,
+                    name=f"{user_id} Personal",
+                    owner_id=user_id,
+                    created_at=now,
+                )
+                await self._repos.legacy_workspaces.add(personal)
+            return personal.id
+        # Collaborative workspace shares the User Group id (user_group_service).
+        return owner.id
 
     async def fork_source(self, user_id: str, project_id: str) -> ForkRelation | None:
         """这个 Project 是从哪儿来的。不是 Fork 出来的就返回 None。"""

--- a/backend/src/workspace107/application/run_configuration_service.py
+++ b/backend/src/workspace107/application/run_configuration_service.py
@@ -47,7 +47,7 @@ class RunConfigurationService:
         self._guard = guard
 
     async def list_for_project(self, user_id: str, project_id: str) -> list[RunConfiguration]:
-        await self._guard.project(user_id, project_id)
+        await self._guard.project(user_id, project_id, owner_scope=True)
         return await self._repos.run_configurations.list_for_project(project_id)
 
     async def get(self, user_id: str, configuration_id: str) -> RunConfiguration:
@@ -55,7 +55,7 @@ class RunConfigurationService:
         if configuration is None:
             raise ObjectNotFound("Run Configuration", configuration_id)
         try:
-            await self._guard.project(user_id, configuration.project_id)
+            await self._guard.project(user_id, configuration.project_id, owner_scope=True)
         except ObjectNotFound as exc:
             raise ObjectNotFound("Run Configuration", configuration_id) from exc
         return configuration

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -147,7 +147,7 @@ class RunService:
     # -- 查询 -----------------------------------------------------------
 
     async def list_for_project(self, user_id: str, project_id: str, page: PageRequest) -> Page[Run]:
-        await self._guard.project(user_id, project_id)
+        await self._guard.project(user_id, project_id, owner_scope=True)
         return await self._repos.runs.list_for_project(project_id, page)
 
     async def list_recent_for_user(self, user_id: str, *, limit: int = 10) -> list[Run]:

--- a/backend/src/workspace107/domain/enums.py
+++ b/backend/src/workspace107/domain/enums.py
@@ -39,6 +39,13 @@ class ProjectStatus(StrEnum):
     ARCHIVED = "archived"
 
 
+class ProjectVisibility(StrEnum):
+    """Project discovery boundary, independent from operation permissions."""
+
+    OWNER_SCOPE = "owner_scope"
+    PUBLIC = "public"
+
+
 class RunStatus(StrEnum):
     """Run 执行状态。
 

--- a/backend/src/workspace107/domain/ids.py
+++ b/backend/src/workspace107/domain/ids.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 USER = "usr"
 USER_GROUP = "grp"
+LEGACY_WORKSPACE = "ws"
 MEMBERSHIP = "mbr"
 PROJECT = "prj"
 PROJECT_VERSION = "pv"

--- a/backend/src/workspace107/domain/models.py
+++ b/backend/src/workspace107/domain/models.py
@@ -27,6 +27,7 @@ from .enums import (
     MembershipStatus,
     NotificationType,
     ProjectStatus,
+    ProjectVisibility,
     RunEventType,
     RunStatus,
     TargetType,
@@ -135,13 +136,19 @@ class Secret:
 
 @dataclass(slots=True)
 class Project:
-    """Workspace 下可编辑、可版本化、可运行的计算项目。"""
+    """A versioned project with a canonical User/User Group owner.
+
+    ``workspace_id`` is a bounded compatibility anchor for child domains that
+    are migrated by #37-#42; it is not the ownership authority.
+    """
 
     id: str
     workspace_id: str
     name: str
+    owner: OwnerReference
     description: str = ""
     status: ProjectStatus = ProjectStatus.ACTIVE
+    visibility: ProjectVisibility = ProjectVisibility.OWNER_SCOPE
     environment_version_id: str | None = None
     """None 表示继承 Workspace 默认环境。"""
     default_run_configuration_id: str | None = None

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -92,6 +92,10 @@ class ProjectRepository(Protocol):
         """按最近更新时间列出用户可见的 Project，用于个人首页。"""
         ...
 
+    async def list_discoverable_for_user(self, user_id: str, page: PageRequest) -> Page[Project]:
+        """列出用户可发现的 Project：Owner scope + PUBLIC。"""
+        ...
+
     async def name_exists(self, workspace_id: str, name: str) -> bool: ...
 
 

--- a/backend/src/workspace107/infrastructure/db/repositories.py
+++ b/backend/src/workspace107/infrastructure/db/repositories.py
@@ -24,6 +24,7 @@ from ...domain.enums import (
     MembershipStatus,
     NotificationType,
     ProjectStatus,
+    ProjectVisibility,
     RunEventType,
     RunStatus,
     TargetType,
@@ -418,13 +419,17 @@ class ProjectRepositoryImpl:
         self._session = session
 
     async def add(self, project: Project) -> None:
+        owner_user_id, owner_user_group_id = _owner_columns(project.owner)
         self._session.add(
             t.ProjectRow(
                 id=project.id,
                 workspace_id=project.workspace_id,
+                owner_user_id=owner_user_id,
+                owner_user_group_id=owner_user_group_id,
                 name=project.name,
                 description=project.description,
                 status=project.status.value,
+                visibility=project.visibility.value,
                 environment_version_id=project.environment_version_id,
                 default_run_configuration_id=project.default_run_configuration_id,
                 created_by=project.created_by,
@@ -442,9 +447,13 @@ class ProjectRepositoryImpl:
         row = await self._session.get(t.ProjectRow, project.id)
         if row is None:
             return
+        owner_user_id, owner_user_group_id = _owner_columns(project.owner)
         row.name = project.name
+        row.owner_user_id = owner_user_id
+        row.owner_user_group_id = owner_user_group_id
         row.description = project.description
         row.status = project.status.value
+        row.visibility = project.visibility.value
         row.environment_version_id = project.environment_version_id
         row.default_run_configuration_id = project.default_run_configuration_id
         row.updated_at = project.updated_at or datetime.now(UTC)
@@ -459,15 +468,39 @@ class ProjectRepositoryImpl:
         return await _paginate(self._session, stmt, page, _to_project)
 
     async def list_for_user(self, user_id: str, *, limit: int) -> list[Project]:
-        visible = _visible_workspace_ids(user_id)
+        # Owner-scope only (no PUBLIC discovery): /me recent_projects shows what
+        # the User owns or their User Groups own.
+        group_ids = select(t.MembershipRow.user_group_id).where(
+            t.MembershipRow.user_id == user_id,
+            t.MembershipRow.status == MembershipStatus.ACTIVE.value,
+        )
         stmt = (
             select(t.ProjectRow)
-            .where(t.ProjectRow.workspace_id.in_(visible))
+            .where(
+                (t.ProjectRow.owner_user_id == user_id)
+                | t.ProjectRow.owner_user_group_id.in_(group_ids)
+            )
             .order_by(t.ProjectRow.updated_at.desc())
             .limit(limit)
         )
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_to_project(row) for row in rows]
+
+    async def list_discoverable_for_user(self, user_id: str, page: PageRequest) -> Page[Project]:
+        # Owner scope + PUBLIC projects the User can discover.
+        group_ids = select(t.MembershipRow.user_group_id).where(
+            t.MembershipRow.user_id == user_id,
+            t.MembershipRow.status == MembershipStatus.ACTIVE.value,
+        )
+        owner_scope = (
+            t.ProjectRow.owner_user_id == user_id
+        ) | t.ProjectRow.owner_user_group_id.in_(group_ids)
+        stmt = (
+            select(t.ProjectRow)
+            .where((t.ProjectRow.visibility == ProjectVisibility.PUBLIC.value) | owner_scope)
+            .order_by(t.ProjectRow.updated_at.desc())
+        )
+        return await _paginate(self._session, stmt, page, _to_project)
 
     async def name_exists(self, workspace_id: str, name: str) -> bool:
         stmt = (
@@ -1705,12 +1738,18 @@ def _to_membership(row: t.MembershipRow) -> Membership:
 
 
 def _to_project(row: t.ProjectRow) -> Project:
+    if row.owner_user_id or row.owner_user_group_id:
+        owner = _owner_reference(row.owner_user_id, row.owner_user_group_id)
+    else:  # pragma: no cover - CHECK constraint forbids a row with no owner
+        owner = OwnerReference(OwnerKind.USER_GROUP, row.workspace_id)
     return Project(
         id=row.id,
         workspace_id=row.workspace_id,
         name=row.name,
+        owner=owner,
         description=row.description,
         status=ProjectStatus(row.status),
+        visibility=ProjectVisibility(row.visibility),
         environment_version_id=row.environment_version_id,
         default_run_configuration_id=row.default_run_configuration_id,
         created_by=row.created_by,

--- a/backend/src/workspace107/infrastructure/db/tables.py
+++ b/backend/src/workspace107/infrastructure/db/tables.py
@@ -129,16 +129,30 @@ class ProjectRow(Base):
 
     id: Mapped[str] = mapped_column(ID, primary_key=True)
     workspace_id: Mapped[str] = mapped_column(ID, ForeignKey("workspaces.id"), index=True)
+    owner_user_id: Mapped[str | None] = mapped_column(
+        ID, ForeignKey("users.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
+    owner_user_group_id: Mapped[str | None] = mapped_column(
+        ID, ForeignKey("user_groups.id", ondelete="RESTRICT"), nullable=True, index=True
+    )
     name: Mapped[str] = mapped_column(String(128))
     description: Mapped[str] = mapped_column(Text, default="")
     status: Mapped[str] = mapped_column(String(32))
+    visibility: Mapped[str] = mapped_column(String(32), default="owner_scope")
     environment_version_id: Mapped[str | None] = mapped_column(ID, nullable=True)
     default_run_configuration_id: Mapped[str | None] = mapped_column(ID, nullable=True)
     created_by: Mapped[str] = mapped_column(ID)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
-    __table_args__ = (UniqueConstraint("workspace_id", "name", name="uq_project_name"),)
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "name", name="uq_project_name"),
+        CheckConstraint(
+            "((owner_user_id IS NOT NULL AND owner_user_group_id IS NULL) "
+            "OR (owner_user_id IS NULL AND owner_user_group_id IS NOT NULL))",
+            name="ck_projects_exactly_one_owner",
+        ),
+    )
 
 
 class ProjectFileRow(Base):

--- a/backend/tests/integration/db/test_project_ownership_migration.py
+++ b/backend/tests/integration/db/test_project_ownership_migration.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from workspace107.config import get_settings
+
+PREVIOUS_REVISION = "4d7a2f91c3e5"
+PROJECT_OWNERSHIP_REVISION = "f36a1b2c3d4e"
+
+NOW = "2026-08-23 00:00:00+00:00"
+
+
+def _config(database: Path) -> Config:
+    backend = Path(__file__).resolve().parents[3]
+    config = Config(str(backend / "alembic.ini"))
+    config.set_main_option("script_location", str(backend / "migrations"))
+    config.set_main_option("sqlalchemy.url", f"sqlite+aiosqlite:///{database}")
+    return config
+
+
+def _rows(connection: sqlite3.Connection, sql: str) -> list[tuple[object, ...]]:
+    return list(connection.execute(sql).fetchall())
+
+
+def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
+
+
+def _foreign_keys(connection: sqlite3.Connection, table: str) -> set[tuple[str, str, str]]:
+    return {
+        (str(row[3]), str(row[2]), str(row[6]).upper())
+        for row in connection.execute(f"PRAGMA foreign_key_list({table})")
+    }
+
+
+def _assert_integrity_error(
+    connection: sqlite3.Connection, sql: str, parameters: tuple[object, ...] = ()
+) -> None:
+    connection.execute("SAVEPOINT expected_integrity_error")
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(sql, parameters)
+    finally:
+        connection.execute("ROLLBACK TO expected_integrity_error")
+        connection.execute("RELEASE expected_integrity_error")
+
+
+def _seed_predecessor(connection: sqlite3.Connection) -> None:
+    """Seed the last pre-#36 schema: projects anchored to workspaces, no owner."""
+    connection.execute("PRAGMA foreign_keys = ON")
+    connection.executemany(
+        "INSERT INTO users (id, username, display_name, email, created_at) "
+        "VALUES (?, ?, ?, NULL, ?)",
+        [("usr_alice", "alice", "Alice", NOW), ("usr_bob", "bob", "Bob", NOW)],
+    )
+    connection.executemany(
+        "INSERT INTO workspaces "
+        "(id, kind, name, description, owner_id, default_environment_version_id, created_at) "
+        "VALUES (?, ?, ?, ?, ?, NULL, ?)",
+        [
+            ("ws_personal", "personal", "Alice personal", "", "usr_alice", NOW),
+            ("ws_collab", "collaborative", "Research Lab", "", "usr_alice", NOW),
+        ],
+    )
+    # 现实不变量：collaborative anchor 与 User Group 同 id。
+    connection.execute(
+        "INSERT INTO user_groups (id, name, description, created_by_id, created_at) "
+        "VALUES ('ws_collab', 'Research Lab', '', NULL, ?)",
+        (NOW,),
+    )
+    connection.executemany(
+        "INSERT INTO projects "
+        "(id, workspace_id, name, description, status, environment_version_id, "
+        "default_run_configuration_id, created_by, created_at, updated_at) "
+        "VALUES (?, ?, ?, '', 'active', NULL, NULL, ?, ?, ?)",
+        [
+            ("prj_personal", "ws_personal", "Personal project", "usr_alice", NOW, NOW),
+            ("prj_group", "ws_collab", "Group project", "usr_bob", NOW, NOW),
+        ],
+    )
+    connection.commit()
+
+
+def _assert_owner_schema(connection: sqlite3.Connection) -> None:
+    assert {"owner_user_id", "owner_user_group_id", "visibility"} <= _columns(
+        connection, "projects"
+    )
+    assert {
+        ("owner_user_id", "users", "RESTRICT"),
+        ("owner_user_group_id", "user_groups", "RESTRICT"),
+    } <= _foreign_keys(connection, "projects")
+
+
+def _assert_backfill(connection: sqlite3.Connection) -> None:
+    # 归属权威：personal 锚点 → User owner，collaborative 锚点 → UserGroup owner。
+    assert _rows(
+        connection,
+        "SELECT id, owner_user_id, owner_user_group_id, visibility FROM projects "
+        "WHERE id != 'prj_public' ORDER BY id",
+    ) == [
+        ("prj_group", None, "ws_collab", "owner_scope"),
+        ("prj_personal", "usr_alice", None, "owner_scope"),
+    ]
+    # 兼容锚点保留：#37-#42 迁移窗口内子域仍按 workspace_id 关联。
+    assert _rows(
+        connection, "SELECT id, workspace_id FROM projects WHERE id != 'prj_public' ORDER BY id"
+    ) == [("prj_group", "ws_collab"), ("prj_personal", "ws_personal")]
+
+
+def test_issue_36_project_ownership_migration_backfills_and_round_trips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database = tmp_path / "project-ownership.db"
+    monkeypatch.setenv("WORKSPACE107_DATABASE_URL", f"sqlite+aiosqlite:///{database}")
+    get_settings.cache_clear()
+    config = _config(database)
+
+    try:
+        command.upgrade(config, PREVIOUS_REVISION)
+        with sqlite3.connect(database) as connection:
+            _seed_predecessor(connection)
+
+        command.upgrade(config, PROJECT_OWNERSHIP_REVISION)
+        with sqlite3.connect(database) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
+            _assert_owner_schema(connection)
+            _assert_backfill(connection)
+
+            # 新写入路径：显式 owner + PUBLIC visibility。
+            connection.execute(
+                "INSERT INTO projects "
+                "(id, workspace_id, owner_user_id, owner_user_group_id, name, description, "
+                "status, visibility, environment_version_id, "
+                "default_run_configuration_id, created_by, created_at, updated_at) "
+                "VALUES ('prj_public', 'ws_personal', 'usr_alice', NULL, 'Public', '', "
+                "'active', 'public', NULL, NULL, 'usr_alice', ?, ?)",
+                (NOW, NOW),
+            )
+            assert _rows(
+                connection,
+                "SELECT owner_user_id, owner_user_group_id, visibility FROM projects "
+                "WHERE id = 'prj_public'",
+            ) == [("usr_alice", None, "public")]
+
+            # 恰好一个 owner；owner 不可被删除。
+            _assert_integrity_error(
+                connection,
+                "INSERT INTO projects "
+                "(id, workspace_id, owner_user_id, owner_user_group_id, name, status, "
+                "visibility, created_by, created_at, updated_at) "
+                "VALUES ('prj_both', 'ws_personal', 'usr_alice', 'ws_collab', "
+                "'Invalid', 'active', 'owner_scope', 'usr_alice', ?, ?)",
+                (NOW, NOW),
+            )
+            _assert_integrity_error(
+                connection,
+                "INSERT INTO projects "
+                "(id, workspace_id, owner_user_id, owner_user_group_id, name, status, "
+                "visibility, created_by, created_at, updated_at) "
+                "VALUES ('prj_neither', 'ws_personal', NULL, NULL, "
+                "'Invalid', 'active', 'owner_scope', 'usr_alice', ?, ?)",
+                (NOW, NOW),
+            )
+            _assert_integrity_error(connection, "DELETE FROM users WHERE id = 'usr_alice'")
+            _assert_integrity_error(connection, "DELETE FROM user_groups WHERE id = 'ws_collab'")
+            connection.commit()
+
+        command.downgrade(config, PREVIOUS_REVISION)
+        with sqlite3.connect(database) as connection:
+            columns = _columns(connection, "projects")
+            assert {"owner_user_id", "owner_user_group_id", "visibility"}.isdisjoint(columns)
+            # 行数据保留；owner 与 visibility 是本次新增语义，降级即丢（产品未上线）。
+            assert _rows(connection, "SELECT id, workspace_id FROM projects ORDER BY id") == [
+                ("prj_group", "ws_collab"),
+                ("prj_personal", "ws_personal"),
+                ("prj_public", "ws_personal"),
+            ]
+
+        command.upgrade(config, PROJECT_OWNERSHIP_REVISION)
+        with sqlite3.connect(database) as connection:
+            _assert_owner_schema(connection)
+            # 重新升级后按锚点重新推导 owner。
+            assert _rows(
+                connection,
+                "SELECT id, owner_user_id, owner_user_group_id, visibility FROM projects "
+                "ORDER BY id",
+            ) == [
+                ("prj_group", None, "ws_collab", "owner_scope"),
+                ("prj_personal", "usr_alice", None, "owner_scope"),
+                ("prj_public", "usr_alice", None, "owner_scope"),
+            ]
+    finally:
+        get_settings.cache_clear()

--- a/backend/tests/integration/test_project_ownership.py
+++ b/backend/tests/integration/test_project_ownership.py
@@ -1,0 +1,185 @@
+"""Issue #36：Project Ownership / Visibility 的访问边界。"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers import ensure_user_group
+
+ALICE = {"X-User": "alice"}
+BOB = {"X-User": "bob"}
+
+
+@pytest.mark.asyncio
+async def test_user_owned_project_is_not_visible_to_other_users(client) -> None:
+    alice = (await client.get("/api/v1/me", headers=ALICE)).json()["user"]
+    created = await client.post(
+        "/api/v1/projects",
+        json={"owner": {"kind": "user", "id": alice["id"]}, "name": "Alice Project"},
+        headers=ALICE,
+    )
+    assert created.status_code == 201, created.text
+    project = created.json()
+    assert project["owner"]["kind"] == "user"
+    assert project["owner"]["id"] == alice["id"]
+    # Owner 摘要是解析出的真实显示名，不是裸 id。
+    assert project["owner"]["display_name"] == alice["display_name"] == "alice"
+    assert project["visibility"] == "owner_scope"
+    assert (await client.get(f"/api/v1/projects/{project['id']}", headers=BOB)).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_public_project_exposes_metadata_and_versions_but_not_working_state(
+    client,
+) -> None:
+    group_id = await ensure_user_group(client, headers=ALICE)
+    created = await client.post(
+        f"/api/v1/workspaces/{group_id}/projects",
+        json={"name": "Public Project"},
+        headers=ALICE,
+    )
+    assert created.status_code == 201, created.text
+    project = created.json()
+    assert project["owner"]["kind"] == "user_group"
+    assert project["owner"]["id"] == group_id
+    updated = await client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"visibility": "public"},
+        headers=ALICE,
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["visibility"] == "public"
+    await client.put(
+        f"/api/v1/projects/{project['id']}/files",
+        json={"path": "README.md", "content": "public"},
+        headers=ALICE,
+    )
+    version = await client.post(
+        f"/api/v1/projects/{project['id']}/versions",
+        json={"message": "public version"},
+        headers=ALICE,
+    )
+    assert version.status_code == 201, version.text
+
+    metadata = await client.get(f"/api/v1/projects/{project['id']}", headers=BOB)
+    assert metadata.status_code == 200
+    assert metadata.json()["visibility"] == "public"
+    # 公开读者看不到 Owner 的 mutable environment selection 和默认运行方案。
+    assert metadata.json()["environment_version_id"] is None
+    assert metadata.json()["default_run_configuration_id"] is None
+    versions = await client.get(f"/api/v1/projects/{project['id']}/versions", headers=BOB)
+    assert versions.status_code == 200
+    assert len(versions.json()["items"]) == 1
+    # 受保护子对象对公开读者 404：工作区、Run、活动、运行方案。
+    assert (
+        await client.get(f"/api/v1/projects/{project['id']}/files", headers=BOB)
+    ).status_code == 404
+    assert (
+        await client.get(f"/api/v1/projects/{project['id']}/runs", headers=BOB)
+    ).status_code == 404
+    assert (
+        await client.get(f"/api/v1/projects/{project['id']}/activities", headers=BOB)
+    ).status_code == 404
+    assert (
+        await client.get(f"/api/v1/projects/{project['id']}/run-configurations", headers=BOB)
+    ).status_code == 404
+    # Project 本体可见但不可改：公开读者没有更新能力，是 403 而不是 404。
+    patched = await client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"description": "hijack"},
+        headers=BOB,
+    )
+    assert patched.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_discovery_lists_public_projects_but_home_feed_does_not(client) -> None:
+    group_id = await ensure_user_group(client, headers=ALICE)
+    project = await client.post(
+        f"/api/v1/workspaces/{group_id}/projects",
+        json={"name": "Discoverable"},
+        headers=ALICE,
+    )
+    project_id = project.json()["id"]
+    assert (
+        await client.patch(
+            f"/api/v1/projects/{project_id}",
+            json={"visibility": "public"},
+            headers=ALICE,
+        )
+    ).status_code == 200
+
+    # 发现列表包含他人的 PUBLIC Project。
+    listing = await client.get("/api/v1/projects", headers=BOB)
+    assert listing.status_code == 200
+    assert any(item["id"] == project_id for item in listing.json()["items"])
+
+    # 首页 feed 只包含自己 / 所在 User Group 拥有的 Project，不含他人 PUBLIC。
+    home = await client.get("/api/v1/me", headers=BOB)
+    assert home.status_code == 200
+    assert all(item["id"] != project_id for item in home.json()["recent_projects"])
+
+
+@pytest.mark.asyncio
+async def test_public_version_can_be_forked_to_requesting_user_owner(client) -> None:
+    group_id = await ensure_user_group(client, headers=ALICE)
+    source = await client.post(
+        f"/api/v1/workspaces/{group_id}/projects",
+        json={"name": "Fork Source"},
+        headers=ALICE,
+    )
+    source_id = source.json()["id"]
+    await client.patch(
+        f"/api/v1/projects/{source_id}",
+        json={"visibility": "public"},
+        headers=ALICE,
+    )
+    await client.put(
+        f"/api/v1/projects/{source_id}/files",
+        json={"path": "main.py", "content": "print('ok')"},
+        headers=ALICE,
+    )
+    configuration = await client.post(
+        f"/api/v1/projects/{source_id}/run-configurations",
+        json={
+            "name": "private config",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+        },
+        headers=ALICE,
+    )
+    assert configuration.status_code == 201, configuration.text
+    version = await client.post(
+        f"/api/v1/projects/{source_id}/versions",
+        json={"message": "forkable"},
+        headers=ALICE,
+    )
+    bob = (await client.get("/api/v1/me", headers=BOB)).json()["user"]
+    forked = await client.post(
+        f"/api/v1/versions/{version.json()['id']}/fork",
+        json={"target_owner": {"kind": "user", "id": bob["id"]}, "name": "Bob Fork"},
+        headers=BOB,
+    )
+    assert forked.status_code == 201, forked.text
+    assert forked.json()["owner"]["id"] == bob["id"]
+    assert forked.json()["owner"]["display_name"] == "bob"
+    # PUBLIC 读者派生：不携带源 Project 的 mutable environment selection。
+    assert forked.json()["environment_version_id"] is None
+    forked_id = forked.json()["id"]
+
+    # 文件与不可变版本被复制；Run Configuration 属于源 Owner，不复制。
+    files = await client.get(f"/api/v1/projects/{forked_id}/files", headers=BOB)
+    assert files.status_code == 200
+    assert [f["path"] for f in files.json()] == ["main.py"]
+    copied = await client.get(f"/api/v1/projects/{forked_id}/run-configurations", headers=BOB)
+    assert copied.status_code == 200
+    assert copied.json() == []
+
+    # 负向：不能把 Project Fork 到别人的 Owner 名下。
+    alice = (await client.get("/api/v1/me", headers=ALICE)).json()["user"]
+    hijack = await client.post(
+        f"/api/v1/versions/{version.json()['id']}/fork",
+        json={"target_owner": {"kind": "user", "id": alice["id"]}, "name": "Stolen Fork"},
+        headers=BOB,
+    )
+    assert hijack.status_code == 404

--- a/backend/tests/integration/test_project_ownership.py
+++ b/backend/tests/integration/test_project_ownership.py
@@ -29,6 +29,46 @@ async def test_user_owned_project_is_not_visible_to_other_users(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_canonical_create_requires_owner_to_match_compatibility_anchor(client) -> None:
+    group_id = await ensure_user_group(client, headers=ALICE)
+    created = await client.post(
+        "/api/v1/projects",
+        json={"owner": {"kind": "user_group", "id": group_id}, "name": "Group Project"},
+        headers=ALICE,
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["owner"]["kind"] == "user_group"
+    assert created.json()["owner"]["id"] == group_id
+
+    # 负向：拿自己的 personal anchor 冒充 UserGroup Owner。
+    # personal anchor 的 canonical owner 是 User(Alice)，与请求的 owner 不一致，
+    # 必须干净地 404，而不是把 owner_user_group_id 落到 DB FK 边界。
+    alice = (await client.get("/api/v1/me", headers=ALICE)).json()["user"]
+    personal = await client.post(
+        "/api/v1/projects",
+        json={"owner": {"kind": "user", "id": alice["id"]}, "name": "Alice Personal"},
+        headers=ALICE,
+    )
+    assert personal.status_code == 201, personal.text
+    personal_anchor = (await client.get("/api/v1/me", headers=ALICE)).json()[
+        "personal_resource_context_id"
+    ]
+    assert personal_anchor is not None
+    hijack = await client.post(
+        "/api/v1/projects",
+        json={
+            "owner": {"kind": "user_group", "id": personal_anchor},
+            "name": "Hijack Project",
+        },
+        headers=ALICE,
+    )
+    assert hijack.status_code == 404
+    listing = await client.get("/api/v1/projects", headers=ALICE)
+    assert listing.status_code == 200
+    assert all(item["name"] != "Hijack Project" for item in listing.json()["items"])
+
+
+@pytest.mark.asyncio
 async def test_public_project_exposes_metadata_and_versions_but_not_working_state(
     client,
 ) -> None:

--- a/backend/tests/integration/test_scoped_config_run.py
+++ b/backend/tests/integration/test_scoped_config_run.py
@@ -10,6 +10,7 @@ from workspace107.domain.compute import ComputeRequest, ResolvedSchedulerConfigu
 from workspace107.domain.config_scope import ConfigScope, SecretReference
 from workspace107.domain.enums import EnvValueKind, LegacyWorkspaceKind, MembershipRole
 from workspace107.domain.models import LegacyWorkspace, Project, Variable
+from workspace107.domain.ownership import OwnerKind, OwnerReference
 from workspace107.domain.run_snapshot import build_snapshot
 from workspace107.domain.secrets import EnvValue, ResolvedEnv, parse_env_map
 from workspace107.infrastructure.db.repositories import SqlRepositories
@@ -18,9 +19,10 @@ from workspace107.infrastructure.db.secret_vault import DatabaseSecretVault
 
 def _access() -> ProjectAccess:
     return ProjectAccess(
-        Project("project", "workspace", "Project", ""),
+        Project("project", "workspace", "Project", owner=OwnerReference(OwnerKind.USER, "owner")),
         LegacyWorkspace("workspace", LegacyWorkspaceKind.PERSONAL, "Personal", owner_id="owner"),
         MembershipRole.OWNER,
+        owner_scope=True,
     )
 
 

--- a/backend/tests/unit/application/test_scoped_config_resolver.py
+++ b/backend/tests/unit/application/test_scoped_config_resolver.py
@@ -5,6 +5,7 @@ from workspace107.application.scoped_config_resolver import ScopedConfigResolver
 from workspace107.domain.config_scope import ConfigScope, SecretReference
 from workspace107.domain.enums import EnvValueKind, LegacyWorkspaceKind, MembershipRole
 from workspace107.domain.models import LegacyWorkspace, Project, Variable
+from workspace107.domain.ownership import OwnerKind, OwnerReference
 from workspace107.domain.secrets import EnvValue
 
 
@@ -26,8 +27,13 @@ class Secrets:
 
 def access(kind=LegacyWorkspaceKind.PERSONAL):
     workspace = LegacyWorkspace("ws", kind, "w", owner_id="owner")
-    project = Project("project", "ws", "p", "")
-    return ProjectAccess(project, workspace, MembershipRole.OWNER)
+    owner = (
+        OwnerReference(OwnerKind.USER, "owner")
+        if kind is LegacyWorkspaceKind.PERSONAL
+        else OwnerReference(OwnerKind.USER_GROUP, "ws")
+    )
+    project = Project("project", "ws", "p", owner=owner)
+    return ProjectAccess(project, workspace, MembershipRole.OWNER, owner_scope=True)
 
 
 @pytest.mark.asyncio

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -641,14 +641,28 @@
             "title": "Name",
             "type": "string"
           },
+          "target_owner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OwnerReferenceIn"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "target_workspace_id": {
-            "title": "Target Workspace Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Workspace Id"
           }
         },
-        "required": [
-          "target_workspace_id"
-        ],
         "title": "ForkIn",
         "type": "object"
       },
@@ -1589,6 +1603,34 @@
         "title": "ProjectCreateIn",
         "type": "object"
       },
+      "ProjectCreateOwnedIn": {
+        "properties": {
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/OwnerReferenceIn"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/ProjectVisibility",
+            "default": "owner_scope"
+          }
+        },
+        "required": [
+          "name",
+          "owner"
+        ],
+        "title": "ProjectCreateOwnedIn",
+        "type": "object"
+      },
       "ProjectFileOut": {
         "properties": {
           "content_hash": {
@@ -1677,6 +1719,9 @@
             "title": "Name",
             "type": "string"
           },
+          "owner": {
+            "$ref": "#/components/schemas/OwnerSummaryOut"
+          },
           "status": {
             "$ref": "#/components/schemas/ProjectStatus"
           },
@@ -1692,6 +1737,9 @@
             ],
             "title": "Updated At"
           },
+          "visibility": {
+            "$ref": "#/components/schemas/ProjectVisibility"
+          },
           "workspace_id": {
             "title": "Workspace Id",
             "type": "string"
@@ -1700,9 +1748,11 @@
         "required": [
           "id",
           "workspace_id",
+          "owner",
           "name",
           "description",
           "status",
+          "visibility",
           "environment_version_id",
           "default_run_configuration_id",
           "created_by",
@@ -1782,6 +1832,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ProjectStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "visibility": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProjectVisibility"
               },
               {
                 "type": "null"
@@ -1930,6 +1990,15 @@
         ],
         "title": "ProjectVersionOut",
         "type": "object"
+      },
+      "ProjectVisibility": {
+        "description": "Project discovery boundary, independent from operation permissions.",
+        "enum": [
+          "owner_scope",
+          "public"
+        ],
+        "title": "ProjectVisibility",
+        "type": "string"
       },
       "ReadinessOut": {
         "properties": {
@@ -4845,6 +4914,240 @@
         "summary": "将通知标记为已读",
         "tags": [
           "notification"
+        ]
+      }
+    },
+    "/api/v1/projects": {
+      "get": {
+        "description": "列出当前用户可发现的 Project：自己 / 所属 User Group 拥有的，以及 PUBLIC Project。",
+        "operationId": "list_discoverable_projects_api_v1_projects_get",
+        "parameters": [
+          {
+            "description": "页码，从 1 开始",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "页码，从 1 开始",
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "每页条数",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "每页条数",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PageOut_ProjectOut_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "列出当前用户可发现的 Project",
+        "tags": [
+          "project"
+        ]
+      },
+      "post": {
+        "operationId": "create_owned_project_api_v1_projects_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreateOwnedIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "为 User 或 User Group 创建 Project",
+        "tags": [
+          "project"
         ]
       }
     },
@@ -12389,7 +12692,7 @@
     },
     "/api/v1/versions/{version_id}/fork": {
       "post": {
-        "description": "两侧都会校验：源版本可读、目标空间可写。\n\n复制内容、运行方案和环境选择；**不复制**权益、凭据、成员权限和 Run 历史\n（GR-503）。Secret 只复制引用表达式，目标空间缺同名 Secret 时\n提交前检查会拦下（GR-407）。",
+        "description": "两侧都会校验：源版本可读、目标 Owner 下可创建。\n\n``target_workspace_id`` 与 ``target_owner`` 二选一；显式 Owner 形态是\n#36 的正路，workspace 形态是过渡兼容。复制内容、运行方案和环境选择；\n**不复制**权益、凭据、成员权限和 Run 历史（GR-503）。Secret 只复制\n引用表达式，目标空间缺同名 Secret 时提交前检查会拦下（GR-407）。\n\nPUBLIC 读者只能 Fork 出只含文件与不可变版本的新 Project。",
         "operationId": "fork_version_api_v1_versions__version_id__fork_post",
         "parameters": [
           {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -298,6 +298,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 列出当前用户可发现的 Project
+         * @description 列出当前用户可发现的 Project：自己 / 所属 User Group 拥有的，以及 PUBLIC Project。
+         */
+        get: operations["list_discoverable_projects_api_v1_projects_get"];
+        put?: never;
+        /** 为 User 或 User Group 创建 Project */
+        post: operations["create_owned_project_api_v1_projects_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/{project_id}": {
         parameters: {
             query?: never;
@@ -1287,11 +1308,14 @@ export interface paths {
         put?: never;
         /**
          * 从历史版本派生新 Project
-         * @description 两侧都会校验：源版本可读、目标空间可写。
+         * @description 两侧都会校验：源版本可读、目标 Owner 下可创建。
          *
-         *     复制内容、运行方案和环境选择；**不复制**权益、凭据、成员权限和 Run 历史
-         *     （GR-503）。Secret 只复制引用表达式，目标空间缺同名 Secret 时
-         *     提交前检查会拦下（GR-407）。
+         *     ``target_workspace_id`` 与 ``target_owner`` 二选一；显式 Owner 形态是
+         *     #36 的正路，workspace 形态是过渡兼容。复制内容、运行方案和环境选择；
+         *     **不复制**权益、凭据、成员权限和 Run 历史（GR-503）。Secret 只复制
+         *     引用表达式，目标空间缺同名 Secret 时提交前检查会拦下（GR-407）。
+         *
+         *     PUBLIC 读者只能 Fork 出只含文件与不可变版本的新 Project。
          */
         post: operations["fork_version_api_v1_versions__version_id__fork_post"];
         delete?: never;
@@ -1694,8 +1718,9 @@ export interface components {
              * @default
              */
             name: string;
+            target_owner?: components["schemas"]["OwnerReferenceIn"] | null;
             /** Target Workspace Id */
-            target_workspace_id: string;
+            target_workspace_id?: string | null;
         };
         /**
          * ForkSourceOut
@@ -2095,6 +2120,19 @@ export interface components {
             /** Name */
             name: string;
         };
+        /** ProjectCreateOwnedIn */
+        ProjectCreateOwnedIn: {
+            /**
+             * Description
+             * @default
+             */
+            description: string;
+            /** Name */
+            name: string;
+            owner: components["schemas"]["OwnerReferenceIn"];
+            /** @default owner_scope */
+            visibility: components["schemas"]["ProjectVisibility"];
+        };
         /** ProjectFileOut */
         ProjectFileOut: {
             /** Content Hash */
@@ -2122,9 +2160,11 @@ export interface components {
             id: string;
             /** Name */
             name: string;
+            owner: components["schemas"]["OwnerSummaryOut"];
             status: components["schemas"]["ProjectStatus"];
             /** Updated At */
             updated_at: string | null;
+            visibility: components["schemas"]["ProjectVisibility"];
             /** Workspace Id */
             workspace_id: string;
         };
@@ -2147,6 +2187,7 @@ export interface components {
             /** Name */
             name?: string | null;
             status?: components["schemas"]["ProjectStatus"] | null;
+            visibility?: components["schemas"]["ProjectVisibility"] | null;
         };
         /** ProjectVersionDetailOut */
         ProjectVersionDetailOut: {
@@ -2207,6 +2248,12 @@ export interface components {
             /** Total Size */
             total_size: number;
         };
+        /**
+         * ProjectVisibility
+         * @description Project discovery boundary, independent from operation permissions.
+         * @enum {string}
+         */
+        ProjectVisibility: "owner_scope" | "public";
         /** ReadinessOut */
         ReadinessOut: {
             /** Database */
@@ -3780,6 +3827,167 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    list_discoverable_projects_api_v1_projects_get: {
+        parameters: {
+            query?: {
+                /** @description 页码，从 1 开始 */
+                page?: number;
+                /** @description 每页条数 */
+                page_size?: number;
+            };
+            header?: {
+                "X-User"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PageOut_ProjectOut_"];
+                };
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    create_owned_project_api_v1_projects_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectCreateOwnedIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectOut"];
+                };
             };
             /** @description 请求不合法 */
             400: {

--- a/frontend/tests/component/AppShell.test.tsx
+++ b/frontend/tests/component/AppShell.test.tsx
@@ -33,6 +33,8 @@ const homeData: Home = {
       name: 'LJ 流体模拟',
       description: '',
       workspace_id: 'grp-1',
+      owner: { kind: 'user_group', id: 'grp-1', display_name: '计算物理课题组' },
+      visibility: 'owner_scope',
       status: 'active',
       created_by: 'u-1',
       created_at: '2026-08-15T10:00:00Z',

--- a/frontend/tests/component/ForkModal.test.tsx
+++ b/frontend/tests/component/ForkModal.test.tsx
@@ -90,6 +90,8 @@ describe('ForkModal target eligibility', () => {
     const created: Project = {
       id: 'prj_forked',
       workspace_id: 'grp_writer',
+      owner: { kind: 'user_group', id: 'grp_writer', display_name: 'Writer Lab' },
+      visibility: 'owner_scope',
       name: 'Source Project',
       description: '',
       status: 'active',

--- a/frontend/tests/component/GlobalNavigationDrawer.test.tsx
+++ b/frontend/tests/component/GlobalNavigationDrawer.test.tsx
@@ -28,6 +28,8 @@ function makeProject(index: number, workspaceId = `group-${index}`): Project {
     name: `Project ${index}`,
     description: '',
     workspace_id: workspaceId,
+    owner: { kind: 'user_group', id: workspaceId, display_name: `Group ${index}` },
+    visibility: 'owner_scope',
     status: 'active',
     created_by: 'user-1',
     created_at: '2026-08-15T10:00:00Z',

--- a/frontend/tests/component/HomePage.test.tsx
+++ b/frontend/tests/component/HomePage.test.tsx
@@ -38,6 +38,8 @@ const homeData: Home = {
       name: 'LJ 流体模拟',
       description: '',
       workspace_id: 'ws-1',
+      owner: { kind: 'user', id: 'u-1', display_name: 'student' },
+      visibility: 'owner_scope',
       status: 'active',
       created_by: 'u-1',
       created_at: '2026-08-15T10:00:00Z',

--- a/frontend/tests/component/VersionDetailPage.test.tsx
+++ b/frontend/tests/component/VersionDetailPage.test.tsx
@@ -49,6 +49,8 @@ const version: ProjectVersionDetail = {
 const project: Project = {
   id: 'prj_test',
   workspace_id: 'ws_test',
+  owner: { kind: 'user', id: 'usr_student', display_name: 'student' },
+  visibility: 'owner_scope',
   name: 'Test Project',
   description: '',
   status: 'active',


### PR DESCRIPTION
## 关联 Issue

Closes 114August514/107-workspace#36
Refs 114August514/107-workspace#34

## 修改内容

> 重整合说明：原实现（ae95626）基于旧基线 4b38130，与 main 上 114August514/107-workspace#58/#67/#62 等提交语义冲突（VIEWER 已删除、migration 链头前进、owner schema 基础设施已存在）。本 PR 在新分支上从 origin/main (10bdea6) 语义重放整套变更后强推，历史已重写。

- Project 归属权威迁移为 User / User Group Owner：`projects` 表新增 `owner_user_id` / `owner_user_group_id`（双 FK RESTRICT + exactly-one-owner CHECK）与 `visibility`；`workspace_id` 降级为 114August514/107-workspace#37–#42 迁移窗口内的兼容锚点（须镜像 Owner，ScopedConfigResolver 依赖此不变量）
- 新增 `OWNER_SCOPE` / `PUBLIC` Visibility：PUBLIC 对外仅公开元数据与不可变版本（environment selection、默认运行方案对公开读者隐藏）；受保护子对象（文件、working state、Run、活动、运行方案）经 `owner_scope=True` guard 走 404，Project 本体 PATCH 走 403
- 公开读者以 `ProjectAccess.role=None` + `{PROJECT_VIEW}` 能力集表达——#67 已删除 VIEWER，不复活
- 发现与订阅语义分离：`GET /projects` 返回 owner scope + PUBLIC；`/me recent_projects` 仅返回自己 / 所在 User Group 拥有的 Project
- `POST /projects` 显式 Owner 创建（USER 限本人并懒创建 personal anchor，USER_GROUP 要求同 id collaborative 锚点存在）；`ForkIn` 为 `target_workspace_id` XOR `target_owner`
- Fork：目标 Owner 显式 invariant 检查（非 `assert`）；PUBLIC 读者派生**结构性**不进入受保护配置读取路径——不读取、不验证、不复制源 Project 的 mutable environment selection、Run Configuration、Secret
- 复用 114August514/107-workspace#58 的 `OwnerReferenceIn` / `OwnerSummaryOut` / `owner_summaries` 批量解析，列表端点无 N+1；`ProjectService` 提供薄封装
- Migration `f36a1b2c3d4e`（down_revision=`4d7a2f91c3e5`）：按锚点 backfill（personal → User owner，collaborative → UserGroup owner）

## 验证证据

- 统一检查 `uv run --no-project python scripts/workspace.py check`：All requested checks passed（backend fmt / lint / tests、frontend fmt / lint / typecheck / tests / build、API contract）
- Backend：275 passed, 3 skipped；新增 `tests/integration/test_project_ownership.py`（4 项：User-owned 对他人 404、PUBLIC 元数据+版本可读而子对象 404 / PATCH 403、发现列表与首页 feed 分离、PUBLIC fork 不复制 run config + 指定他人为 target_owner 的负向 fork）
- Migration：`tests/integration/db/test_project_ownership_migration.py` 验证 upgrade → downgrade → upgrade 往返、owner backfill、CHECK / FK 约束与 owner 删除保护
- Frontend：116 passed；`tsc --noEmit` 无错误
- CI migration up/down/up 与 postgres job 在本 PR 上运行

## 影响范围

- API：`ProjectOut` 新增 `owner` / `visibility`；新增 `GET /projects`（发现）与 `POST /projects`（显式 Owner 创建）；`ForkIn` 双形态 XOR；旧 workspace 路由行为不变（保持 deprecated）
- 数据库：`projects` 新增 owner / visibility 列、索引、FK（RESTRICT）、CHECK；已有部署需跑 migration（backfill 依赖锚点 workspace 存在，FK 保证）
- 权限：`AccessGuard.project(owner_scope=...)`；Run / activity / run-configuration guard 全部收紧为 owner scope
- 兼容性：`ProjectOut.workspace_id` 与 `ForkIn.target_workspace_id` 为过渡字段，删除路径 = 删除 deprecated workspace 路由后删除字段
- 前端仅契约再生成 + 测试 fixture（5 个组件测试补 `owner` / `visibility`）；`forkVersion` 客户端仍发 `target_workspace_id`，XOR 下兼容

## 延后事项与实现妥协

- Deferred ID：无
- PUBLIC 发现入口与 Owner 展示的 UI 属于前端切片（#20 及后续），本 PR 仅同步契约与 fixture

## 按需检查

- [x] API 发生变化：OpenAPI 与前端生成类型已同步并提交
- [x] 数据库发生变化：升级、回退一步、再次升级均已实际验证
- [x] 认证或授权发生变化：正常路径与越权路径均有验证证据
