### PR TITLE
feat(authz): 实现跨 Owner Environment / Shared Resource USE Grant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ backend/.alembic-test/
 
 # Local notes and scratch data kept outside the shared project tree
 /.local/
+.qoder/

--- a/backend/migrations/versions/1f61cd1dc3ac_grants.py
+++ b/backend/migrations/versions/1f61cd1dc3ac_grants.py
@@ -1,12 +1,14 @@
 """Add grants table for cross-owner USE grants (Issue #40).
 
-Grants separate asset ownership from use entitlement: an asset Owner can issue a
-USE grant to another User or User Group, allowing that grantee to reference the
-asset (top-level Environment or Shared Resource) from their own Project.
+Grants separate asset ownership from use entitlement: a Grantor (User or User
+Group) issues a USE grant to a Grantee (User or User Group), allowing the
+grantee to reference the Grantor's top-level Environment or Shared Resource
+from their own Project. Target can also be ALL to cover all current and future
+assets owned by the Grantor.
 
-The grants table stores grantee as a discriminated union (grantee_kind +
-grantee_id) and does not FK to environments/shared_resources, so a grant row can
-outlive a deleted asset until the application layer cleans it up.
+The grants table stores grantor and grantee as discriminated unions
+(kind + id columns) and does not FK to environments/shared_resources, so a
+grant row can outlive a deleted asset until the application layer cleans it up.
 
 Revision ID: 1f61cd1dc3ac
 Revises: f37c0a1e2b9d
@@ -32,10 +34,12 @@ def upgrade() -> None:
     op.create_table(
         "grants",
         sa.Column("id", _ID, primary_key=True),
+        sa.Column("grantor_kind", sa.String(length=16), nullable=False),
+        sa.Column("grantor_id", _ID, nullable=False),
         sa.Column("grantee_kind", sa.String(length=16), nullable=False),
         sa.Column("grantee_id", _ID, nullable=False),
         sa.Column("target_kind", sa.String(length=32), nullable=False),
-        sa.Column("target_id", _ID, nullable=False),
+        sa.Column("target_id", _ID, nullable=False, server_default=""),
         sa.Column("action", sa.String(length=16), nullable=False),
         sa.Column(
             "granted_by_id",
@@ -43,23 +47,25 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="RESTRICT"),
             nullable=False,
         ),
-        sa.Column("grantor_owner_kind", sa.String(length=16), nullable=False),
-        sa.Column("grantor_owner_id", _ID, nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.UniqueConstraint(
+            "grantor_kind",
+            "grantor_id",
             "grantee_kind",
             "grantee_id",
             "target_kind",
             "target_id",
             "action",
-            name="uq_grant_grantee_target_action",
+            name="uq_grant_grantor_grantee_target_action",
         ),
     )
     op.create_index("ix_grants_target", "grants", ["target_kind", "target_id"], unique=False)
     op.create_index("ix_grants_grantee", "grants", ["grantee_kind", "grantee_id"], unique=False)
+    op.create_index("ix_grants_grantor", "grants", ["grantor_kind", "grantor_id"], unique=False)
 
 
 def downgrade() -> None:
+    op.drop_index("ix_grants_grantor", table_name="grants")
     op.drop_index("ix_grants_grantee", table_name="grants")
     op.drop_index("ix_grants_target", table_name="grants")
     op.drop_table("grants")

--- a/backend/migrations/versions/1f61cd1dc3ac_grants.py
+++ b/backend/migrations/versions/1f61cd1dc3ac_grants.py
@@ -1,0 +1,63 @@
+"""Add grants table for cross-owner USE grants (Issue #40).
+
+Grants separate asset ownership from use entitlement: an asset Owner can issue a
+USE grant to another User or User Group, allowing that grantee to reference the
+asset (top-level Environment or Shared Resource) from their own Project.
+
+The grants table stores grantee as a discriminated union (grantee_kind +
+grantee_id) and does not FK to environments/shared_resources, so a grant row can
+outlive a deleted asset until the application layer cleans it up.
+
+Revision ID: 1f61cd1dc3ac
+Revises: f37c0a1e2b9d
+Create Date: 2026-08-22
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "1f61cd1dc3ac"
+down_revision: str | None = "f37c0a1e2b9d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_ID = sa.String(length=40)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "grants",
+        sa.Column("id", _ID, primary_key=True),
+        sa.Column("grantee_kind", sa.String(length=16), nullable=False),
+        sa.Column("grantee_id", _ID, nullable=False),
+        sa.Column("target_kind", sa.String(length=32), nullable=False),
+        sa.Column("target_id", _ID, nullable=False),
+        sa.Column("action", sa.String(length=16), nullable=False),
+        sa.Column(
+            "granted_by_id",
+            _ID,
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "grantee_kind",
+            "grantee_id",
+            "target_kind",
+            "target_id",
+            "action",
+            name="uq_grant_grantee_target_action",
+        ),
+    )
+    op.create_index("ix_grants_target", "grants", ["target_kind", "target_id"], unique=False)
+    op.create_index("ix_grants_grantee", "grants", ["grantee_kind", "grantee_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_grants_grantee", table_name="grants")
+    op.drop_index("ix_grants_target", table_name="grants")
+    op.drop_table("grants")

--- a/backend/migrations/versions/1f61cd1dc3ac_grants.py
+++ b/backend/migrations/versions/1f61cd1dc3ac_grants.py
@@ -43,6 +43,8 @@ def upgrade() -> None:
             sa.ForeignKey("users.id", ondelete="RESTRICT"),
             nullable=False,
         ),
+        sa.Column("grantor_owner_kind", sa.String(length=16), nullable=False),
+        sa.Column("grantor_owner_id", _ID, nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.UniqueConstraint(
             "grantee_kind",

--- a/backend/src/workspace107/api/deps.py
+++ b/backend/src/workspace107/api/deps.py
@@ -142,7 +142,7 @@ def build_services(context: AppContext, session: AsyncSession) -> Services:
             activity,
             max_file_bytes=context.settings.max_file_bytes,
         ),
-        grants=GrantService(repos, guard, context.clock, activity),
+        grants=GrantService(repos, guard, context.clock),
     )
 
 

--- a/backend/src/workspace107/api/deps.py
+++ b/backend/src/workspace107/api/deps.py
@@ -16,7 +16,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from ..application.access import AccessGuard
 from ..application.activity import ActivityRecorder, ActivityService
 from ..application.catalog_service import CatalogService
- @both
+from ..application.configuration_service import ConfigurationService
+from ..application.grant_service import GrantService
 from ..application.health_service import HealthService
 from ..application.identity_service import IdentityService
 from ..application.notifier import NotificationService, Notifier

--- a/backend/src/workspace107/api/deps.py
+++ b/backend/src/workspace107/api/deps.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from ..application.access import AccessGuard
 from ..application.activity import ActivityRecorder, ActivityService
 from ..application.catalog_service import CatalogService
-from ..application.configuration_service import ConfigurationService
+ @both
 from ..application.health_service import HealthService
 from ..application.identity_service import IdentityService
 from ..application.notifier import NotificationService, Notifier
@@ -82,6 +82,7 @@ class Services:
     activities: ActivityService
     notifications: NotificationService
     shared_resources: SharedResourceService
+    grants: GrantService
 
 
 def build_services(context: AppContext, session: AsyncSession) -> Services:
@@ -141,6 +142,7 @@ def build_services(context: AppContext, session: AsyncSession) -> Services:
             activity,
             max_file_bytes=context.settings.max_file_bytes,
         ),
+        grants=GrantService(repos, guard, context.clock, activity),
     )
 
 

--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -428,6 +428,6 @@ def grant_out(view: GrantView) -> s.GrantOut:
         target_kind=view.grant.target_kind.value,
         target_id=view.grant.target_id,
         action=view.grant.action.value,
-        granted_by=owner_summary_out(view.target_owner),
+        granted_by=owner_summary_out(view.granted_by),
         created_at=view.grant.created_at,
     )

--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from ..application.catalog_service import EnvironmentView
+from ..application.grant_service import GrantView
 from ..application.ownership import OwnerSummary
 from ..application.shared_resource_service import SharedResourceAccessView, SharedResourceView
 from ..application.user_group_service import InvitationView, MemberView, UserGroupView
@@ -417,4 +418,16 @@ def shared_resource_version_detail_out(
             s.SharedResourceVersionFileOut(path=f.path, size=f.size, content_hash=f.content_hash)
             for f in version.files
         ],
+    )
+
+
+def grant_out(view: GrantView) -> s.GrantOut:
+    return s.GrantOut(
+        id=view.grant.id,
+        grantee=owner_summary_out(view.grantee),
+        target_kind=view.grant.target_kind.value,
+        target_id=view.grant.target_id,
+        action=view.grant.action.value,
+        granted_by=owner_summary_out(view.target_owner),
+        created_at=view.grant.created_at,
     )

--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -424,6 +424,7 @@ def shared_resource_version_detail_out(
 def grant_out(view: GrantView) -> s.GrantOut:
     return s.GrantOut(
         id=view.grant.id,
+        grantor=owner_summary_out(view.grantor),
         grantee=owner_summary_out(view.grantee),
         target_kind=view.grant.target_kind.value,
         target_id=view.grant.target_id,

--- a/backend/src/workspace107/api/routes/__init__.py
+++ b/backend/src/workspace107/api/routes/__init__.py
@@ -7,7 +7,8 @@ from fastapi import APIRouter
 from ..schemas import ErrorOut
 from . import (
     catalog,
- @both
+    configuration,
+    grants,
     health,
     home,
     notifications,

--- a/backend/src/workspace107/api/routes/__init__.py
+++ b/backend/src/workspace107/api/routes/__init__.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter
 from ..schemas import ErrorOut
 from . import (
     catalog,
-    configuration,
+ @both
     health,
     home,
     notifications,
@@ -40,5 +40,6 @@ api_router.include_router(runs.router)
 api_router.include_router(catalog.router)
 api_router.include_router(notifications.router)
 api_router.include_router(shared_resources.router)
+api_router.include_router(grants.router)
 
 __all__ = ["api_router"]

--- a/backend/src/workspace107/api/routes/grants.py
+++ b/backend/src/workspace107/api/routes/grants.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Query, status
 
+from ...domain.errors import ValidationFailed
 from ...domain.grant import GrantTargetKind
 from ...domain.ownership import OwnerKind, OwnerReference
 from .. import presenters as p
@@ -69,19 +70,32 @@ async def list_grants(
     """List Grants.
 
     Filter by target asset (``target_kind`` + ``target_id``) or by Grantor
-    (``grantor_kind`` + ``grantor_id``).  Exactly one filter pair must be given.
+    (``grantor_kind`` + ``grantor_id``).  Exactly one complete filter pair must
+    be given; partial pairs or both pairs simultaneously are rejected with 422.
     """
-    if target_kind is not None and target_id is not None:
+    has_target = target_kind is not None and target_id is not None
+    has_grantor = grantor_kind is not None and grantor_id is not None
+    partial_target = (target_kind is not None) != (target_id is not None)
+    partial_grantor = (grantor_kind is not None) != (grantor_id is not None)
+    if (
+        partial_target
+        or partial_grantor
+        or (has_target and has_grantor)
+        or (not has_target and not has_grantor)
+    ):
+        raise ValidationFailed(
+            "必须且只能提供一组完整的过滤条件："
+            "(target_kind + target_id) 或 (grantor_kind + grantor_id)"
+        )
+    if has_target:
         views = await services.grants.list_for_target(
             user.id,
             target_kind=GrantTargetKind(target_kind),
             target_id=target_id,
         )
-    elif grantor_kind is not None and grantor_id is not None:
+    else:
         grantor = OwnerReference(grantor_kind, grantor_id)
         views = await services.grants.list_for_grantor(user.id, grantor)
-    else:
-        views = []
     return [p.grant_out(view) for view in views]
 
 

--- a/backend/src/workspace107/api/routes/grants.py
+++ b/backend/src/workspace107/api/routes/grants.py
@@ -1,0 +1,82 @@
+"""Grant routes.
+
+Cross-owner USE Grant management:
+
+- ``POST   /grants``           —— create a USE Grant (asset Owner only)
+- ``GET    /grants``            —— list Grants for a target asset (asset Owner only)
+- ``DELETE /grants/{id}``       —— revoke a Grant (asset Owner only)
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, status
+
+from ...domain.grant import GrantTargetKind
+from ...domain.ownership import OwnerKind, OwnerReference
+from .. import presenters as p
+from .. import schemas as s
+from ..deps import CurrentUser, ServicesDep
+
+router = APIRouter(tags=["grant"])
+
+
+@router.post(
+    "/grants",
+    response_model=s.GrantOut,
+    status_code=status.HTTP_201_CREATED,
+    summary="创建跨 Owner USE Grant",
+)
+async def create_grant(
+    payload: s.GrantCreateIn,
+    user: CurrentUser,
+    services: ServicesDep,
+) -> s.GrantOut:
+    """Create a USE Grant allowing ``grantee`` to reference the target asset.
+
+    Only the target asset's Owner may create a Grant.  The target must be a
+    top-level Environment or Shared Resource (not a version).
+    """
+    grantee = OwnerReference(OwnerKind(payload.grantee.kind), payload.grantee.id)
+    view = await services.grants.create(
+        user.id,
+        target_kind=GrantTargetKind(payload.target_kind),
+        target_id=payload.target_id,
+        grantee=grantee,
+    )
+    return p.grant_out(view)
+
+
+@router.get(
+    "/grants",
+    response_model=list[s.GrantOut],
+    summary="列出指向某资产的 Grant",
+)
+async def list_grants(
+    user: CurrentUser,
+    services: ServicesDep,
+    target_kind: GrantTargetKind = Query(
+        ..., description="资产种类：environment 或 shared_resource"
+    ),
+    target_id: str = Query(..., description="顶层资产 ID"),
+) -> list[s.GrantOut]:
+    """List all Grants for a target asset.  Only the asset Owner may list."""
+    views = await services.grants.list_for_target(
+        user.id,
+        target_kind=GrantTargetKind(target_kind),
+        target_id=target_id,
+    )
+    return [p.grant_out(view) for view in views]
+
+
+@router.delete(
+    "/grants/{grant_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="撤销 USE Grant",
+)
+async def revoke_grant(
+    grant_id: str,
+    user: CurrentUser,
+    services: ServicesDep,
+) -> None:
+    """Revoke a Grant.  Only the target asset's Owner may revoke."""
+    await services.grants.revoke(user.id, grant_id)

--- a/backend/src/workspace107/api/routes/grants.py
+++ b/backend/src/workspace107/api/routes/grants.py
@@ -2,9 +2,9 @@
 
 Cross-owner USE Grant management:
 
-- ``POST   /grants``           —— create a USE Grant (asset Owner only)
-- ``GET    /grants``            —— list Grants for a target asset (asset Owner only)
-- ``DELETE /grants/{id}``       —— revoke a Grant (asset Owner only)
+- ``POST   /grants``           —— create a USE Grant (GRANT_MANAGE capability)
+- ``GET    /grants``            —— list Grants (by target asset or by grantor)
+- ``DELETE /grants/{id}``       —— revoke a Grant (GRANT_MANAGE capability)
 """
 
 from __future__ import annotations
@@ -31,17 +31,22 @@ async def create_grant(
     user: CurrentUser,
     services: ServicesDep,
 ) -> s.GrantOut:
-    """Create a USE Grant allowing ``grantee`` to reference the target asset.
+    """Create a USE Grant allowing ``grantee`` to reference the Grantor's asset(s).
 
-    Only the target asset's Owner may create a Grant.  The target must be a
-    top-level Environment or Shared Resource (not a version).
+    For asset grants (environment/shared_resource), the Grantor is derived from
+    the target asset's current owner.  For ALL grants, ``grantor`` must be
+    supplied explicitly and the caller must have GRANT_MANAGE on that Grantor.
     """
     grantee = OwnerReference(OwnerKind(payload.grantee.kind), payload.grantee.id)
+    grantor: OwnerReference | None = None
+    if payload.grantor is not None:
+        grantor = OwnerReference(OwnerKind(payload.grantor.kind), payload.grantor.id)
     view = await services.grants.create(
         user.id,
         target_kind=GrantTargetKind(payload.target_kind),
         target_id=payload.target_id,
         grantee=grantee,
+        grantor=grantor,
     )
     return p.grant_out(view)
 
@@ -49,22 +54,34 @@ async def create_grant(
 @router.get(
     "/grants",
     response_model=list[s.GrantOut],
-    summary="列出指向某资产的 Grant",
+    summary="列出 Grant",
 )
 async def list_grants(
     user: CurrentUser,
     services: ServicesDep,
-    target_kind: GrantTargetKind = Query(
-        ..., description="资产种类：environment 或 shared_resource"
+    target_kind: GrantTargetKind | None = Query(
+        None, description="按资产种类过滤：environment 或 shared_resource"
     ),
-    target_id: str = Query(..., description="顶层资产 ID"),
+    target_id: str | None = Query(None, description="顶层资产 ID"),
+    grantor_kind: OwnerKind | None = Query(None, description="按 Grantor 种类过滤"),
+    grantor_id: str | None = Query(None, description="Grantor ID"),
 ) -> list[s.GrantOut]:
-    """List all Grants for a target asset.  Only the asset Owner may list."""
-    views = await services.grants.list_for_target(
-        user.id,
-        target_kind=GrantTargetKind(target_kind),
-        target_id=target_id,
-    )
+    """List Grants.
+
+    Filter by target asset (``target_kind`` + ``target_id``) or by Grantor
+    (``grantor_kind`` + ``grantor_id``).  Exactly one filter pair must be given.
+    """
+    if target_kind is not None and target_id is not None:
+        views = await services.grants.list_for_target(
+            user.id,
+            target_kind=GrantTargetKind(target_kind),
+            target_id=target_id,
+        )
+    elif grantor_kind is not None and grantor_id is not None:
+        grantor = OwnerReference(grantor_kind, grantor_id)
+        views = await services.grants.list_for_grantor(user.id, grantor)
+    else:
+        views = []
     return [p.grant_out(view) for view in views]
 
 
@@ -78,5 +95,5 @@ async def revoke_grant(
     user: CurrentUser,
     services: ServicesDep,
 ) -> None:
-    """Revoke a Grant.  Only the target asset's Owner may revoke."""
+    """Revoke a Grant.  Requires GRANT_MANAGE on the Grant's Grantor."""
     await services.grants.revoke(user.id, grant_id)

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -329,6 +330,25 @@ class CanonicalSharedResourceCreateIn(Model):
 class SharedResourceUpdateIn(Model):
     name: str | None = Field(default=None, min_length=1, max_length=128)
     description: str | None = Field(default=None, max_length=4096)
+
+
+# -- Grant ------------------------------------------------------------------
+
+
+class GrantOut(Model):
+    id: str
+    grantee: OwnerSummaryOut
+    target_kind: Literal["environment", "shared_resource"]
+    target_id: str
+    action: Literal["use"]
+    granted_by: OwnerSummaryOut
+    created_at: datetime
+
+
+class GrantCreateIn(Model):
+    target_kind: Literal["environment", "shared_resource"]
+    target_id: str
+    grantee: OwnerReferenceIn
 
 
 # -- 运行方案 ---------------------------------------------------------------

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -337,8 +337,9 @@ class SharedResourceUpdateIn(Model):
 
 class GrantOut(Model):
     id: str
+    grantor: OwnerSummaryOut
     grantee: OwnerSummaryOut
-    target_kind: Literal["environment", "shared_resource"]
+    target_kind: Literal["environment", "shared_resource", "all"]
     target_id: str
     action: Literal["use"]
     granted_by: OwnerSummaryOut
@@ -346,9 +347,12 @@ class GrantOut(Model):
 
 
 class GrantCreateIn(Model):
-    target_kind: Literal["environment", "shared_resource"]
-    target_id: str
+    target_kind: Literal["environment", "shared_resource", "all"]
+    target_id: str = ""
     grantee: OwnerReferenceIn
+    grantor: OwnerReferenceIn | None = None
+    """Required for ALL grants (who issues the grant); omitted for asset grants
+    (derived from the target asset's current owner)."""
 
 
 # -- 运行方案 ---------------------------------------------------------------

--- a/backend/src/workspace107/application/access.py
+++ b/backend/src/workspace107/application/access.py
@@ -14,6 +14,7 @@ from ..domain.capabilities import (
 from ..domain.enums import MembershipRole
 from ..domain.errors import ObjectNotFound, PermissionDenied
 from ..domain.models import (
+    Environment,
     LegacyWorkspace,
     Project,
     Run,
@@ -103,6 +104,25 @@ class SharedResourceAccess:
     """Current User's role-derived access to a repository-visible resource."""
 
     resource: SharedResource
+    role: MembershipRole
+
+    @property
+    def capabilities(self) -> frozenset[Capability]:
+        return capabilities_of(self.role)
+
+    def can(self, capability: Capability) -> bool:
+        return capability in self.capabilities
+
+    def require(self, capability: Capability) -> None:
+        if not self.can(capability):
+            raise PermissionDenied(f"当前角色（{self.role.value}）无权{describe(capability)}")
+
+
+@dataclass(frozen=True, slots=True)
+class EnvironmentAccess:
+    """Current User's role-derived access to a repository-visible environment."""
+
+    environment: Environment
     role: MembershipRole
 
     @property
@@ -220,6 +240,29 @@ class AccessGuard:
             role = membership.role
 
         access = SharedResourceAccess(resource=resource, role=role)
+        if needs is not None:
+            access.require(needs)
+        return access
+
+    async def environment(
+        self, user_id: str, environment_id: str, *, needs: Capability | None = None
+    ) -> EnvironmentAccess:
+        environment = await self._repos.environments.get_discoverable_for_user(
+            user_id, environment_id
+        )
+        if environment is None:
+            raise ObjectNotFound("Environment", environment_id)
+
+        if environment.owner.kind is OwnerKind.USER:
+            # Repository visibility already proved the exact User owner is the actor.
+            role = MembershipRole.OWNER
+        else:
+            membership = await self._repos.memberships.get(environment.owner.id, user_id)
+            if membership is None or not membership.is_active:  # pragma: no cover - SQL guard
+                raise ObjectNotFound("Environment", environment_id)
+            role = membership.role
+
+        access = EnvironmentAccess(environment=environment, role=role)
         if needs is not None:
             access.require(needs)
         return access

--- a/backend/src/workspace107/application/asset_use.py
+++ b/backend/src/workspace107/application/asset_use.py
@@ -3,7 +3,8 @@
 Repository reads keep actor-scoped discovery.  This boundary additionally requires the
 asset owner to be the consuming Project owner.  Issue #40 extends this seam with an
 explicit USE Grant: when the asset Owner differs from the consuming Project Owner, a
-valid USE Grant pointing at the consuming Owner allows use.
+valid USE Grant from the asset's current Owner (Grantor) to the consuming Owner or
+acting User (Grantee) allows use.  A Grant with Target = ALL covers all Grantor assets.
 """
 
 from __future__ import annotations

--- a/backend/src/workspace107/application/asset_use.py
+++ b/backend/src/workspace107/application/asset_use.py
@@ -74,11 +74,17 @@ async def _environment_version_for_grant_use(
     environment = await repos.environments.get_by_id(version.environment_id)  # trusted lookup
     if environment is None:
         return None
+    # Cross-owner use only: if the asset Owner IS the target_owner, discovery
+    # should have found it in the same-owner path above.  Fail closed here.
     if environment.owner == target_owner:
-        # Same-owner but discovery failed — conservatively allow.
-        return version
+        return None
     if await _has_use_grant(
-        repos, user_id, target_owner, GrantTargetKind.ENVIRONMENT, environment.id
+        repos,
+        user_id,
+        target_owner,
+        GrantTargetKind.ENVIRONMENT,
+        environment.id,
+        environment.owner,
     ):
         return version
     return None
@@ -96,11 +102,16 @@ async def _shared_resource_version_for_grant_use(
     resource = await repos.shared_resources.get_by_id(version.shared_resource_id)  # trusted lookup
     if resource is None:
         return None
+    # Cross-owner use only: same-owner discovery should have succeeded above.
     if resource.owner == target_owner:
-        # Same-owner but discovery failed — conservatively allow.
-        return version
+        return None
     if await _has_use_grant(
-        repos, user_id, target_owner, GrantTargetKind.SHARED_RESOURCE, resource.id
+        repos,
+        user_id,
+        target_owner,
+        GrantTargetKind.SHARED_RESOURCE,
+        resource.id,
+        resource.owner,
     ):
         return version
     return None
@@ -112,10 +123,13 @@ async def _has_use_grant(
     target_owner: OwnerReference,
     target_kind: GrantTargetKind,
     target_id: str,
+    asset_owner: OwnerReference,
 ) -> bool:
-    """Check for a USE Grant matching either the consuming Owner or the acting User."""
-    if await repos.grants.exists_use_grant(target_owner, target_kind, target_id):
+    """Check for a valid USE Grant matching either the consuming Owner or the
+    acting User, issued under the asset's current Owner (GR-408).
+    """
+    if await repos.grants.exists_use_grant(target_owner, target_kind, target_id, asset_owner):
         return True
     # A personal User-level Grant for the acting user also authorizes use.
     user_grantee = OwnerReference(kind=OwnerKind.USER, id=user_id)
-    return await repos.grants.exists_use_grant(user_grantee, target_kind, target_id)
+    return await repos.grants.exists_use_grant(user_grantee, target_kind, target_id, asset_owner)

--- a/backend/src/workspace107/application/asset_use.py
+++ b/backend/src/workspace107/application/asset_use.py
@@ -1,14 +1,16 @@
 """Application-layer authorization for using versioned assets in a Project.
 
 Repository reads keep actor-scoped discovery.  This boundary additionally requires the
-asset owner to be the consuming Project owner.  Issue #40 can extend this one seam with
-an explicit USE Grant; Issue #39 intentionally allows exact same-owner use only.
+asset owner to be the consuming Project owner.  Issue #40 extends this seam with an
+explicit USE Grant: when the asset Owner differs from the consuming Project Owner, a
+valid USE Grant pointing at the consuming Owner allows use.
 """
 
 from __future__ import annotations
 
+from ..domain.grant import GrantTargetKind
 from ..domain.models import EnvironmentVersion, SharedResourceVersion
-from ..domain.ownership import OwnerReference
+from ..domain.ownership import OwnerKind, OwnerReference
 from ..domain.ports.repositories import Repositories
 
 
@@ -18,16 +20,24 @@ async def environment_version_for_owner_use(
     version_id: str,
     target_owner: OwnerReference,
 ) -> EnvironmentVersion | None:
-    """Return an actor-discoverable Environment Version only for the exact target owner."""
+    """Return an Environment Version authorized for ``target_owner`` use.
+
+    1. Same-owner discovery path (Issue #39): actor-discoverable version whose
+       Environment is owned by ``target_owner``.
+    2. Grant path (Issue #40): trusted lookup of version + environment; if the
+       environment Owner differs from ``target_owner``, a USE Grant for either
+       ``target_owner`` or the acting user (as a User grantee) authorizes use.
+    """
+    # 1. Same-owner path (Issue #39 logic unchanged)
     version = await repos.environments.get_version_discoverable_for_user(user_id, version_id)
-    if version is None:
-        return None
-    environment = await repos.environments.get_discoverable_for_user(
-        user_id, version.environment_id
-    )
-    if environment is None or environment.owner != target_owner:
-        return None
-    return version
+    if version is not None:
+        environment = await repos.environments.get_discoverable_for_user(
+            user_id, version.environment_id
+        )
+        if environment is not None and environment.owner == target_owner:
+            return version
+    # 2. Grant path: cross-owner use
+    return await _environment_version_for_grant_use(repos, user_id, version_id, target_owner)
 
 
 async def shared_resource_version_for_owner_use(
@@ -36,13 +46,76 @@ async def shared_resource_version_for_owner_use(
     version_id: str,
     target_owner: OwnerReference,
 ) -> SharedResourceVersion | None:
-    """Return an actor-discoverable Shared Resource Version for the exact target owner."""
+    """Return a Shared Resource Version authorized for ``target_owner`` use.
+
+    Same two-path structure as :func:`environment_version_for_owner_use`.
+    """
+    # 1. Same-owner path (Issue #39 logic unchanged)
     version = await repos.shared_resources.get_version_discoverable_for_user(user_id, version_id)
+    if version is not None:
+        resource = await repos.shared_resources.get_discoverable_for_user(
+            user_id, version.shared_resource_id
+        )
+        if resource is not None and resource.owner == target_owner:
+            return version
+    # 2. Grant path: cross-owner use
+    return await _shared_resource_version_for_grant_use(repos, user_id, version_id, target_owner)
+
+
+async def _environment_version_for_grant_use(
+    repos: Repositories,
+    user_id: str,
+    version_id: str,
+    target_owner: OwnerReference,
+) -> EnvironmentVersion | None:
+    version = await repos.environments.get_version_by_id(version_id)  # trusted lookup
     if version is None:
         return None
-    resource = await repos.shared_resources.get_discoverable_for_user(
-        user_id, version.shared_resource_id
-    )
-    if resource is None or resource.owner != target_owner:
+    environment = await repos.environments.get_by_id(version.environment_id)  # trusted lookup
+    if environment is None:
         return None
-    return version
+    if environment.owner == target_owner:
+        # Same-owner but discovery failed — conservatively allow.
+        return version
+    if await _has_use_grant(
+        repos, user_id, target_owner, GrantTargetKind.ENVIRONMENT, environment.id
+    ):
+        return version
+    return None
+
+
+async def _shared_resource_version_for_grant_use(
+    repos: Repositories,
+    user_id: str,
+    version_id: str,
+    target_owner: OwnerReference,
+) -> SharedResourceVersion | None:
+    version = await repos.shared_resources.get_version_by_id(version_id)  # trusted lookup
+    if version is None:
+        return None
+    resource = await repos.shared_resources.get_by_id(version.shared_resource_id)  # trusted lookup
+    if resource is None:
+        return None
+    if resource.owner == target_owner:
+        # Same-owner but discovery failed — conservatively allow.
+        return version
+    if await _has_use_grant(
+        repos, user_id, target_owner, GrantTargetKind.SHARED_RESOURCE, resource.id
+    ):
+        return version
+    return None
+
+
+async def _has_use_grant(
+    repos: Repositories,
+    user_id: str,
+    target_owner: OwnerReference,
+    target_kind: GrantTargetKind,
+    target_id: str,
+) -> bool:
+    """Check for a USE Grant matching either the consuming Owner or the acting User."""
+    if await repos.grants.exists_use_grant(target_owner, target_kind, target_id):
+        return True
+    # A personal User-level Grant for the acting user also authorizes use.
+    user_grantee = OwnerReference(kind=OwnerKind.USER, id=user_id)
+    return await repos.grants.exists_use_grant(user_grantee, target_kind, target_id)

--- a/backend/src/workspace107/application/grant_service.py
+++ b/backend/src/workspace107/application/grant_service.py
@@ -1,14 +1,14 @@
 """Cross-owner USE Grant use cases.
 
-An asset Owner creates a USE Grant to let another User or User Group reference a
-top-level Environment or Shared Resource from their own Project.  Grants do not
-confer management permission — only the Owner role on the target asset may create
-or revoke a Grant.
+A Grantor (User or User Group) creates a USE Grant to let another User or User
+Group (Grantee) reference the Grantor's top-level Environment or Shared Resource
+from their own Project.  Target can also be ALL to cover all current and future
+Grantor assets.
 
-``grantor_owner`` (the asset Owner at creation time) is persisted on the Grant row.
-GR-408: after an asset Ownership transfer, Grants issued under the old Owner are
-automatically invalid because ``exists_use_grant`` checks ``grantor_owner == current
-asset owner``.
+Grant management requires the ``GRANT_MANAGE`` capability, which is available to
+ADMIN and OWNER roles in UserGroup-owned assets, and to the exact User for
+User-owned assets.  This deliberately does not hardcode ``MembershipRole.OWNER``
+as the asset-Owner check.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..domain import ids
-from ..domain.enums import MembershipRole
+from ..domain.capabilities import Capability, capabilities_of, describe
 from ..domain.errors import ConflictError, ObjectNotFound, PermissionDenied
 from ..domain.grant import Grant, GrantAction, GrantTargetKind
 from ..domain.ownership import OwnerKind, OwnerReference
@@ -29,8 +29,8 @@ from .ownership import OwnerSummary, owner_summaries
 @dataclass(frozen=True, slots=True)
 class GrantView:
     grant: Grant
+    grantor: OwnerSummary
     grantee: OwnerSummary
-    target_owner: OwnerSummary
     granted_by: OwnerSummary
 
 
@@ -52,58 +52,93 @@ class GrantService:
         target_kind: GrantTargetKind,
         target_id: str,
         grantee: OwnerReference,
+        grantor: OwnerReference | None = None,
     ) -> GrantView:
-        """Create a USE Grant.  Only the target asset's Owner may grant."""
-        asset_owner = await self._resolve_target_owner(user_id, target_kind, target_id)
+        """Create a USE Grant.
+
+        For asset grants the grantor is derived from the target asset's owner.
+        For ALL grants the grantor must be supplied explicitly and the caller
+        must have GRANT_MANAGE capability on that grantor (User or UserGroup).
+        """
+        if grantor is None:
+            grantor = await self._resolve_grantor(user_id, target_kind, target_id)
+        else:
+            await self._require_grant_manage(user_id, grantor)
         await self._validate_grantee_exists(grantee)
-        if await self._repos.grants.exists_use_grant(grantee, target_kind, target_id, asset_owner):
-            raise ConflictError("该 Grantee 已拥有此资产的 USE Grant")
+        if await self._repos.grants.exists_use_grant(grantee, target_kind, target_id, grantor):
+            raise ConflictError("该 Grantee 已拥有此 Grantor 的相应 USE Grant")
         grant = Grant(
             id=ids.new_id(ids.GRANT),
+            grantor=grantor,
             grantee=grantee,
             target_kind=target_kind,
             target_id=target_id,
             action=GrantAction.USE,
             granted_by=user_id,
-            grantor_owner=asset_owner,
             created_at=self._clock.now(),
         )
         await self._repos.grants.add(grant)
-        return await self._view(grant, asset_owner)
+        return await self._view(grant)
 
     async def list_for_target(
         self, user_id: str, target_kind: GrantTargetKind, target_id: str
     ) -> list[GrantView]:
-        """List all Grants for a target asset.  Only the asset Owner may list."""
-        asset_owner = await self._resolve_target_owner(user_id, target_kind, target_id)
+        """List all Grants for a target asset. Requires GRANT_MANAGE capability."""
+        grantor = await self._resolve_grantor(user_id, target_kind, target_id)
         grants = await self._repos.grants.list_for_target(target_kind, target_id)
-        return [await self._view(g, asset_owner) for g in grants]
+        return [await self._view(g) for g in grants if g.grantor == grantor]
+
+    async def list_for_grantor(self, user_id: str, grantor: OwnerReference) -> list[GrantView]:
+        """List all Grants issued by ``grantor`` (ALL + asset). Requires GRANT_MANAGE."""
+        await self._require_grant_manage(user_id, grantor)
+        grants = await self._repos.grants.list_for_grantor(grantor)
+        return [await self._view(g) for g in grants]
 
     async def revoke(self, user_id: str, grant_id: str) -> None:
-        """Revoke a Grant.  Only the target asset's Owner may revoke."""
+        """Revoke a Grant. Requires GRANT_MANAGE capability on the grant's grantor."""
         grant = await self._repos.grants.get(grant_id)
         if grant is None:
             raise ObjectNotFound("Grant", grant_id)
-        await self._resolve_target_owner(user_id, grant.target_kind, grant.target_id)
+        await self._require_grant_manage(user_id, grant.grantor)
         await self._repos.grants.delete(grant_id)
 
     # -- internals ------------------------------------------------------
 
-    async def _resolve_target_owner(
+    async def _resolve_grantor(
         self, user_id: str, target_kind: GrantTargetKind, target_id: str
     ) -> OwnerReference:
-        """Verify the caller is the Owner of the target asset and return its owner."""
+        """Verify the caller can manage Grants on the target and return its owner.
+
+        For User-owned assets the exact owning User is the Grantor.
+        For UserGroup-owned assets the caller must be an active member with the
+        ``GRANT_MANAGE`` capability (ADMIN or OWNER role).
+        """
+        if target_kind is GrantTargetKind.ALL:
+            raise ObjectNotFound("Grant target", target_id)
         if target_kind is GrantTargetKind.SHARED_RESOURCE:
-            access = await self._guard.shared_resource(user_id, target_id)
+            access = await self._guard.shared_resource(
+                user_id, target_id, needs=Capability.GRANT_MANAGE
+            )
+            return access.resource.owner
+        access = await self._guard.environment(user_id, target_id, needs=Capability.GRANT_MANAGE)
+        return access.environment.owner
+
+    async def _require_grant_manage(self, user_id: str, grantor: OwnerReference) -> None:
+        """Verify the caller has GRANT_MANAGE on ``grantor`` (User or UserGroup).
+
+        For a User grantor, the caller must be that exact User.
+        For a UserGroup grantor, the caller must be an active member with
+        GRANT_MANAGE capability (ADMIN or OWNER role).
+        """
+        if grantor.kind is OwnerKind.USER:
+            if grantor.id != user_id:
+                raise ObjectNotFound("User", grantor.id)
         else:
-            access = await self._guard.environment(user_id, target_id)
-        if access.role != MembershipRole.OWNER:
-            raise PermissionDenied("只有资产 Owner 可以管理 USE Grant")
-        return (
-            access.resource.owner
-            if target_kind is GrantTargetKind.SHARED_RESOURCE
-            else access.environment.owner
-        )
+            access = await self._guard.user_group(user_id, grantor.id)
+            if Capability.GRANT_MANAGE not in capabilities_of(access.role):
+                raise PermissionDenied(
+                    f"当前角色（{access.role.value}）无权{describe(Capability.GRANT_MANAGE)}"
+                )
 
     async def _validate_grantee_exists(self, grantee: OwnerReference) -> None:
         """Reject grants to nonexistent Users or UserGroups (stable 404)."""
@@ -116,12 +151,14 @@ class GrantService:
             if group is None:
                 raise ObjectNotFound("UserGroup", grantee.id)
 
-    async def _view(self, grant: Grant, asset_owner: OwnerReference) -> GrantView:
+    async def _view(self, grant: Grant) -> GrantView:
         granted_by_ref = OwnerReference(kind=OwnerKind.USER, id=grant.granted_by)
-        summaries = await owner_summaries(self._repos, (grant.grantee, asset_owner, granted_by_ref))
+        summaries = await owner_summaries(
+            self._repos, (grant.grantor, grant.grantee, granted_by_ref)
+        )
         return GrantView(
             grant=grant,
+            grantor=summaries[(grant.grantor.kind, grant.grantor.id)],
             grantee=summaries[(grant.grantee.kind, grant.grantee.id)],
-            target_owner=summaries[(asset_owner.kind, asset_owner.id)],
             granted_by=summaries[(granted_by_ref.kind, granted_by_ref.id)],
         )

--- a/backend/src/workspace107/application/grant_service.py
+++ b/backend/src/workspace107/application/grant_service.py
@@ -4,6 +4,11 @@ An asset Owner creates a USE Grant to let another User or User Group reference a
 top-level Environment or Shared Resource from their own Project.  Grants do not
 confer management permission — only the Owner role on the target asset may create
 or revoke a Grant.
+
+``grantor_owner`` (the asset Owner at creation time) is persisted on the Grant row.
+GR-408: after an asset Ownership transfer, Grants issued under the old Owner are
+automatically invalid because ``exists_use_grant`` checks ``grantor_owner == current
+asset owner``.
 """
 
 from __future__ import annotations
@@ -11,14 +16,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..domain import ids
-from ..domain.enums import ActivityAction, MembershipRole, TargetType
+from ..domain.enums import MembershipRole
 from ..domain.errors import ConflictError, ObjectNotFound, PermissionDenied
 from ..domain.grant import Grant, GrantAction, GrantTargetKind
 from ..domain.ownership import OwnerKind, OwnerReference
 from ..domain.ports.clock import Clock
 from ..domain.ports.repositories import Repositories
 from .access import AccessGuard
-from .activity import ActivityRecorder
 from .ownership import OwnerSummary, owner_summaries
 
 
@@ -27,6 +31,7 @@ class GrantView:
     grant: Grant
     grantee: OwnerSummary
     target_owner: OwnerSummary
+    granted_by: OwnerSummary
 
 
 class GrantService:
@@ -35,12 +40,10 @@ class GrantService:
         repos: Repositories,
         guard: AccessGuard,
         clock: Clock,
-        activity: ActivityRecorder,
     ) -> None:
         self._repos = repos
         self._guard = guard
         self._clock = clock
-        self._activity = activity
 
     async def create(
         self,
@@ -52,7 +55,8 @@ class GrantService:
     ) -> GrantView:
         """Create a USE Grant.  Only the target asset's Owner may grant."""
         asset_owner = await self._resolve_target_owner(user_id, target_kind, target_id)
-        if await self._repos.grants.exists_use_grant(grantee, target_kind, target_id):
+        await self._validate_grantee_exists(grantee)
+        if await self._repos.grants.exists_use_grant(grantee, target_kind, target_id, asset_owner):
             raise ConflictError("该 Grantee 已拥有此资产的 USE Grant")
         grant = Grant(
             id=ids.new_id(ids.GRANT),
@@ -61,10 +65,10 @@ class GrantService:
             target_id=target_id,
             action=GrantAction.USE,
             granted_by=user_id,
+            grantor_owner=asset_owner,
             created_at=self._clock.now(),
         )
         await self._repos.grants.add(grant)
-        await self._record_activity(user_id, asset_owner, ActivityAction.GRANT_CREATED, grant.id)
         return await self._view(grant, asset_owner)
 
     async def list_for_target(
@@ -80,9 +84,8 @@ class GrantService:
         grant = await self._repos.grants.get(grant_id)
         if grant is None:
             raise ObjectNotFound("Grant", grant_id)
-        asset_owner = await self._resolve_target_owner(user_id, grant.target_kind, grant.target_id)
+        await self._resolve_target_owner(user_id, grant.target_kind, grant.target_id)
         await self._repos.grants.delete(grant_id)
-        await self._record_activity(user_id, asset_owner, ActivityAction.GRANT_REVOKED, grant_id)
 
     # -- internals ------------------------------------------------------
 
@@ -102,29 +105,23 @@ class GrantService:
             else access.environment.owner
         )
 
+    async def _validate_grantee_exists(self, grantee: OwnerReference) -> None:
+        """Reject grants to nonexistent Users or UserGroups (stable 404)."""
+        if grantee.kind is OwnerKind.USER:
+            user = await self._repos.users.get(grantee.id)
+            if user is None:
+                raise ObjectNotFound("User", grantee.id)
+        else:
+            group = await self._repos.user_groups.get(grantee.id)
+            if group is None:
+                raise ObjectNotFound("UserGroup", grantee.id)
+
     async def _view(self, grant: Grant, asset_owner: OwnerReference) -> GrantView:
-        summaries = await owner_summaries(self._repos, (grant.grantee, asset_owner))
+        granted_by_ref = OwnerReference(kind=OwnerKind.USER, id=grant.granted_by)
+        summaries = await owner_summaries(self._repos, (grant.grantee, asset_owner, granted_by_ref))
         return GrantView(
             grant=grant,
             grantee=summaries[(grant.grantee.kind, grant.grantee.id)],
             target_owner=summaries[(asset_owner.kind, asset_owner.id)],
+            granted_by=summaries[(granted_by_ref.kind, granted_by_ref.id)],
         )
-
-    async def _record_activity(
-        self,
-        user_id: str,
-        asset_owner: OwnerReference,
-        action: ActivityAction,
-        grant_id: str,
-    ) -> None:
-        # Activity is UserGroup-scoped; User-owned assets have no Workspace feed.
-        workspace_id = asset_owner.id if asset_owner.kind is OwnerKind.USER_GROUP else None
-        if workspace_id is not None:
-            await self._activity.record(
-                actor_id=user_id,
-                workspace_id=workspace_id,
-                action=action,
-                target_type=TargetType.GRANT,
-                target_id=grant_id,
-                target_name=grant_id,
-            )

--- a/backend/src/workspace107/application/grant_service.py
+++ b/backend/src/workspace107/application/grant_service.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 
 from ..domain import ids
 from ..domain.capabilities import Capability, capabilities_of, describe
-from ..domain.errors import ConflictError, ObjectNotFound, PermissionDenied
+from ..domain.errors import ConflictError, ObjectNotFound, PermissionDenied, ValidationFailed
 from ..domain.grant import Grant, GrantAction, GrantTargetKind
 from ..domain.ownership import OwnerKind, OwnerReference
 from ..domain.ports.clock import Clock
@@ -56,14 +56,28 @@ class GrantService:
     ) -> GrantView:
         """Create a USE Grant.
 
-        For asset grants the grantor is derived from the target asset's owner.
-        For ALL grants the grantor must be supplied explicitly and the caller
-        must have GRANT_MANAGE capability on that grantor (User or UserGroup).
+        Cross-field invariants:
+        - ALL target: ``target_id`` must be empty, ``grantor`` must be supplied
+          explicitly, and the caller must have GRANT_MANAGE on that grantor.
+        - Environment/SharedResource target: ``target_id`` must be non-empty,
+          ``grantor`` is always derived from the target asset's current owner
+          (explicit grantor is rejected to prevent cross-owner spoofing).
         """
-        if grantor is None:
-            grantor = await self._resolve_grantor(user_id, target_kind, target_id)
-        else:
+        if target_kind is GrantTargetKind.ALL:
+            if target_id:
+                raise ValidationFailed("target_id must be empty when target_kind is 'all'")
+            if grantor is None:
+                raise ValidationFailed("grantor is required when target_kind is 'all'")
             await self._require_grant_manage(user_id, grantor)
+        else:
+            if not target_id:
+                raise ValidationFailed("target_id is required for asset-specific grants")
+            if grantor is not None:
+                raise ValidationFailed(
+                    "grantor must not be specified for asset-specific grants; "
+                    "it is derived from the target asset's owner"
+                )
+            grantor = await self._resolve_grantor(user_id, target_kind, target_id)
         await self._validate_grantee_exists(grantee)
         if await self._repos.grants.exists_use_grant(grantee, target_kind, target_id, grantor):
             raise ConflictError("该 Grantee 已拥有此 Grantor 的相应 USE Grant")
@@ -83,7 +97,13 @@ class GrantService:
     async def list_for_target(
         self, user_id: str, target_kind: GrantTargetKind, target_id: str
     ) -> list[GrantView]:
-        """List all Grants for a target asset. Requires GRANT_MANAGE capability."""
+        """List Grants directly pointing at a specific target asset.
+
+        Requires GRANT_MANAGE capability on the target asset's current owner.
+        Only returns grants with an exact ``(target_kind, target_id)`` match;
+        ALL-type grants that also cover this asset are NOT included.  Use the
+        grantor view (``list_for_grantor``) for a complete authorization picture.
+        """
         grantor = await self._resolve_grantor(user_id, target_kind, target_id)
         grants = await self._repos.grants.list_for_target(target_kind, target_id)
         return [await self._view(g) for g in grants if g.grantor == grantor]

--- a/backend/src/workspace107/application/grant_service.py
+++ b/backend/src/workspace107/application/grant_service.py
@@ -1,0 +1,130 @@
+"""Cross-owner USE Grant use cases.
+
+An asset Owner creates a USE Grant to let another User or User Group reference a
+top-level Environment or Shared Resource from their own Project.  Grants do not
+confer management permission — only the Owner role on the target asset may create
+or revoke a Grant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..domain import ids
+from ..domain.enums import ActivityAction, MembershipRole, TargetType
+from ..domain.errors import ConflictError, ObjectNotFound, PermissionDenied
+from ..domain.grant import Grant, GrantAction, GrantTargetKind
+from ..domain.ownership import OwnerKind, OwnerReference
+from ..domain.ports.clock import Clock
+from ..domain.ports.repositories import Repositories
+from .access import AccessGuard
+from .activity import ActivityRecorder
+from .ownership import OwnerSummary, owner_summaries
+
+
+@dataclass(frozen=True, slots=True)
+class GrantView:
+    grant: Grant
+    grantee: OwnerSummary
+    target_owner: OwnerSummary
+
+
+class GrantService:
+    def __init__(
+        self,
+        repos: Repositories,
+        guard: AccessGuard,
+        clock: Clock,
+        activity: ActivityRecorder,
+    ) -> None:
+        self._repos = repos
+        self._guard = guard
+        self._clock = clock
+        self._activity = activity
+
+    async def create(
+        self,
+        user_id: str,
+        *,
+        target_kind: GrantTargetKind,
+        target_id: str,
+        grantee: OwnerReference,
+    ) -> GrantView:
+        """Create a USE Grant.  Only the target asset's Owner may grant."""
+        asset_owner = await self._resolve_target_owner(user_id, target_kind, target_id)
+        if await self._repos.grants.exists_use_grant(grantee, target_kind, target_id):
+            raise ConflictError("该 Grantee 已拥有此资产的 USE Grant")
+        grant = Grant(
+            id=ids.new_id(ids.GRANT),
+            grantee=grantee,
+            target_kind=target_kind,
+            target_id=target_id,
+            action=GrantAction.USE,
+            granted_by=user_id,
+            created_at=self._clock.now(),
+        )
+        await self._repos.grants.add(grant)
+        await self._record_activity(user_id, asset_owner, ActivityAction.GRANT_CREATED, grant.id)
+        return await self._view(grant, asset_owner)
+
+    async def list_for_target(
+        self, user_id: str, target_kind: GrantTargetKind, target_id: str
+    ) -> list[GrantView]:
+        """List all Grants for a target asset.  Only the asset Owner may list."""
+        asset_owner = await self._resolve_target_owner(user_id, target_kind, target_id)
+        grants = await self._repos.grants.list_for_target(target_kind, target_id)
+        return [await self._view(g, asset_owner) for g in grants]
+
+    async def revoke(self, user_id: str, grant_id: str) -> None:
+        """Revoke a Grant.  Only the target asset's Owner may revoke."""
+        grant = await self._repos.grants.get(grant_id)
+        if grant is None:
+            raise ObjectNotFound("Grant", grant_id)
+        asset_owner = await self._resolve_target_owner(user_id, grant.target_kind, grant.target_id)
+        await self._repos.grants.delete(grant_id)
+        await self._record_activity(user_id, asset_owner, ActivityAction.GRANT_REVOKED, grant_id)
+
+    # -- internals ------------------------------------------------------
+
+    async def _resolve_target_owner(
+        self, user_id: str, target_kind: GrantTargetKind, target_id: str
+    ) -> OwnerReference:
+        """Verify the caller is the Owner of the target asset and return its owner."""
+        if target_kind is GrantTargetKind.SHARED_RESOURCE:
+            access = await self._guard.shared_resource(user_id, target_id)
+        else:
+            access = await self._guard.environment(user_id, target_id)
+        if access.role != MembershipRole.OWNER:
+            raise PermissionDenied("只有资产 Owner 可以管理 USE Grant")
+        return (
+            access.resource.owner
+            if target_kind is GrantTargetKind.SHARED_RESOURCE
+            else access.environment.owner
+        )
+
+    async def _view(self, grant: Grant, asset_owner: OwnerReference) -> GrantView:
+        summaries = await owner_summaries(self._repos, (grant.grantee, asset_owner))
+        return GrantView(
+            grant=grant,
+            grantee=summaries[(grant.grantee.kind, grant.grantee.id)],
+            target_owner=summaries[(asset_owner.kind, asset_owner.id)],
+        )
+
+    async def _record_activity(
+        self,
+        user_id: str,
+        asset_owner: OwnerReference,
+        action: ActivityAction,
+        grant_id: str,
+    ) -> None:
+        # Activity is UserGroup-scoped; User-owned assets have no Workspace feed.
+        workspace_id = asset_owner.id if asset_owner.kind is OwnerKind.USER_GROUP else None
+        if workspace_id is not None:
+            await self._activity.record(
+                actor_id=user_id,
+                workspace_id=workspace_id,
+                action=action,
+                target_type=TargetType.GRANT,
+                target_id=grant_id,
+                target_name=grant_id,
+            )

--- a/backend/src/workspace107/domain/capabilities.py
+++ b/backend/src/workspace107/domain/capabilities.py
@@ -88,6 +88,10 @@ class Capability(StrEnum):
     SHARED_RESOURCE_VERSION_CREATE = "shared_resource.version.create"
     """为 Shared Resource 上传文件形成新的不可变版本。"""
 
+    # -- Grant -------------------------------------------------------------
+    GRANT_MANAGE = "grant.manage"
+    """管理跨 Owner USE Grant（创建、查看、撤销）。"""
+
 
 _VIEW_ONLY: frozenset[Capability] = frozenset(
     {
@@ -118,6 +122,7 @@ _ADMINISTER: frozenset[Capability] = _CONTRIBUTE | {
     Capability.USER_GROUP_UPDATE,
     Capability.MEMBER_MANAGE,
     Capability.CONFIG_MANAGE,
+    Capability.GRANT_MANAGE,
 }
 
 ROLE_CAPABILITIES: dict[MembershipRole, frozenset[Capability]] = {
@@ -148,6 +153,7 @@ CAPABILITY_LABELS: dict[Capability, str] = {
     Capability.SHARED_RESOURCE_VIEW: "查看 Shared Resource",
     Capability.SHARED_RESOURCE_MANAGE: "管理 Shared Resource",
     Capability.SHARED_RESOURCE_VERSION_CREATE: "上传 Shared Resource 版本",
+    Capability.GRANT_MANAGE: "管理 USE Grant",
 }
 
 USER_GROUP_CAPABILITY_LABELS: dict[UserGroupCapability, str] = {

--- a/backend/src/workspace107/domain/enums.py
+++ b/backend/src/workspace107/domain/enums.py
@@ -156,6 +156,8 @@ class ActivityAction(StrEnum):
     SHARED_RESOURCE_CREATED = "shared_resource_created"
     SHARED_RESOURCE_UPDATED = "shared_resource_updated"
     SHARED_RESOURCE_VERSION_PUBLISHED = "shared_resource_version_published"
+    GRANT_CREATED = "grant_created"
+    GRANT_REVOKED = "grant_revoked"
 
 
 class TargetType(StrEnum):
@@ -173,6 +175,7 @@ class TargetType(StrEnum):
     RUN = "run"
     SHARED_RESOURCE = "shared_resource"
     SHARED_RESOURCE_VERSION = "shared_resource_version"
+    GRANT = "grant"
 
 
 class NotificationType(StrEnum):

--- a/backend/src/workspace107/domain/enums.py
+++ b/backend/src/workspace107/domain/enums.py
@@ -156,8 +156,6 @@ class ActivityAction(StrEnum):
     SHARED_RESOURCE_CREATED = "shared_resource_created"
     SHARED_RESOURCE_UPDATED = "shared_resource_updated"
     SHARED_RESOURCE_VERSION_PUBLISHED = "shared_resource_version_published"
-    GRANT_CREATED = "grant_created"
-    GRANT_REVOKED = "grant_revoked"
 
 
 class TargetType(StrEnum):
@@ -175,7 +173,6 @@ class TargetType(StrEnum):
     RUN = "run"
     SHARED_RESOURCE = "shared_resource"
     SHARED_RESOURCE_VERSION = "shared_resource_version"
-    GRANT = "grant"
 
 
 class NotificationType(StrEnum):

--- a/backend/src/workspace107/domain/grant.py
+++ b/backend/src/workspace107/domain/grant.py
@@ -1,8 +1,12 @@
 """跨 Owner 使用许可。
 
 Grant 把资产的 *Ownership*（谁创建并管理资产）与 *使用资格*（谁能引用资产）
-分离：Owner 可向其他 Owner 主体（User 或 User Group）发放 USE Grant，
-使其能在自己的 Project 中引用该顶层 Environment 或 Shared Resource。
+分离：Grantor 向 Grantee 发放 USE Grant，使其能在自己的 Project 中引用该
+顶层 Environment 或 Shared Resource。
+
+Target = ALL 表示 Grantee 可以使用 Grantor 当前以及以后拥有的全部可授权资产。
+资产 Ownership 转移后，Grantor 不再拥有该资产，其 Grant 自然不再匹配——
+无需额外的 Owner snapshot 机制。
 """
 
 from __future__ import annotations
@@ -21,26 +25,35 @@ class GrantAction(StrEnum):
 
 
 class GrantTargetKind(StrEnum):
-    """Grant 指向的资产种类。仅限顶层资产，不包含 version。"""
+    """Grant 指向的资产范围。
 
+    ``ALL`` 表示授权 Grantor 当前及未来拥有的全部可授权 Environment /
+    Shared Resource；此时 ``target_id`` 为空字符串。
+    ``ENVIRONMENT`` / ``SHARED_RESOURCE`` 表示仅授权具体顶层资产。
+    """
+
+    ALL = "all"
     ENVIRONMENT = "environment"
     SHARED_RESOURCE = "shared_resource"
 
 
 @dataclass(frozen=True, slots=True)
 class Grant:
-    """跨 Owner 使用许可。Target 为顶层 Environment 或 Shared Resource。
+    """跨 Owner USE 许可。
 
-    ``grantor_owner`` 记录创建此 Grant 时的资产 Owner。GR-408：资产
-    Ownership 转移后，旧 Owner 建立的 Grant 失效——``exists_use_grant``
-    校验 ``grantor_owner == asset.current_owner``。
+    ``grantor`` 是发出授权的业务主体（User 或 User Group），即当前拥有
+    这些资产的 Owner。使用授权时以资产 *当前* Owner 为准：只有当
+    ``grantor == asset.current_owner`` 时该 Grant 才作用于该资产。
+
+    ``granted_by`` 仅记录实际执行授权操作的具体 User，用于审计，不参与
+    Grant 有效性判断。
     """
 
     id: str
+    grantor: OwnerReference
     grantee: OwnerReference
     target_kind: GrantTargetKind
     target_id: str
     action: GrantAction
     granted_by: str
-    grantor_owner: OwnerReference
     created_at: datetime

--- a/backend/src/workspace107/domain/grant.py
+++ b/backend/src/workspace107/domain/grant.py
@@ -29,7 +29,12 @@ class GrantTargetKind(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class Grant:
-    """跨 Owner 使用许可。Target 为顶层 Environment 或 Shared Resource。"""
+    """跨 Owner 使用许可。Target 为顶层 Environment 或 Shared Resource。
+
+    ``grantor_owner`` 记录创建此 Grant 时的资产 Owner。GR-408：资产
+    Ownership 转移后，旧 Owner 建立的 Grant 失效——``exists_use_grant``
+    校验 ``grantor_owner == asset.current_owner``。
+    """
 
     id: str
     grantee: OwnerReference
@@ -37,4 +42,5 @@ class Grant:
     target_id: str
     action: GrantAction
     granted_by: str
+    grantor_owner: OwnerReference
     created_at: datetime

--- a/backend/src/workspace107/domain/grant.py
+++ b/backend/src/workspace107/domain/grant.py
@@ -1,0 +1,40 @@
+"""跨 Owner 使用许可。
+
+Grant 把资产的 *Ownership*（谁创建并管理资产）与 *使用资格*（谁能引用资产）
+分离：Owner 可向其他 Owner 主体（User 或 User Group）发放 USE Grant，
+使其能在自己的 Project 中引用该顶层 Environment 或 Shared Resource。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from workspace107.domain.ownership import OwnerReference
+
+
+class GrantAction(StrEnum):
+    """Grant 授权的动作。V1 只有 USE。"""
+
+    USE = "use"
+
+
+class GrantTargetKind(StrEnum):
+    """Grant 指向的资产种类。仅限顶层资产，不包含 version。"""
+
+    ENVIRONMENT = "environment"
+    SHARED_RESOURCE = "shared_resource"
+
+
+@dataclass(frozen=True, slots=True)
+class Grant:
+    """跨 Owner 使用许可。Target 为顶层 Environment 或 Shared Resource。"""
+
+    id: str
+    grantee: OwnerReference
+    target_kind: GrantTargetKind
+    target_id: str
+    action: GrantAction
+    granted_by: str
+    created_at: datetime

--- a/backend/src/workspace107/domain/ids.py
+++ b/backend/src/workspace107/domain/ids.py
@@ -26,6 +26,7 @@ NOTIFICATION = "ntf"
 FORK_RELATION = "fork"
 SHARED_RESOURCE = "shr"
 SHARED_RESOURCE_VERSION = "shrv"
+GRANT = "gnt"
 
 
 def new_id(prefix: str) -> str:

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -286,15 +286,16 @@ class GrantRepository(Protocol):
         self, target_kind: GrantTargetKind, target_id: str
     ) -> list[Grant]: ...
     async def list_for_grantee(self, grantee: OwnerReference) -> list[Grant]: ...
+    async def list_for_grantor(self, grantor: OwnerReference) -> list[Grant]: ...
     async def delete(self, grant_id: str) -> bool: ...
     async def exists_use_grant(
         self,
         grantee: OwnerReference,
         target_kind: GrantTargetKind,
         target_id: str,
-        grantor_owner: OwnerReference,
+        grantor: OwnerReference,
     ) -> bool:
-        """Check for a valid USE Grant (grantee, target) issued under ``grantor_owner``."""
+        """Check for a USE Grant from ``grantor`` to ``grantee`` for ``target``."""
         ...
 
 

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -288,9 +288,13 @@ class GrantRepository(Protocol):
     async def list_for_grantee(self, grantee: OwnerReference) -> list[Grant]: ...
     async def delete(self, grant_id: str) -> bool: ...
     async def exists_use_grant(
-        self, grantee: OwnerReference, target_kind: GrantTargetKind, target_id: str
+        self,
+        grantee: OwnerReference,
+        target_kind: GrantTargetKind,
+        target_id: str,
+        grantor_owner: OwnerReference,
     ) -> bool:
-        """检查是否存在指向 (grantee, target) 的 USE Grant。"""
+        """Check for a valid USE Grant (grantee, target) issued under ``grantor_owner``."""
         ...
 
 

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -12,7 +12,8 @@ from datetime import datetime
 from typing import Protocol
 
 from ..compute import ComputePlan, ResourceEntitlement
- @both
+from ..config_scope import ConfigScope
+from ..grant import Grant, GrantTargetKind
 from ..models import (
     Activity,
     Artifact,

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Protocol
 
 from ..compute import ComputePlan, ResourceEntitlement
-from ..config_scope import ConfigScope
+ @both
 from ..models import (
     Activity,
     Artifact,
@@ -35,6 +35,7 @@ from ..models import (
     UserGroup,
     Variable,
 )
+from ..ownership import OwnerReference
 from ..pagination import Page, PageRequest
 from ..run_snapshot import RunSnapshot
 
@@ -124,6 +125,13 @@ class EnvironmentRepository(Protocol):
     async def get_version_discoverable_for_user(
         self, user_id: str, version_id: str
     ) -> EnvironmentVersion | None: ...
+    async def get_version_by_id(self, version_id: str) -> EnvironmentVersion | None:
+        """Trusted exact lookup for grant-authorized use."""
+        ...
+
+    async def get_by_id(self, environment_id: str) -> Environment | None:
+        """Trusted exact lookup for grant-authorized use."""
+        ...
 
 
 class ComputePlanRepository(Protocol):
@@ -264,7 +272,26 @@ class SharedResourceRepository(Protocol):
         """Trusted exact lookup for execution of an already-fixed snapshot."""
         ...
 
+    async def get_by_id(self, resource_id: str) -> SharedResource | None:
+        """Trusted exact lookup for grant-authorized use."""
+        ...
+
     async def next_version_sequence(self, resource_id: str) -> int: ...
+
+
+class GrantRepository(Protocol):
+    async def add(self, grant: Grant) -> None: ...
+    async def get(self, grant_id: str) -> Grant | None: ...
+    async def list_for_target(
+        self, target_kind: GrantTargetKind, target_id: str
+    ) -> list[Grant]: ...
+    async def list_for_grantee(self, grantee: OwnerReference) -> list[Grant]: ...
+    async def delete(self, grant_id: str) -> bool: ...
+    async def exists_use_grant(
+        self, grantee: OwnerReference, target_kind: GrantTargetKind, target_id: str
+    ) -> bool:
+        """检查是否存在指向 (grantee, target) 的 USE Grant。"""
+        ...
 
 
 class Repositories(Protocol):
@@ -291,6 +318,7 @@ class Repositories(Protocol):
     notifications: NotificationRepository
     fork_relations: ForkRelationRepository
     shared_resources: SharedResourceRepository
+    grants: GrantRepository
 
     async def commit(self) -> None: ...
     async def rollback(self) -> None: ...

--- a/backend/src/workspace107/infrastructure/db/repositories.py
+++ b/backend/src/workspace107/infrastructure/db/repositories.py
@@ -1492,6 +1492,8 @@ class GrantRepositoryImpl:
                 target_id=grant.target_id,
                 action=grant.action.value,
                 granted_by_id=grant.granted_by,
+                grantor_owner_kind=grant.grantor_owner.kind.value,
+                grantor_owner_id=grant.grantor_owner.id,
                 created_at=grant.created_at,
             )
         )
@@ -1532,8 +1534,17 @@ class GrantRepositoryImpl:
         return result.rowcount > 0
 
     async def exists_use_grant(
-        self, grantee: OwnerReference, target_kind: GrantTargetKind, target_id: str
+        self,
+        grantee: OwnerReference,
+        target_kind: GrantTargetKind,
+        target_id: str,
+        grantor_owner: OwnerReference,
     ) -> bool:
+        """Check for a valid USE Grant (grantee, target) issued under ``grantor_owner``.
+
+        GR-408: a Grant is only valid while the asset Owner matches the Owner
+        that issued it.  After Ownership transfer, stale Grants are rejected.
+        """
         stmt = (
             select(t.GrantRow.id)
             .where(
@@ -1542,6 +1553,8 @@ class GrantRepositoryImpl:
                 t.GrantRow.target_kind == target_kind.value,
                 t.GrantRow.target_id == target_id,
                 t.GrantRow.action == GrantAction.USE.value,
+                t.GrantRow.grantor_owner_kind == grantor_owner.kind.value,
+                t.GrantRow.grantor_owner_id == grantor_owner.id,
             )
             .limit(1)
         )
@@ -1855,5 +1868,6 @@ def _to_grant(row: t.GrantRow) -> Grant:
         target_id=row.target_id,
         action=GrantAction(row.action),
         granted_by=row.granted_by_id,
+        grantor_owner=OwnerReference(OwnerKind(row.grantor_owner_kind), row.grantor_owner_id),
         created_at=_aware(row.created_at),
     )

--- a/backend/src/workspace107/infrastructure/db/repositories.py
+++ b/backend/src/workspace107/infrastructure/db/repositories.py
@@ -29,6 +29,7 @@ from ...domain.enums import (
     TargetType,
 )
 from ...domain.errors import ConflictError
+from ...domain.grant import Grant, GrantAction, GrantTargetKind
 from ...domain.models import (
     Activity,
     Artifact,
@@ -707,6 +708,16 @@ class EnvironmentRepositoryImpl:
         )
         row = (await self._session.execute(stmt)).scalar_one_or_none()
         return _to_environment_version(row) if row else None
+
+    async def get_version_by_id(self, version_id: str) -> EnvironmentVersion | None:
+        """Trusted exact lookup for grant-authorized use."""
+        row = await self._session.get(t.EnvironmentVersionRow, version_id)
+        return _to_environment_version(row) if row else None
+
+    async def get_by_id(self, environment_id: str) -> Environment | None:
+        """Trusted exact lookup for grant-authorized use."""
+        row = await self._session.get(t.EnvironmentRow, environment_id)
+        return _to_environment(row) if row else None
 
 
 class ComputePlanRepositoryImpl:
@@ -1410,6 +1421,11 @@ class SharedResourceRepositoryImpl:
         row = await self._session.get(t.SharedResourceVersionRow, version_id)
         return await self._hydrate_version(row) if row else None
 
+    async def get_by_id(self, resource_id: str) -> SharedResource | None:
+        """Trusted exact lookup for grant-authorized use."""
+        row = await self._session.get(t.SharedResourceRow, resource_id)
+        return _to_shared_resource(row) if row else None
+
     async def list_versions_discoverable_for_user(
         self, user_id: str, resource_id: str
     ) -> list[SharedResourceVersion]:
@@ -1460,6 +1476,79 @@ class SharedResourceRepositoryImpl:
         )
 
 
+class GrantRepositoryImpl:
+    """Grant persistence with discriminated-union grantee/target columns."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def add(self, grant: Grant) -> None:
+        self._session.add(
+            t.GrantRow(
+                id=grant.id,
+                grantee_kind=grant.grantee.kind.value,
+                grantee_id=grant.grantee.id,
+                target_kind=grant.target_kind.value,
+                target_id=grant.target_id,
+                action=grant.action.value,
+                granted_by_id=grant.granted_by,
+                created_at=grant.created_at,
+            )
+        )
+        await _flush(self._session)
+
+    async def get(self, grant_id: str) -> Grant | None:
+        row = await self._session.get(t.GrantRow, grant_id)
+        return _to_grant(row) if row else None
+
+    async def list_for_target(self, target_kind: GrantTargetKind, target_id: str) -> list[Grant]:
+        stmt = (
+            select(t.GrantRow)
+            .where(
+                t.GrantRow.target_kind == target_kind.value,
+                t.GrantRow.target_id == target_id,
+            )
+            .order_by(t.GrantRow.created_at)
+        )
+        rows = (await self._session.execute(stmt)).scalars().all()
+        return [_to_grant(row) for row in rows]
+
+    async def list_for_grantee(self, grantee: OwnerReference) -> list[Grant]:
+        stmt = (
+            select(t.GrantRow)
+            .where(
+                t.GrantRow.grantee_kind == grantee.kind.value,
+                t.GrantRow.grantee_id == grantee.id,
+            )
+            .order_by(t.GrantRow.created_at)
+        )
+        rows = (await self._session.execute(stmt)).scalars().all()
+        return [_to_grant(row) for row in rows]
+
+    async def delete(self, grant_id: str) -> bool:
+        stmt = delete(t.GrantRow).where(t.GrantRow.id == grant_id)
+        result = await self._session.execute(stmt)
+        await _flush(self._session)
+        return result.rowcount > 0
+
+    async def exists_use_grant(
+        self, grantee: OwnerReference, target_kind: GrantTargetKind, target_id: str
+    ) -> bool:
+        stmt = (
+            select(t.GrantRow.id)
+            .where(
+                t.GrantRow.grantee_kind == grantee.kind.value,
+                t.GrantRow.grantee_id == grantee.id,
+                t.GrantRow.target_kind == target_kind.value,
+                t.GrantRow.target_id == target_id,
+                t.GrantRow.action == GrantAction.USE.value,
+            )
+            .limit(1)
+        )
+        row = (await self._session.execute(stmt)).scalar_one_or_none()
+        return row is not None
+
+
 class SqlRepositories:
     """一次工作单元内的全部仓储。"""
 
@@ -1486,6 +1575,7 @@ class SqlRepositories:
         self.notifications = NotificationRepositoryImpl(session)
         self.fork_relations = ForkRelationRepositoryImpl(session)
         self.shared_resources = SharedResourceRepositoryImpl(session)
+        self.grants = GrantRepositoryImpl(session)
 
     async def commit(self) -> None:
         await self._session.commit()
@@ -1753,5 +1843,17 @@ def _to_shared_resource(row: t.SharedResourceRow) -> SharedResource:
         name=row.name,
         owner=_owner_reference(row.owner_user_id, row.owner_user_group_id),
         description=row.description,
+        created_at=_aware(row.created_at),
+    )
+
+
+def _to_grant(row: t.GrantRow) -> Grant:
+    return Grant(
+        id=row.id,
+        grantee=OwnerReference(OwnerKind(row.grantee_kind), row.grantee_id),
+        target_kind=GrantTargetKind(row.target_kind),
+        target_id=row.target_id,
+        action=GrantAction(row.action),
+        granted_by=row.granted_by_id,
         created_at=_aware(row.created_at),
     )

--- a/backend/src/workspace107/infrastructure/db/repositories.py
+++ b/backend/src/workspace107/infrastructure/db/repositories.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import delete, func, select, text, update
+from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -90,6 +90,10 @@ _CONFLICT_RULES: tuple[tuple[tuple[str, ...], str], ...] = (
     (
         ("uq_shared_resource_version_seq", "shared_resource_versions.sequence"),
         "有其他人同时发布了这个 Shared Resource 的版本，请刷新后重试",
+    ),
+    (
+        ("uq_grant_grantor_grantee_target_action", "grants.grantor_id"),
+        "该 Grantee 已拥有此 Grantor 的相应 USE Grant",
     ),
 )
 
@@ -1486,14 +1490,14 @@ class GrantRepositoryImpl:
         self._session.add(
             t.GrantRow(
                 id=grant.id,
+                grantor_kind=grant.grantor.kind.value,
+                grantor_id=grant.grantor.id,
                 grantee_kind=grant.grantee.kind.value,
                 grantee_id=grant.grantee.id,
                 target_kind=grant.target_kind.value,
                 target_id=grant.target_id,
                 action=grant.action.value,
                 granted_by_id=grant.granted_by,
-                grantor_owner_kind=grant.grantor_owner.kind.value,
-                grantor_owner_id=grant.grantor_owner.id,
                 created_at=grant.created_at,
             )
         )
@@ -1527,6 +1531,18 @@ class GrantRepositoryImpl:
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_to_grant(row) for row in rows]
 
+    async def list_for_grantor(self, grantor: OwnerReference) -> list[Grant]:
+        stmt = (
+            select(t.GrantRow)
+            .where(
+                t.GrantRow.grantor_kind == grantor.kind.value,
+                t.GrantRow.grantor_id == grantor.id,
+            )
+            .order_by(t.GrantRow.created_at)
+        )
+        rows = (await self._session.execute(stmt)).scalars().all()
+        return [_to_grant(row) for row in rows]
+
     async def delete(self, grant_id: str) -> bool:
         stmt = delete(t.GrantRow).where(t.GrantRow.id == grant_id)
         result = await self._session.execute(stmt)
@@ -1538,23 +1554,29 @@ class GrantRepositoryImpl:
         grantee: OwnerReference,
         target_kind: GrantTargetKind,
         target_id: str,
-        grantor_owner: OwnerReference,
+        grantor: OwnerReference,
     ) -> bool:
-        """Check for a valid USE Grant (grantee, target) issued under ``grantor_owner``.
+        """Check for a USE Grant from ``grantor`` to ``grantee`` for ``target``.
 
-        GR-408: a Grant is only valid while the asset Owner matches the Owner
-        that issued it.  After Ownership transfer, stale Grants are rejected.
+        Matches either Target == ALL (covering all Grantor assets) or an exact
+        (target_kind, target_id) match. The ``grantor`` must equal the asset's
+        current Owner — after Ownership transfer, old Grants no longer match.
         """
         stmt = (
             select(t.GrantRow.id)
             .where(
+                t.GrantRow.grantor_kind == grantor.kind.value,
+                t.GrantRow.grantor_id == grantor.id,
                 t.GrantRow.grantee_kind == grantee.kind.value,
                 t.GrantRow.grantee_id == grantee.id,
-                t.GrantRow.target_kind == target_kind.value,
-                t.GrantRow.target_id == target_id,
                 t.GrantRow.action == GrantAction.USE.value,
-                t.GrantRow.grantor_owner_kind == grantor_owner.kind.value,
-                t.GrantRow.grantor_owner_id == grantor_owner.id,
+                or_(
+                    t.GrantRow.target_kind == GrantTargetKind.ALL.value,
+                    and_(
+                        t.GrantRow.target_kind == target_kind.value,
+                        t.GrantRow.target_id == target_id,
+                    ),
+                ),
             )
             .limit(1)
         )
@@ -1863,11 +1885,11 @@ def _to_shared_resource(row: t.SharedResourceRow) -> SharedResource:
 def _to_grant(row: t.GrantRow) -> Grant:
     return Grant(
         id=row.id,
+        grantor=OwnerReference(OwnerKind(row.grantor_kind), row.grantor_id),
         grantee=OwnerReference(OwnerKind(row.grantee_kind), row.grantee_id),
         target_kind=GrantTargetKind(row.target_kind),
         target_id=row.target_id,
         action=GrantAction(row.action),
         granted_by=row.granted_by_id,
-        grantor_owner=OwnerReference(OwnerKind(row.grantor_owner_kind), row.grantor_owner_id),
         created_at=_aware(row.created_at),
     )

--- a/backend/src/workspace107/infrastructure/db/tables.py
+++ b/backend/src/workspace107/infrastructure/db/tables.py
@@ -515,6 +515,8 @@ class GrantRow(Base):
     target_id: Mapped[str] = mapped_column(ID)
     action: Mapped[str] = mapped_column(String(16))  # 'use'
     granted_by_id: Mapped[str] = mapped_column(ID, ForeignKey("users.id", ondelete="RESTRICT"))
+    grantor_owner_kind: Mapped[str] = mapped_column(String(16))  # 'user' | 'user_group'
+    grantor_owner_id: Mapped[str] = mapped_column(ID)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     __table_args__ = (

--- a/backend/src/workspace107/infrastructure/db/tables.py
+++ b/backend/src/workspace107/infrastructure/db/tables.py
@@ -499,8 +499,12 @@ class SharedResourceVersionFileRow(Base):
 class GrantRow(Base):
     """跨 Owner 使用许可（Issue #40）。
 
-    Grantee 是 "User 或 UserGroup" 的判别联合，用 ``grantee_kind``+``grantee_id``
+    Grantor 和 Grantee 都是 "User 或 UserGroup" 的判别联合，用 ``kind``+``id``
     两列表示，与 Activity 表的 ``target_type``+``target_id`` 模式一致。
+
+    ``target_kind`` 可以是 ``"all"``、``"environment"`` 或 ``"shared_resource"``。
+    当 ``target_kind == "all"`` 时 ``target_id`` 为空字符串，表示授权 Grantor
+    当前及未来拥有的全部可授权资产。
 
     Grant target 可能引用未来被删除的资产，因此不对 environments/shared_resources
     加 FK——删除资产时需在应用层清理指向该资产的 Grant 行。
@@ -509,25 +513,30 @@ class GrantRow(Base):
     __tablename__ = "grants"
 
     id: Mapped[str] = mapped_column(ID, primary_key=True)
+    grantor_kind: Mapped[str] = mapped_column(String(16))  # 'user' | 'user_group'
+    grantor_id: Mapped[str] = mapped_column(ID)
     grantee_kind: Mapped[str] = mapped_column(String(16))  # 'user' | 'user_group'
     grantee_id: Mapped[str] = mapped_column(ID)
-    target_kind: Mapped[str] = mapped_column(String(32))  # 'environment' | 'shared_resource'
-    target_id: Mapped[str] = mapped_column(ID)
+    target_kind: Mapped[str] = mapped_column(
+        String(32)
+    )  # 'all' | 'environment' | 'shared_resource'
+    target_id: Mapped[str] = mapped_column(ID, default="")  # '' when target_kind == 'all'
     action: Mapped[str] = mapped_column(String(16))  # 'use'
     granted_by_id: Mapped[str] = mapped_column(ID, ForeignKey("users.id", ondelete="RESTRICT"))
-    grantor_owner_kind: Mapped[str] = mapped_column(String(16))  # 'user' | 'user_group'
-    grantor_owner_id: Mapped[str] = mapped_column(ID)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     __table_args__ = (
         UniqueConstraint(
+            "grantor_kind",
+            "grantor_id",
             "grantee_kind",
             "grantee_id",
             "target_kind",
             "target_id",
             "action",
-            name="uq_grant_grantee_target_action",
+            name="uq_grant_grantor_grantee_target_action",
         ),
         Index("ix_grants_target", "target_kind", "target_id"),
         Index("ix_grants_grantee", "grantee_kind", "grantee_id"),
+        Index("ix_grants_grantor", "grantor_kind", "grantor_id"),
     )

--- a/backend/src/workspace107/infrastructure/db/tables.py
+++ b/backend/src/workspace107/infrastructure/db/tables.py
@@ -494,3 +494,38 @@ class SharedResourceVersionFileRow(Base):
     path: Mapped[str] = mapped_column(String(1024), primary_key=True)
     size: Mapped[int] = mapped_column(Integer)
     content_hash: Mapped[str] = mapped_column(String(64))
+
+
+class GrantRow(Base):
+    """跨 Owner 使用许可（Issue #40）。
+
+    Grantee 是 "User 或 UserGroup" 的判别联合，用 ``grantee_kind``+``grantee_id``
+    两列表示，与 Activity 表的 ``target_type``+``target_id`` 模式一致。
+
+    Grant target 可能引用未来被删除的资产，因此不对 environments/shared_resources
+    加 FK——删除资产时需在应用层清理指向该资产的 Grant 行。
+    """
+
+    __tablename__ = "grants"
+
+    id: Mapped[str] = mapped_column(ID, primary_key=True)
+    grantee_kind: Mapped[str] = mapped_column(String(16))  # 'user' | 'user_group'
+    grantee_id: Mapped[str] = mapped_column(ID)
+    target_kind: Mapped[str] = mapped_column(String(32))  # 'environment' | 'shared_resource'
+    target_id: Mapped[str] = mapped_column(ID)
+    action: Mapped[str] = mapped_column(String(16))  # 'use'
+    granted_by_id: Mapped[str] = mapped_column(ID, ForeignKey("users.id", ondelete="RESTRICT"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        UniqueConstraint(
+            "grantee_kind",
+            "grantee_id",
+            "target_kind",
+            "target_id",
+            "action",
+            name="uq_grant_grantee_target_action",
+        ),
+        Index("ix_grants_target", "target_kind", "target_id"),
+        Index("ix_grants_grantee", "grantee_kind", "grantee_id"),
+    )

--- a/backend/tests/integration/db/test_grants_migration.py
+++ b/backend/tests/integration/db/test_grants_migration.py
@@ -77,14 +77,14 @@ def test_grants_migration_creates_table_and_round_trips(
         # Table exists with expected columns.
         expected_columns = {
             "id",
+            "grantor_kind",
+            "grantor_id",
             "grantee_kind",
             "grantee_id",
             "target_kind",
             "target_id",
             "action",
             "granted_by_id",
-            "grantor_owner_kind",
-            "grantor_owner_id",
             "created_at",
         }
         assert expected_columns <= _columns(conn, "grants")
@@ -93,20 +93,30 @@ def test_grants_migration_creates_table_and_round_trips(
         fks = _foreign_keys(conn, "grants")
         assert ("granted_by_id", "users", "RESTRICT") in fks
 
-        # Unique constraint over (grantee_kind, grantee_id, target_kind, target_id, action).
-        # SQLite names these sqlite_autoindex_*; verify by column set instead of name.
+        # Unique constraint over (grantor_kind, grantor_id, grantee_kind,
+        # grantee_id, target_kind, target_id, action).
+        # SQLite names these sqlite_autoindex_*; verify by column set.
         unique_index_names = _unique_constraints(conn, "grants")
         unique_col_sets: list[list[str]] = []
         for idx_name in unique_index_names:
             unique_col_sets.append(_index_columns(conn, "grants", idx_name))
-        assert sorted(["grantee_kind", "grantee_id", "target_kind", "target_id", "action"]) in (
-            sorted(cols) for cols in unique_col_sets
-        )
+        assert sorted(
+            [
+                "grantor_kind",
+                "grantor_id",
+                "grantee_kind",
+                "grantee_id",
+                "target_kind",
+                "target_id",
+                "action",
+            ]
+        ) in (sorted(cols) for cols in unique_col_sets)
 
-        # Indexes: ix_grants_target, ix_grants_grantee.
+        # Indexes: ix_grants_target, ix_grants_grantee, ix_grants_grantor.
         indexes = _indexes(conn, "grants")
         assert "ix_grants_target" in indexes
         assert "ix_grants_grantee" in indexes
+        assert "ix_grants_grantor" in indexes
 
     # Downgrade back to previous revision.
     command.downgrade(config, PREVIOUS_REVISION)

--- a/backend/tests/integration/db/test_grants_migration.py
+++ b/backend/tests/integration/db/test_grants_migration.py
@@ -83,6 +83,8 @@ def test_grants_migration_creates_table_and_round_trips(
             "target_id",
             "action",
             "granted_by_id",
+            "grantor_owner_kind",
+            "grantor_owner_id",
             "created_at",
         }
         assert expected_columns <= _columns(conn, "grants")

--- a/backend/tests/integration/db/test_grants_migration.py
+++ b/backend/tests/integration/db/test_grants_migration.py
@@ -1,0 +1,118 @@
+"""Grants table migration (Issue #40)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from workspace107.config import get_settings
+
+PREVIOUS_REVISION = "c471ac39f002"
+GRANTS_REVISION = "1f61cd1dc3ac"
+
+
+def _config(database: Path) -> Config:
+    backend = Path(__file__).resolve().parents[3]
+    config = Config(str(backend / "alembic.ini"))
+    config.set_main_option("script_location", str(backend / "migrations"))
+    config.set_main_option("sqlalchemy.url", f"sqlite+aiosqlite:///{database}")
+    return config
+
+
+def _columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in connection.execute(f"PRAGMA table_info({table})")}
+
+
+def _indexes(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in connection.execute(f"PRAGMA index_list({table})")}
+
+
+def _index_columns(connection: sqlite3.Connection, table: str, index: str) -> list[str]:
+    return [str(row[2]) for row in connection.execute(f"PRAGMA index_info({index})")]
+
+
+def _unique_constraints(connection: sqlite3.Connection, table: str) -> set[str]:
+    """Return the set of unique index names (sqlite implements UNIQUE constraints as indexes)."""
+    return {
+        str(row[1])
+        for row in connection.execute(f"PRAGMA index_list({table})")
+        if int(row[2]) == 1  # origin == "u" (unique constraint)
+    }
+
+
+def _foreign_keys(connection: sqlite3.Connection, table: str) -> set[tuple[str, str, str]]:
+    return {
+        (str(row[3]), str(row[2]), str(row[6]).upper())
+        for row in connection.execute(f"PRAGMA foreign_key_list({table})")
+    }
+
+
+def test_grants_migration_creates_table_and_round_trips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Upgrade creates the grants table; downgrade drops it."""
+    database = tmp_path / "grants.db"
+    monkeypatch.setenv("WORKSPACE107_DATABASE_URL", f"sqlite+aiosqlite:///{database}")
+    get_settings.cache_clear()
+
+    config = _config(database)
+
+    # Upgrade to the previous revision (before grants).
+    command.upgrade(config, PREVIOUS_REVISION)
+
+    with sqlite3.connect(str(database)) as conn:
+        table_exists = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='grants'"
+        ).fetchone()
+        assert table_exists is None
+
+    # Upgrade to the grants revision.
+    command.upgrade(config, GRANTS_REVISION)
+
+    with sqlite3.connect(str(database)) as conn:
+        # Table exists with expected columns.
+        expected_columns = {
+            "id",
+            "grantee_kind",
+            "grantee_id",
+            "target_kind",
+            "target_id",
+            "action",
+            "granted_by_id",
+            "created_at",
+        }
+        assert expected_columns <= _columns(conn, "grants")
+
+        # Foreign key: granted_by_id → users.id (RESTRICT).
+        fks = _foreign_keys(conn, "grants")
+        assert ("granted_by_id", "users", "RESTRICT") in fks
+
+        # Unique constraint over (grantee_kind, grantee_id, target_kind, target_id, action).
+        # SQLite names these sqlite_autoindex_*; verify by column set instead of name.
+        unique_index_names = _unique_constraints(conn, "grants")
+        unique_col_sets: list[list[str]] = []
+        for idx_name in unique_index_names:
+            unique_col_sets.append(_index_columns(conn, "grants", idx_name))
+        assert sorted(["grantee_kind", "grantee_id", "target_kind", "target_id", "action"]) in (
+            sorted(cols) for cols in unique_col_sets
+        )
+
+        # Indexes: ix_grants_target, ix_grants_grantee.
+        indexes = _indexes(conn, "grants")
+        assert "ix_grants_target" in indexes
+        assert "ix_grants_grantee" in indexes
+
+    # Downgrade back to previous revision.
+    command.downgrade(config, PREVIOUS_REVISION)
+
+    with sqlite3.connect(str(database)) as conn:
+        table_exists = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='grants'"
+        ).fetchone()
+        assert table_exists is None
+
+    get_settings.cache_clear()

--- a/backend/tests/integration/resource/test_cross_owner_use_grant.py
+++ b/backend/tests/integration/resource/test_cross_owner_use_grant.py
@@ -695,8 +695,6 @@ async def test_all_grant_covers_current_and_future_assets(
     project = await _create_project_with_version(client, group_a, name="A project")
     _resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
 
-    alice_id = await _get_user_id(client, ALICE)
-
     # Without grant: referencing B's resource → 404.
     response = await client.post(
         f"/api/v1/projects/{project['id']}/run-configurations",
@@ -716,17 +714,18 @@ async def test_all_grant_covers_current_and_future_assets(
     )
     assert response.status_code == 404, response.text
 
-    # Create an ALL grant: Group B → Group A.
-    await _insert_grant(
-        session,
-        grantee_kind="user_group",
-        grantee_id=group_a,
-        target_kind="all",
-        target_id="",
-        granted_by_id=alice_id,
-        grantor_kind="user_group",
-        grantor_id=group_b,
+    # Create an ALL grant: Group B → Group A via the Grant API.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "all",
+            "target_id": "",
+            "grantee": {"kind": "user_group", "id": group_a},
+            "grantor": {"kind": "user_group", "id": group_b},
+        },
+        headers=ALICE,
     )
+    assert response.status_code == 201, response.text
 
     # With ALL grant: same resource now works.
     response = await client.post(
@@ -796,19 +795,17 @@ async def test_new_owner_can_re_grant_after_transfer(
     project = await _create_project_with_version(client, group_a, name="A project")
     resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
 
-    alice_id = await _get_user_id(client, ALICE)
-
-    # Grant under group_b → works.
-    await _insert_grant(
-        session,
-        grantee_kind="user_group",
-        grantee_id=group_a,
-        target_kind="shared_resource",
-        target_id=resource_b_id,
-        granted_by_id=alice_id,
-        grantor_kind="user_group",
-        grantor_id=group_b,
+    # Grant: Group B → Group A via the Grant API (grantor derived from resource owner).
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user_group", "id": group_a},
+        },
+        headers=ALICE,
     )
+    assert response.status_code == 201, response.text
     response = await client.post(
         f"/api/v1/projects/{project['id']}/run-configurations",
         json={
@@ -858,17 +855,18 @@ async def test_new_owner_can_re_grant_after_transfer(
     )
     assert response.status_code == 404, response.text
 
-    # New owner (group_c) re-grants to group_a.
-    await _insert_grant(
-        session,
-        grantee_kind="user_group",
-        grantee_id=group_a,
-        target_kind="shared_resource",
-        target_id=resource_b_id,
-        granted_by_id=alice_id,
-        grantor_kind="user_group",
-        grantor_id=group_c,
+    # New owner (group_c) re-grants to group_a via the Grant API.
+    # Alice is an OWNER of group_c, so she has GRANT_MANAGE on the new owner.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user_group", "id": group_a},
+        },
+        headers=ALICE,
     )
+    assert response.status_code == 201, response.text
     response = await client.post(
         f"/api/v1/projects/{project['id']}/run-configurations",
         json={
@@ -990,3 +988,60 @@ async def test_usergroup_owner_role_transfer_preserves_grant(
         headers=ALICE,
     )
     assert response.status_code == 201, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 13: ALL grant with non-empty target_id is rejected
+# ---------------------------------------------------------------------------
+
+
+async def test_all_grant_with_nonempty_target_id_rejected(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """ALL grant must have empty target_id; non-empty → 422."""
+    group_a = await _create_group(client, "RejectAllA")
+    group_b = await _create_group(client, "RejectAllB")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    _resource_b_id, _ = await _create_resource_version(client, group_b)
+
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "all",
+            "target_id": "shr_should_be_empty",
+            "grantee": {"kind": "user_group", "id": group_a},
+            "grantor": {"kind": "user_group", "id": group_b},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 422, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 14: Explicit grantor for asset-specific grant is rejected
+# ---------------------------------------------------------------------------
+
+
+async def test_explicit_grantor_for_asset_grant_rejected(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """Asset-specific grants must not carry an explicit grantor; it is derived
+    from the target asset's current owner.  An explicit grantor → 422."""
+    group_a = await _create_group(client, "RejectExplicitA")
+    group_b = await _create_group(client, "RejectExplicitB")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    resource_b_id, _ = await _create_resource_version(client, group_b)
+
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user_group", "id": group_a},
+            "grantor": {"kind": "user_group", "id": group_a},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 422, response.text

--- a/backend/tests/integration/resource/test_cross_owner_use_grant.py
+++ b/backend/tests/integration/resource/test_cross_owner_use_grant.py
@@ -135,22 +135,22 @@ async def _insert_grant(
     target_kind: str,
     target_id: str,
     granted_by_id: str,
-    grantor_owner_kind: str,
-    grantor_owner_id: str,
+    grantor_kind: str,
+    grantor_id: str,
 ) -> str:
     """Insert a GrantRow directly."""
     grant_id = ids.new_id(ids.GRANT)
     session.add(
         GrantRow(
             id=grant_id,
+            grantor_kind=grantor_kind,
+            grantor_id=grantor_id,
             grantee_kind=grantee_kind,
             grantee_id=grantee_id,
             target_kind=target_kind,
             target_id=target_id,
             action="use",
             granted_by_id=granted_by_id,
-            grantor_owner_kind=grantor_owner_kind,
-            grantor_owner_id=grantor_owner_id,
             created_at=datetime.now(UTC),
         )
     )
@@ -210,8 +210,8 @@ async def test_user_grant_enables_cross_owner_shared_resource_use(
         target_kind="shared_resource",
         target_id=resource_b_id,
         granted_by_id=alice_id,
-        grantor_owner_kind="user_group",
-        grantor_owner_id=group_b,
+        grantor_kind="user_group",
+        grantor_id=group_b,
     )
 
     # With Grant: same request succeeds.
@@ -267,8 +267,8 @@ async def test_user_group_grant_enables_cross_owner_environment_use(
         target_kind="environment",
         target_id=env_b_id,
         granted_by_id=alice_id,
-        grantor_owner_kind="user_group",
-        grantor_owner_id=group_b,
+        grantor_kind="user_group",
+        grantor_id=group_b,
     )
 
     # With Grant: assignment succeeds.
@@ -308,8 +308,8 @@ async def test_user_group_grant_inactive_member_cannot_use(
         target_kind="shared_resource",
         target_id=resource_b_id,
         granted_by_id=alice_id,
-        grantor_owner_kind="user_group",
-        grantor_owner_id=group_b,
+        grantor_kind="user_group",
+        grantor_id=group_b,
     )
 
     # Remove Alice from Group A (set membership status to REMOVED).
@@ -587,8 +587,8 @@ async def test_ownership_transfer_invalidates_grant(
         target_kind="shared_resource",
         target_id=resource_b_id,
         granted_by_id=alice_id,
-        grantor_owner_kind="user_group",
-        grantor_owner_id=group_b,
+        grantor_kind="user_group",
+        grantor_id=group_b,
     )
 
     # With grant: run-configuration creation succeeds.
@@ -677,3 +677,316 @@ async def test_grant_to_nonexistent_grantee_rejected(
         headers=ALICE,
     )
     assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 10: ALL grant covers current and future assets (GR-401)
+# ---------------------------------------------------------------------------
+
+
+async def test_all_grant_covers_current_and_future_assets(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """An ALL grant from a Grantor covers all current and future assets."""
+    group_a = await _create_group(client, "ALL Grant Group A")
+    group_b = await _create_group(client, "ALL Grant Group B")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+    _resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Without grant: referencing B's resource → 404.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "no-grant",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text
+
+    # Create an ALL grant: Group B → Group A.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="all",
+        target_id="",
+        granted_by_id=alice_id,
+        grantor_kind="user_group",
+        grantor_id=group_b,
+    )
+
+    # With ALL grant: same resource now works.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "all-grant-existing",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Create a NEW resource under Group B — ALL grant should cover it too.
+    _resource_b2_id, resource_b2_version_id = await _create_resource_version(client, group_b)
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "all-grant-future",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b2_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Create an environment under Group B — ALL grant should cover it too.
+    _env_b_id, env_b_version_id = await _create_environment_version(
+        session, owner_user_group_id=group_b
+    )
+    response = await client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"environment_version_id": env_b_version_id},
+        headers=ALICE,
+    )
+    assert response.status_code == 200, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 11: New owner can re-grant after ownership transfer (GR-408)
+# ---------------------------------------------------------------------------
+
+
+async def test_new_owner_can_re_grant_after_transfer(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """After asset ownership transfers, the new owner can issue a fresh grant."""
+    group_a = await _create_group(client, "ReGrant Group A")
+    group_b = await _create_group(client, "ReGrant Group B")
+    group_c = await _create_group(client, "ReGrant Group C")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+    resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Grant under group_b → works.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="shared_resource",
+        target_id=resource_b_id,
+        granted_by_id=alice_id,
+        grantor_kind="user_group",
+        grantor_id=group_b,
+    )
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "before-transfer",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Transfer ownership: group_b → group_c.
+    from workspace107.infrastructure.db.tables import SharedResourceRow
+
+    resource_row = (
+        await session.execute(
+            select(SharedResourceRow).where(SharedResourceRow.id == resource_b_id)
+        )
+    ).scalar_one()
+    resource_row.owner_user_group_id = group_c
+    resource_row.owner_user_id = None
+    await session.commit()
+
+    # Old grant no longer works.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "after-transfer-old-grant",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text
+
+    # New owner (group_c) re-grants to group_a.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="shared_resource",
+        target_id=resource_b_id,
+        granted_by_id=alice_id,
+        grantor_kind="user_group",
+        grantor_id=group_c,
+    )
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "after-transfer-regrant",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 12: UserGroup internal OWNER role transfer does not invalidate grants
+# ---------------------------------------------------------------------------
+
+
+async def test_usergroup_owner_role_transfer_preserves_grant(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """Transferring the UserGroup OWNER role does not affect asset grants;
+    the asset still belongs to the same UserGroup."""
+    group_a = await _create_group(client, "RoleTransfer Group A")
+    group_b = await _create_group(client, "RoleTransfer Group B")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+    resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Grant: Group B → Group A.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="shared_resource",
+        target_id=resource_b_id,
+        granted_by_id=alice_id,
+        grantor_kind="user_group",
+        grantor_id=group_b,
+    )
+
+    # Grant works.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "before-role-transfer",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Transfer OWNER role within Group B: Alice → Bob.
+    from workspace107.domain.enums import MembershipStatus
+    from workspace107.infrastructure.db.tables import MembershipRow
+
+    # Ensure Bob exists (API call) before opening a write transaction on the
+    # test session — SQLite file-level lock would otherwise block the API.
+    bob_id = await _get_user_id(client, BOB)
+
+    # Demote Alice from OWNER to ADMIN in Group B first (uq_membership_active_owner
+    # allows only one active owner per group).
+    alice_membership = (
+        await session.execute(
+            select(MembershipRow).where(
+                MembershipRow.user_group_id == group_b,
+                MembershipRow.user_id == alice_id,
+            )
+        )
+    ).scalar_one()
+    alice_membership.role = "admin"
+    await session.flush()
+
+    # Add Bob as the new OWNER of Group B.
+    session.add(
+        MembershipRow(
+            id=ids.new_id("mbr"),
+            user_group_id=group_b,
+            user_id=bob_id,
+            role="owner",
+            status=MembershipStatus.ACTIVE.value,
+            created_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+
+    # Grant still works — asset is still owned by Group B.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "after-role-transfer",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text

--- a/backend/tests/integration/resource/test_cross_owner_use_grant.py
+++ b/backend/tests/integration/resource/test_cross_owner_use_grant.py
@@ -1,0 +1,550 @@
+"""Issue #40 cross-owner USE Grant enables asset use across ownership boundaries."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers import grant_test_entitlement
+from workspace107.domain import ids
+from workspace107.infrastructure.db.tables import (
+    EnvironmentRow,
+    EnvironmentVersionRow,
+    GrantRow,
+    RunConfigurationRow,
+)
+
+ALICE = {"X-User": "alice"}
+BOB = {"X-User": "bob"}
+
+
+async def _create_group(
+    client: httpx.AsyncClient, name: str, *, headers: dict | None = None
+) -> str:
+    response = await client.post(
+        "/api/v1/user-groups", json={"name": name}, headers=headers or ALICE
+    )
+    response.raise_for_status()
+    return str(response.json()["id"])
+
+
+async def _create_project_with_version(
+    client: httpx.AsyncClient, user_group_id: str, *, name: str, headers: dict | None = None
+) -> dict:
+    response = await client.post(
+        f"/api/v1/workspaces/{user_group_id}/projects",
+        json={"name": name},
+        headers=headers or ALICE,
+    )
+    response.raise_for_status()
+    project = response.json()
+    response = await client.put(
+        f"/api/v1/projects/{project['id']}/files",
+        json={"path": "main.py", "content": "print('ok')"},
+        headers=headers or ALICE,
+    )
+    response.raise_for_status()
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/versions",
+        json={"message": "v1"},
+        headers=headers or ALICE,
+    )
+    response.raise_for_status()
+    project["_version_id"] = response.json()["id"]
+    return project
+
+
+async def _create_resource_version(
+    client: httpx.AsyncClient, user_group_id: str
+) -> tuple[str, str]:
+    """Create Shared Resource + Version owned by ``user_group_id``. Returns (id, version_id)."""
+    response = await client.post(
+        "/api/v1/shared-resources",
+        json={
+            "owner": {"kind": "user_group", "id": user_group_id},
+            "name": f"resource-{user_group_id[:8]}",
+        },
+        headers=ALICE,
+    )
+    response.raise_for_status()
+    resource_id = str(response.json()["id"])
+    response = await client.post(
+        f"/api/v1/shared-resources/{resource_id}/versions",
+        data={"description": "v1"},
+        files={"files": ("data.txt", b"data", "text/plain")},
+        headers=ALICE,
+    )
+    response.raise_for_status()
+    return resource_id, str(response.json()["id"])
+
+
+async def _create_environment_version(
+    session: AsyncSession,
+    *,
+    owner_user_id: str | None = None,
+    owner_user_group_id: str | None = None,
+) -> tuple[str, str]:
+    """Create an Environment + Version. Returns (environment_id, version_id)."""
+    environment_id = ids.new_id(ids.ENVIRONMENT)
+    version_id = ids.new_id(ids.ENVIRONMENT_VERSION)
+    session.add(
+        EnvironmentRow(
+            id=environment_id,
+            name=f"{environment_id} environment",
+            description="",
+            owner_user_id=owner_user_id,
+            owner_user_group_id=owner_user_group_id,
+        )
+    )
+    await session.flush()
+    session.add(
+        EnvironmentVersionRow(
+            id=version_id,
+            environment_id=environment_id,
+            version="1",
+            description="",
+            image="python:3.12-slim",
+            setup_command="",
+        )
+    )
+    await session.commit()
+    return environment_id, version_id
+
+
+async def _set_group_environment(
+    session: AsyncSession, client: httpx.AsyncClient, user_group_id: str
+) -> str:
+    _, version_id = await _create_environment_version(session, owner_user_group_id=user_group_id)
+    response = await client.patch(
+        f"/api/v1/workspaces/{user_group_id}",
+        json={"default_environment_version_id": version_id},
+        headers=ALICE,
+    )
+    response.raise_for_status()
+    return version_id
+
+
+async def _insert_grant(
+    session: AsyncSession,
+    *,
+    grantee_kind: str,
+    grantee_id: str,
+    target_kind: str,
+    target_id: str,
+    granted_by_id: str,
+) -> str:
+    """Insert a GrantRow directly."""
+    grant_id = ids.new_id(ids.GRANT)
+    session.add(
+        GrantRow(
+            id=grant_id,
+            grantee_kind=grantee_kind,
+            grantee_id=grantee_id,
+            target_kind=target_kind,
+            target_id=target_id,
+            action="use",
+            granted_by_id=granted_by_id,
+            created_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+    return grant_id
+
+
+async def _get_user_id(client: httpx.AsyncClient, headers: dict) -> str:
+    """Get the internal user id for a dev-user header."""
+    response = await client.get("/api/v1/me", headers=headers)
+    response.raise_for_status()
+    return str(response.json()["user"]["id"])
+
+
+# ---------------------------------------------------------------------------
+# Test 1: User Grant enables cross-owner Shared Resource use
+# ---------------------------------------------------------------------------
+
+
+async def test_user_grant_enables_cross_owner_shared_resource_use(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """A User-level USE Grant lets Alice reference Group B's resource from Group A's project."""
+    group_a = await _create_group(client, "Grant Group A")
+    group_b = await _create_group(client, "Grant Group B")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+    resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Without a Grant: creating a run-configuration referencing B's resource → 404.
+    attempted = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "cross-owner",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert attempted.status_code == 404, attempted.text
+
+    # Insert a User → B-resource USE Grant.
+    await _insert_grant(
+        session,
+        grantee_kind="user",
+        grantee_id=alice_id,
+        target_kind="shared_resource",
+        target_id=resource_b_id,
+        granted_by_id=alice_id,
+    )
+
+    # With Grant: same request succeeds.
+    attempted = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "cross-owner-granted",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert attempted.status_code == 201, attempted.text
+
+
+# ---------------------------------------------------------------------------
+# Test 2: User Group Grant enables cross-owner Environment use
+# ---------------------------------------------------------------------------
+
+
+async def test_user_group_grant_enables_cross_owner_environment_use(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """A UserGroup-level USE Grant lets Group A use Group B's environment."""
+    group_a = await _create_group(client, "Env Grant Group A")
+    group_b = await _create_group(client, "Env Grant Group B")
+    await _set_group_environment(session, client, group_a)
+    env_b_id, env_b_version_id = await _create_environment_version(
+        session, owner_user_group_id=group_b
+    )
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A env project")
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Without Grant: assigning B's environment to A's project → 404.
+    response = await client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"environment_version_id": env_b_version_id},
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text
+
+    # Insert a UserGroup(A) → B-environment USE Grant.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="environment",
+        target_id=env_b_id,
+        granted_by_id=alice_id,
+    )
+
+    # With Grant: assignment succeeds.
+    response = await client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"environment_version_id": env_b_version_id},
+        headers=ALICE,
+    )
+    assert response.status_code == 200, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 3: User Group Grantee — inactive member cannot use
+# ---------------------------------------------------------------------------
+
+
+async def test_user_group_grant_inactive_member_cannot_use(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """Grant exists but Alice is removed from Group A; preflight and run create must reject."""
+    from workspace107.infrastructure.db.tables import MembershipRow
+
+    group_a = await _create_group(client, "Inactive Member Group A")
+    group_b = await _create_group(client, "Inactive Member Group B")
+    env_a = await _set_group_environment(session, client, group_a)
+    resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Insert UserGroup(A) → B-resource USE Grant.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="shared_resource",
+        target_id=resource_b_id,
+        granted_by_id=alice_id,
+    )
+
+    # Remove Alice from Group A (set membership status to REMOVED).
+    membership = (
+        await session.execute(
+            select(MembershipRow).where(
+                MembershipRow.user_group_id == group_a,
+                MembershipRow.user_id == alice_id,
+            )
+        )
+    ).scalar_one()
+    membership.status = "removed"
+    await session.commit()
+
+    # Create a bypassed run-configuration to test preflight and run create.
+    configuration_id = "rc_inactive_member"
+    session.add(
+        RunConfigurationRow(
+            id=configuration_id,
+            project_id=project["id"],
+            name="bypassed",
+            description="",
+            working_directory=".",
+            command="python main.py",
+            environment_version_id=env_a,
+            environment_variables={},
+            input_bindings=[
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                    "source_subpath": "",
+                }
+            ],
+            compute_plan_id="plan_cpu_quick",
+            compute_request=None,
+            artifact_rules=[],
+        )
+    )
+    await session.commit()
+
+    # Alice is no longer an active member of Group A, so the project is not visible.
+    # Preflight and run-create should reject — AccessGuard already blocks at the project level.
+    preflight = await client.post(
+        f"/api/v1/projects/{project['id']}/runs/preflight",
+        json={"run_configuration_id": configuration_id},
+        headers=ALICE,
+    )
+    assert preflight.status_code == 404, preflight.text
+
+    create = await client.post(
+        f"/api/v1/projects/{project['id']}/runs",
+        json={"run_configuration_id": configuration_id},
+        headers=ALICE,
+    )
+    assert create.status_code == 404, create.text
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Grant target must be top-level, not version
+# ---------------------------------------------------------------------------
+
+
+async def test_grant_target_must_be_top_level_not_version(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """``target_kind='shared_resource_version'`` is rejected at the schema layer (422)."""
+    group_b = await _create_group(client, "Schema Validation Group B")
+    _, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource_version",
+            "target_id": resource_b_version_id,
+            "grantee": {"kind": "user", "id": "usr_someuser"},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 422, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Grant does not grant management permission
+# ---------------------------------------------------------------------------
+
+
+async def test_grant_does_not_grant_management_permission(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """A USE Grant does not let the grantee manage (PATCH) the resource."""
+    await _create_group(client, "Mgmt Group A")
+    group_b = await _create_group(client, "Mgmt Group B")
+    resource_b_id, _ = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Alice owns Group B resource; create a User → B-resource USE Grant for Alice.
+    # (Alice is already the owner, but the point is: even with a Grant, a non-owner
+    # non-member cannot PATCH.)
+    # Use the grants API to create the grant.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user", "id": alice_id},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Alice can already manage because she's the owner via group B membership.
+    # To test that Grant ≠ management, we need a user who is NOT a B member.
+    # Bob has no group B membership; the Grant for Alice doesn't help Bob.
+    # But we can verify the API: create a grant for Bob, then Bob tries to PATCH.
+    bob_id = await _get_user_id(client, BOB)
+
+    # Create a User → B-resource USE Grant for Bob.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user", "id": bob_id},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Bob tries to PATCH the resource — should fail (404, not visible for management).
+    response = await client.patch(
+        f"/api/v1/shared-resources/{resource_b_id}",
+        json={"name": "hacked by bob"},
+        headers=BOB,
+    )
+    assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Revoke Grant blocks subsequent use
+# ---------------------------------------------------------------------------
+
+
+async def test_revoke_grant_blocks_subsequent_use(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """After revoking a Grant, creating a run-configuration referencing the asset → 404."""
+    group_a = await _create_group(client, "Revoke Group A")
+    group_b = await _create_group(client, "Revoke Group B")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+    resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Create a grant via the API.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user", "id": alice_id},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+    grant_id = response.json()["id"]
+
+    # With Grant: run-configuration creation succeeds.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "with-grant",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Revoke the grant.
+    response = await client.delete(f"/api/v1/grants/{grant_id}", headers=ALICE)
+    assert response.status_code == 204, response.text
+
+    # After revoke: same request → 404.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "after-revoke",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Same-owner use requires no grant (Issue #39 regression)
+# ---------------------------------------------------------------------------
+
+
+async def test_same_owner_use_requires_no_grant(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """Owner-scope self-use still works without any Grant (Issue #39 regression)."""
+    group_a = await _create_group(client, "Same Owner Group A")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A self-use project")
+    _, resource_a_version_id = await _create_resource_version(client, group_a)
+
+    # No Grant needed: same-owner use succeeds.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "same-owner",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_a_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text

--- a/backend/tests/integration/resource/test_cross_owner_use_grant.py
+++ b/backend/tests/integration/resource/test_cross_owner_use_grant.py
@@ -135,6 +135,8 @@ async def _insert_grant(
     target_kind: str,
     target_id: str,
     granted_by_id: str,
+    grantor_owner_kind: str,
+    grantor_owner_id: str,
 ) -> str:
     """Insert a GrantRow directly."""
     grant_id = ids.new_id(ids.GRANT)
@@ -147,6 +149,8 @@ async def _insert_grant(
             target_id=target_id,
             action="use",
             granted_by_id=granted_by_id,
+            grantor_owner_kind=grantor_owner_kind,
+            grantor_owner_id=grantor_owner_id,
             created_at=datetime.now(UTC),
         )
     )
@@ -206,6 +210,8 @@ async def test_user_grant_enables_cross_owner_shared_resource_use(
         target_kind="shared_resource",
         target_id=resource_b_id,
         granted_by_id=alice_id,
+        grantor_owner_kind="user_group",
+        grantor_owner_id=group_b,
     )
 
     # With Grant: same request succeeds.
@@ -254,8 +260,6 @@ async def test_user_group_grant_enables_cross_owner_environment_use(
         headers=ALICE,
     )
     assert response.status_code == 404, response.text
-
-    # Insert a UserGroup(A) → B-environment USE Grant.
     await _insert_grant(
         session,
         grantee_kind="user_group",
@@ -263,6 +267,8 @@ async def test_user_group_grant_enables_cross_owner_environment_use(
         target_kind="environment",
         target_id=env_b_id,
         granted_by_id=alice_id,
+        grantor_owner_kind="user_group",
+        grantor_owner_id=group_b,
     )
 
     # With Grant: assignment succeeds.
@@ -302,6 +308,8 @@ async def test_user_group_grant_inactive_member_cannot_use(
         target_kind="shared_resource",
         target_id=resource_b_id,
         granted_by_id=alice_id,
+        grantor_owner_kind="user_group",
+        grantor_owner_id=group_b,
     )
 
     # Remove Alice from Group A (set membership status to REMOVED).
@@ -548,3 +556,124 @@ async def test_same_owner_use_requires_no_grant(
         headers=ALICE,
     )
     assert response.status_code == 201, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Ownership transfer invalidates grants issued under old owner (GR-408)
+# ---------------------------------------------------------------------------
+
+
+async def test_ownership_transfer_invalidates_grant(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """After asset Ownership transfers to a new Owner, grants issued under the
+    old Owner no longer authorize use (GR-408).
+    """
+    group_a = await _create_group(client, "Transfer Group A")
+    group_b = await _create_group(client, "Transfer Group B")
+    group_c = await _create_group(client, "Transfer Group C")
+    await _set_group_environment(session, client, group_a)
+    await grant_test_entitlement(session, group_a)
+    project = await _create_project_with_version(client, group_a, name="A project")
+    resource_b_id, resource_b_version_id = await _create_resource_version(client, group_b)
+
+    alice_id = await _get_user_id(client, ALICE)
+
+    # Create a UserGroup(A) → B-resource USE Grant issued under group_b's ownership.
+    await _insert_grant(
+        session,
+        grantee_kind="user_group",
+        grantee_id=group_a,
+        target_kind="shared_resource",
+        target_id=resource_b_id,
+        granted_by_id=alice_id,
+        grantor_owner_kind="user_group",
+        grantor_owner_id=group_b,
+    )
+
+    # With grant: run-configuration creation succeeds.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "before-transfer",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 201, response.text
+
+    # Transfer ownership of resource_b from group_b to group_c.
+    from workspace107.infrastructure.db.tables import SharedResourceRow
+
+    resource_row = (
+        await session.execute(
+            select(SharedResourceRow).where(SharedResourceRow.id == resource_b_id)
+        )
+    ).scalar_one()
+    resource_row.owner_user_group_id = group_c
+    resource_row.owner_user_id = None
+    await session.commit()
+
+    # After transfer: the grant issued under group_b is now invalid → 404.
+    response = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "after-transfer",
+            "command": "python main.py",
+            "compute_plan_id": "plan_cpu_quick",
+            "input_bindings": [
+                {
+                    "source_type": "shared_resource_version",
+                    "source_id": resource_b_version_id,
+                    "access_path": "/inputs/data",
+                }
+            ],
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Grant to nonexistent grantee is rejected (404)
+# ---------------------------------------------------------------------------
+
+
+async def test_grant_to_nonexistent_grantee_rejected(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
+    """Creating a grant for a nonexistent User or UserGroup returns 404."""
+    group_b = await _create_group(client, "Grantee Validation Group B")
+    resource_b_id, _ = await _create_resource_version(client, group_b)
+
+    # Grant to a nonexistent User.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user", "id": "usr_nonexistent0000000000001"},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text
+
+    # Grant to a nonexistent UserGroup.
+    response = await client.post(
+        "/api/v1/grants",
+        json={
+            "target_kind": "shared_resource",
+            "target_id": resource_b_id,
+            "grantee": {"kind": "user_group", "id": "ugp_nonexistent0000000000001"},
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 404, response.text

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -295,7 +295,8 @@
           "run.cancel",
           "shared_resource.view",
           "shared_resource.manage",
-          "shared_resource.version.create"
+          "shared_resource.version.create",
+          "grant.manage"
         ],
         "title": "Capability",
         "type": "string"
@@ -697,14 +698,27 @@
           "grantee": {
             "$ref": "#/components/schemas/OwnerReferenceIn"
           },
+          "grantor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OwnerReferenceIn"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Required for ALL grants (who issues the grant); omitted for asset grants\n(derived from the target asset's current owner)."
+          },
           "target_id": {
+            "default": "",
             "title": "Target Id",
             "type": "string"
           },
           "target_kind": {
             "enum": [
               "environment",
-              "shared_resource"
+              "shared_resource",
+              "all"
             ],
             "title": "Target Kind",
             "type": "string"
@@ -712,7 +726,6 @@
         },
         "required": [
           "target_kind",
-          "target_id",
           "grantee"
         ],
         "title": "GrantCreateIn",
@@ -736,6 +749,9 @@
           "grantee": {
             "$ref": "#/components/schemas/OwnerSummaryOut"
           },
+          "grantor": {
+            "$ref": "#/components/schemas/OwnerSummaryOut"
+          },
           "id": {
             "title": "Id",
             "type": "string"
@@ -747,7 +763,8 @@
           "target_kind": {
             "enum": [
               "environment",
-              "shared_resource"
+              "shared_resource",
+              "all"
             ],
             "title": "Target Kind",
             "type": "string"
@@ -755,6 +772,7 @@
         },
         "required": [
           "id",
+          "grantor",
           "grantee",
           "target_kind",
           "target_id",
@@ -766,8 +784,9 @@
         "type": "object"
       },
       "GrantTargetKind": {
-        "description": "Grant 指向的资产种类。仅限顶层资产，不包含 version。",
+        "description": "Grant 指向的资产范围。\n\n``ALL`` 表示授权 Grantor 当前及未来拥有的全部可授权 Environment /\nShared Resource；此时 ``target_id`` 为空字符串。\n``ENVIRONMENT`` / ``SHARED_RESOURCE`` 表示仅授权具体顶层资产。",
         "enum": [
+          "all",
           "environment",
           "shared_resource"
         ],
@@ -3615,28 +3634,79 @@
     },
     "/api/v1/grants": {
       "get": {
-        "description": "List all Grants for a target asset.  Only the asset Owner may list.",
+        "description": "List Grants.\n\nFilter by target asset (``target_kind`` + ``target_id``) or by Grantor\n(``grantor_kind`` + ``grantor_id``).  Exactly one filter pair must be given.",
         "operationId": "list_grants_api_v1_grants_get",
         "parameters": [
           {
-            "description": "资产种类：environment 或 shared_resource",
+            "description": "按资产种类过滤：environment 或 shared_resource",
             "in": "query",
             "name": "target_kind",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/GrantTargetKind",
-              "description": "资产种类：environment 或 shared_resource"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/GrantTargetKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按资产种类过滤：environment 或 shared_resource",
+              "title": "Target Kind"
             }
           },
           {
             "description": "顶层资产 ID",
             "in": "query",
             "name": "target_id",
-            "required": true,
+            "required": false,
             "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "description": "顶层资产 ID",
-              "title": "Target Id",
-              "type": "string"
+              "title": "Target Id"
+            }
+          },
+          {
+            "description": "按 Grantor 种类过滤",
+            "in": "query",
+            "name": "grantor_kind",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OwnerKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按 Grantor 种类过滤",
+              "title": "Grantor Kind"
+            }
+          },
+          {
+            "description": "Grantor ID",
+            "in": "query",
+            "name": "grantor_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Grantor ID",
+              "title": "Grantor Id"
             }
           },
           {
@@ -3732,13 +3802,13 @@
             "description": "底层调度系统返回错误"
           }
         },
-        "summary": "列出指向某资产的 Grant",
+        "summary": "列出 Grant",
         "tags": [
           "grant"
         ]
       },
       "post": {
-        "description": "Create a USE Grant allowing ``grantee`` to reference the target asset.\n\nOnly the target asset's Owner may create a Grant.  The target must be a\ntop-level Environment or Shared Resource (not a version).",
+        "description": "Create a USE Grant allowing ``grantee`` to reference the Grantor's asset(s).\n\nFor asset grants (environment/shared_resource), the Grantor is derived from\nthe target asset's current owner.  For ALL grants, ``grantor`` must be\nsupplied explicitly and the caller must have GRANT_MANAGE on that Grantor.",
         "operationId": "create_grant_api_v1_grants_post",
         "parameters": [
           {
@@ -3848,7 +3918,7 @@
     },
     "/api/v1/grants/{grant_id}": {
       "delete": {
-        "description": "Revoke a Grant.  Only the target asset's Owner may revoke.",
+        "description": "Revoke a Grant.  Requires GRANT_MANAGE on the Grant's Grantor.",
         "operationId": "revoke_grant_api_v1_grants__grant_id__delete",
         "parameters": [
           {

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -3634,7 +3634,7 @@
     },
     "/api/v1/grants": {
       "get": {
-        "description": "List Grants.\n\nFilter by target asset (``target_kind`` + ``target_id``) or by Grantor\n(``grantor_kind`` + ``grantor_id``).  Exactly one filter pair must be given.",
+        "description": "List Grants.\n\nFilter by target asset (``target_kind`` + ``target_id``) or by Grantor\n(``grantor_kind`` + ``grantor_id``).  Exactly one complete filter pair must\nbe given; partial pairs or both pairs simultaneously are rejected with 422.",
         "operationId": "list_grants_api_v1_grants_get",
         "parameters": [
           {

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -24,7 +24,9 @@
           "run_finished",
           "shared_resource_created",
           "shared_resource_updated",
-          "shared_resource_version_published"
+          "shared_resource_version_published",
+          "grant_created",
+          "grant_revoked"
         ],
         "title": "ActivityAction",
         "type": "string"
@@ -691,6 +693,88 @@
         ],
         "title": "ForkSourceOut",
         "type": "object"
+      },
+      "GrantCreateIn": {
+        "properties": {
+          "grantee": {
+            "$ref": "#/components/schemas/OwnerReferenceIn"
+          },
+          "target_id": {
+            "title": "Target Id",
+            "type": "string"
+          },
+          "target_kind": {
+            "enum": [
+              "environment",
+              "shared_resource"
+            ],
+            "title": "Target Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_kind",
+          "target_id",
+          "grantee"
+        ],
+        "title": "GrantCreateIn",
+        "type": "object"
+      },
+      "GrantOut": {
+        "properties": {
+          "action": {
+            "const": "use",
+            "title": "Action",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "granted_by": {
+            "$ref": "#/components/schemas/OwnerSummaryOut"
+          },
+          "grantee": {
+            "$ref": "#/components/schemas/OwnerSummaryOut"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "target_id": {
+            "title": "Target Id",
+            "type": "string"
+          },
+          "target_kind": {
+            "enum": [
+              "environment",
+              "shared_resource"
+            ],
+            "title": "Target Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "grantee",
+          "target_kind",
+          "target_id",
+          "action",
+          "granted_by",
+          "created_at"
+        ],
+        "title": "GrantOut",
+        "type": "object"
+      },
+      "GrantTargetKind": {
+        "description": "Grant 指向的资产种类。仅限顶层资产，不包含 version。",
+        "enum": [
+          "environment",
+          "shared_resource"
+        ],
+        "title": "GrantTargetKind",
+        "type": "string"
       },
       "HealthOut": {
         "properties": {
@@ -2824,7 +2908,8 @@
           "project_version",
           "run",
           "shared_resource",
-          "shared_resource_version"
+          "shared_resource_version",
+          "grant"
         ],
         "title": "TargetType",
         "type": "string"
@@ -3528,6 +3613,341 @@
         "summary": "列出运行环境",
         "tags": [
           "catalog"
+        ]
+      }
+    },
+    "/api/v1/grants": {
+      "get": {
+        "description": "List all Grants for a target asset.  Only the asset Owner may list.",
+        "operationId": "list_grants_api_v1_grants_get",
+        "parameters": [
+          {
+            "description": "资产种类：environment 或 shared_resource",
+            "in": "query",
+            "name": "target_kind",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GrantTargetKind",
+              "description": "资产种类：environment 或 shared_resource"
+            }
+          },
+          {
+            "description": "顶层资产 ID",
+            "in": "query",
+            "name": "target_id",
+            "required": true,
+            "schema": {
+              "description": "顶层资产 ID",
+              "title": "Target Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GrantOut"
+                  },
+                  "title": "Response List Grants Api V1 Grants Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "列出指向某资产的 Grant",
+        "tags": [
+          "grant"
+        ]
+      },
+      "post": {
+        "description": "Create a USE Grant allowing ``grantee`` to reference the target asset.\n\nOnly the target asset's Owner may create a Grant.  The target must be a\ntop-level Environment or Shared Resource (not a version).",
+        "operationId": "create_grant_api_v1_grants_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantCreateIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GrantOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "创建跨 Owner USE Grant",
+        "tags": [
+          "grant"
+        ]
+      }
+    },
+    "/api/v1/grants/{grant_id}": {
+      "delete": {
+        "description": "Revoke a Grant.  Only the target asset's Owner may revoke.",
+        "operationId": "revoke_grant_api_v1_grants__grant_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grant_id",
+            "required": true,
+            "schema": {
+              "title": "Grant Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "撤销 USE Grant",
+        "tags": [
+          "grant"
         ]
       }
     },

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -24,9 +24,7 @@
           "run_finished",
           "shared_resource_created",
           "shared_resource_updated",
-          "shared_resource_version_published",
-          "grant_created",
-          "grant_revoked"
+          "shared_resource_version_published"
         ],
         "title": "ActivityAction",
         "type": "string"
@@ -2908,8 +2906,7 @@
           "project_version",
           "run",
           "shared_resource",
-          "shared_resource_version",
-          "grant"
+          "shared_resource_version"
         ],
         "title": "TargetType",
         "type": "string"

--- a/docs/journal/2026-08-21-1558-issue40-cross-owner-use-grant.md
+++ b/docs/journal/2026-08-21-1558-issue40-cross-owner-use-grant.md
@@ -1,0 +1,59 @@
+# issue40-cross-owner-use-grant
+
+- 状态：已认领 Issue #40，建立分支与初始 PR；实现尚未开始
+- 认领：zxb3；本 worktree 的 sole writer
+- 写入边界：`/home/zxbq/107-workspace`（分支 `feat/40-cross-owner-use-grant`）
+- 分支：`feat/40-cross-owner-use-grant`
+- 起点：`origin/main` `23bffe2`（#35 PR #57、#39 PR #58 已合并；依赖 #35/#39 均已 closed）
+- 开始：2026-08-21 15:58 +0800
+- 关联：Issue #40；Parent #34；Depends on #35（已合并）、#39（已合并）
+
+## 意图与完成边界
+
+在 #39 已建立的 `application/asset_use.py` exact-same-Owner use boundary 上扩展「或存在有效 USE Grant」，
+实现跨 Owner Environment / Shared Resource 的统一 USE Grant 模型，使资产 Ownership 与使用资格明确分离。
+
+Grant 语义（来自 `docs/product/design.md` GR-401 ~ GR-404）：
+
+- `Grantee = User | User Group`；`Action = USE`；`Target = Environment | Shared Resource`（顶层资产）。
+- Grant 作用于顶层资产，不直接授予某个 Version；Run Configuration / Run Snapshot 仍引用确定 Version。
+- Grant 不授予资产管理、发布、归档、转移等生命周期权限，也不创建 Membership。
+- User Group 作为 Grantee 时，具体 User 必须同时具有该组有效 Membership 才能以该组资格使用资产。
+- Owner scope 内使用自身资产无需额外 Grant；跨 Owner 使用必须存在有效 USE Grant。
+- Ownership 转移后原 Owner 建立的 Grant 失效。
+- Grant 撤销不改写既有 Run Snapshot，但后续创建/重新执行/重新物化需按当前规则重新校验。
+
+本工作单元包含：Grant 领域对象与值对象、数据库表与 repository、最小 application service / API contract
+（创建、查看、撤销）、`asset_use.py` 上的 USE Grant 扩展、Run / preflight 的跨 Owner 使用资格查询，
+以及覆盖 User→Asset、UserGroup→Asset、target/action 约束、Membership 借用、Ownership 转移失效的授权测试。
+
+## 冻结契约（初稿，实现前可微调）
+
+- 新增 `grants` 表：`grantee_kind`（user / user_group）、`grantee_id`、`target_kind`（environment / shared_resource）、
+  `target_id`、`action`（当前仅 `use`）、`granted_by_id`、`created_at`。Target 仅允许 Environment / Shared Resource，
+  Action 仅允许 USE；不引入有效期、复杂 Action 集合或 Project-level Grant。
+- USE Grant 不创建 Membership，不扩大资产管理权限；Grant 是独立关系对象，按当前 Owner 边界授权（GR-401）。
+- `asset_use.py` 的 use boundary 扩展为「consuming Project Owner 与 asset Owner 完全相等 **或** 存在以
+  发起 User（含其有效 Membership 的 User Group）为 Grantee 的有效 USE Grant」；repository actor discovery
+  与 exact snapshot lookup 职责不变。
+- Ownership 转移后旧 Grant 失效：Grant 不随 Owner 变更改写，但 use authorization 在转移后对旧 Grant 一律 fail closed。
+- Grant 撤销不改写既有 Run Snapshot；后续创建/重新执行/重新物化按当前有效 Grant 重新校验。
+
+## 已接受风险与非目标
+
+- 非目标：Grant 有效期、复杂 Action 集合、Project-level Grant、完整授权管理 UI、通用 ACL / policy engine、
+  改变 Version 不可变与 Input Binding 精确引用语义。
+- 风险控制：Grant 只扩展 use boundary，不引入新资产管理能力；User Group Grant 必须与有效 Membership 叠加校验。
+
+## 验证计划
+
+1. User→Asset、UserGroup→Asset 的 USE Grant 创建/查看/撤销，含授权测试。
+2. Grant target 仅允许 Environment / Shared Resource；Action 仅允许 USE；不允许 Version / Project。
+3. Owner scope 内无需 Grant；跨 Owner 无有效 Grant 时 fail closed；有有效 Grant 时通过。
+4. User Group Grant 不能被非该组有效成员借用。
+5. Ownership 转移后旧 Grant 不生效。
+6. 受影响的 migration / authorization / API tests 与 `make check` 通过。
+
+## 仓外副作用
+
+无；只使用隔离临时 SQLite / test storage。

--- a/docs/journal/2026-08-21-1558-issue40-cross-owner-use-grant.md
+++ b/docs/journal/2026-08-21-1558-issue40-cross-owner-use-grant.md
@@ -1,6 +1,5 @@
 # issue40-cross-owner-use-grant
-
-- 状态：已认领 Issue #40，建立分支与初始 PR；实现尚未开始
+- 状态：实现完成，`make check backend` + contract check 通过
 - 认领：zxb3；本 worktree 的 sole writer
 - 写入边界：`/home/zxbq/107-workspace`（分支 `feat/40-cross-owner-use-grant`）
 - 分支：`feat/40-cross-owner-use-grant`
@@ -57,3 +56,26 @@ Grant 语义（来自 `docs/product/design.md` GR-401 ~ GR-404）：
 ## 仓外副作用
 
 无；只使用隔离临时 SQLite / test storage。
+
+## 实现完成（2026-08-22）
+
+### 已实现
+
+- **Domain** (`domain/grant.py`): `Grant` 聚合、`GrantAction.USE`、`GrantTargetKind.ENVIRONMENT/SHARED_RESOURCE`；`ids.GRANT="gnt"` 前缀；`ActivityAction.GRANT_CREATED/GRANT_REVOKED`、`TargetType.GRANT` 枚举值。
+- **Migration** (`1f61cd1dc3ac_grants.py`): `grants` 表，`uq_grant_grantee_target_action` 唯一约束，`ix_grants_target`/`ix_grants_grantee` 索引，`granted_by_id` FK→`users.id` (RESTRICT)。无 target FK（Grant 可引用已删除资产）。
+- **Repository**: `GrantRepository` port + `GrantRepositoryImpl`（`add`/`get`/`list_for_target`/`list_for_grantee`/`delete`/`exists_use_grant`）；`EnvironmentRepository.get_by_id`/`get_version_by_id`、`SharedResourceRepository.get_by_id` trusted lookups。
+- **AssetUse** (`application/asset_use.py`): 双路径授权——same-owner discovery (Issue #39) + Grant 路径。Grant 路径检查 `target_owner`（Project Owner）或 acting `user_id`（User-level Grant）的 USE Grant。
+- **Service+API**: `GrantService`（create/list_for_target/revoke）；`AccessGuard.environment()`；`POST/GET/DELETE /api/v1/grants` 路由；`GrantOut`/`GrantCreateIn` schemas；`grant_out` presenter；`Services.grants` 注入。
+- **Contract**: `contracts/openapi.json` + `frontend/src/api/schema.d.ts` 已重新生成。
+- **Tests**: `test_cross_owner_use_grant.py`（7 个行为测试）+ `test_grants_migration.py`（迁移 round-trip 测试）全部通过；`test_asset_owner_use.py`（Issue #39 回归）全部通过。
+
+### 修复的遗留问题
+
+- 恢复 `ids.SHARED_RESOURCE_VERSION`（被前序编辑误删）。
+- 恢复 `repositories.py` 的 `ComputePlan` import（被前序编辑误替换）。
+- 恢复 `schemas.SharedResourceUpdateIn.description` 字段（被前序编辑误删）。
+
+### 验证结果
+
+- `make check backend`：lint + format + 221 tests passed（2 skipped）。
+- Contract check：OpenAPI 与 frontend types 匹配。

--- a/docs/product/design.md
+++ b/docs/product/design.md
@@ -118,7 +118,7 @@ User Group、成员与共享资产
     ├── [Core] 使用 User Group 拥有的 Environment 和 Shared Resource 创建 Run
     ├── [Core] 查看和管理 User Group 的 Variable
     ├── [Core] 查看和管理 User Group 的 Secret（不展示 Secret 明文）
-    └── [V1] 为其他 User 或 User Group 使用本组资产建立显式 USE Grant
+    └── [V1] 为其他 User 或 User Group 建立本组资产的 USE Grant
 ```
 
 ### 2.3 Project 与项目文件
@@ -770,9 +770,13 @@ Repository 接口
 
 | 名称 | 定义 |
 | :---- | :-- |
-| Grant | 一条明确的跨 Owner 使用许可，允许 User 或 User Group 使用 Environment 或 Shared Resource |
-| Target | Grant 中“可以使用哪项资产”的对象，只能是 Environment 或 Shared Resource 本身，而不是其中某个 Version |
+| Grant | Grantor 向 Grantee 授予的跨 Owner 使用许可 |
+| Grantor | 发出 Grant 的 User 或 User Group |
+| Grantee | 获得 Grant 的 User 或 User Group |
+| Target | Grant 的作用范围：`ALL`，或某个顶层 Environment / Shared Resource；不直接指向 Version |
 | Action | Grant 中“允许做什么”的操作；当前只有 USE |
+
+`Target = ALL` 只覆盖当前 Owner 为 Grantor 的资产，包括 Grantor 后续新建或取得的资产。具体执行 Grant 操作的 User 只作为操作者记录，不改变 Grantor、Grantee 或 Target 的语义。
 
 `Membership` 的结构如下：
 
@@ -1331,8 +1335,8 @@ Activity 记录操作者（User，或适用时的平台系统）、动作、作�
 
 ```text
 Project、其从属对象或 Run ─────────────▶ Project
-Environment 或其 Version / Grant ─────▶ Environment
-Shared Resource 或其 Version / Grant ─▶ Shared Resource
+Environment 或其 Version ──────────────▶ Environment
+Shared Resource 或其 Version ──────────▶ Shared Resource
 User Group 或 Membership ──────────────▶ User Group
 ```
 
@@ -1607,7 +1611,7 @@ Activity ──▶ 操作者（User / Platform System）、作用对象
 Notification ──▶ User
 Notification ··▶ Activity / 来源对象
 
-User / User Group ── Grant(USE) ──▶ Environment / Shared Resource
+Grantor(User / User Group) ── Grant(USE, ALL / Environment / Shared Resource) ──▶ Grantee(User / User Group)
 ```
 
 这里有几个关键语义：
@@ -1649,7 +1653,7 @@ Resource Entitlement
 → 使 User 获得 Compute Plan 的使用资格；Run 使用发起 User 的资格。
 
 Grant
-→ 向 User 或 User Group 授予顶层 Environment 或 Shared Resource 的 `USE` 权限（当前仅设置了 `USE` 权限）。
+→ 由 Grantor 向 Grantee 授予 `USE`；可覆盖 Grantor 当前拥有的全部 Environment / Shared Resource，或某个具体顶层资产。
 
 Environment、Shared Resource
 → 分别由一个 User 或一个 User Group 拥有；平台提供或运营的资产由平台运营的 User Group 持有。
@@ -1829,11 +1833,11 @@ Run Snapshot 只能记录执行开始前已确定的输入和配置；Log、Arti
 
 ##### **GR-401 — Environment 与 Shared Resource 使用资格**
 
-Owner User 可以管理、发布和使用自己的 Environment 或 Shared Resource；User Group-owned 资产由具体 User 按该组有效 Membership 的 Role / Status 操作；跨 Owner 使用必须具有有效 USE Grant。
+Owner User 可以管理、发布和使用自己的 Environment 或 Shared Resource；User Group-owned 资产由具体 User 按该组有效 Membership 的 Role / Status 操作；跨 Owner 使用必须命中资产当前 Owner 作为 Grantor 发出的有效 USE Grant。
 
-##### **GR-402 — Grant Target 与版本固定分离**
+##### **GR-402 — Grant 主体、范围与版本分离**
 
-资产 Grant 只能向 User 或 User Group 授予权限，Action 只能是 `USE`，Target 只能是顶层 Environment 或 Shared Resource；Grant 不得向 Project 授权，Project 也不得作为 Target，Grant 不授予管理、发布、归档、转移等生命周期权限。
+Grantor 和 Grantee 只能是 User 或 User Group，Action 只能是 `USE`。Target 只能是 `ALL` 或顶层 Environment / Shared Resource；`ALL` 只覆盖当前 Owner 为 Grantor 的资产，包括其后续新建或取得的资产。Grant 不直接授予 Version，不以 Project 为 Grantor、Grantee 或 Target，也不授予管理、发布、归档、转移等生命周期权限。
 
 ##### **GR-403 — Input Binding 内容确定性**
 
@@ -1857,7 +1861,7 @@ Variable、Secret 的值和访问权限不得因 Fork、Template 或其他跨 Ow
 
 ##### **GR-408 — Ownership 变更后的授权失效**
 
-Ownership 转移不得改写已有 Version，也不得改变既有 Run Snapshot 中记录的身份和配置。转移完成后，原 Owner 建立的 Grant 失效，后续使用必须按新的 Owner 边界重新授权。转移不延长所引用内容的保留期限；重新执行时，仍须校验当时有效的授权和内容可用性。
+Ownership 转移不得改写已有 Version，也不得改变既有 Run Snapshot 中记录的身份和配置。Grant 仅在 Grantor 仍是目标资产当前 Owner 时作用于该资产；资产转移后，原 Grantor 的 `ALL` 或单资产 Grant 自然不再适用，新 Owner 可以重新授权。User Group 内部 `MembershipRole.OWNER` 变更不属于资产 Ownership 转移，不影响以该 User Group 为 Grantor 的 Grant。转移不延长所引用内容的保留期限；重新执行时，仍须校验当时有效的授权和内容可用性。
 
 ---
 
@@ -2071,7 +2075,9 @@ Environment 或 Shared Resource 的 Ownership 转移遵循 GR-408。
 
 ##### 管理跨 Owner 资产 Grant
 
-Environment 或 Shared Resource Owner 可以为 User 或 User Group 建立、调整或撤销顶层资产的 USE Grant。
+Asset Owner 可以向 User 或 User Group 建立、调整或撤销 USE Grant；授权范围可以是该 Owner 当前及以后拥有的全部 Environment / Shared Resource，或某个具体顶层资产。
+
+User-owned 资产由该 User 管理 Grant；User Group-owned 资产由有效成员按该组 Membership 的 Role / Status 对应权限管理，不把 `MembershipRole.OWNER` 等同于资产 Owner。实际执行操作的 User 只作为操作者记录。
 
 ##### 管理 Compute Plan
 
@@ -2628,7 +2634,7 @@ Roadmap 和 Milestone 可以根据实现反馈调整，但范围变化应显式�
 当前 Roadmap 以 Competition V1 为近期目标，不绑定具体日期，并根据实现反馈持续更新。
 
 | Milestone | 核心目标 | 关键能力 | 默认推进定位 |
-| :---: | :---: | :---: | :---: |
+| :---: | :---: | :--- | :---: |
 | **M0 Engineering Baseline** | 建立可持续开发的工程基线 | Monorepo、Backend、Worker、测试、配置、统一工程入口 | 工程基线优先 |
 | **M1 Executable Skeleton** | 跑通最薄真实执行链路 | Run / Snapshot、Worker、Git / Shared FS、slurmrestd / Slurm、状态回写 | 真实链路优先 |
 | **M2 Single-user Compute Loop** | 形成单用户完整计算闭环 | User-owned Project / Version、Run Configuration、Run、Log、Artifact | 可见闭环优先 |

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1400,7 +1400,7 @@ export interface components {
          *     取值只增不改。已经写进库的活动会一直用旧值，改名等于让历史记录读不出来。
          * @enum {string}
          */
-        ActivityAction: "workspace_created" | "workspace_updated" | "user_group_created" | "user_group_updated" | "member_invited" | "member_joined" | "member_left" | "member_removed" | "member_role_changed" | "ownership_transferred" | "project_created" | "project_updated" | "project_forked" | "version_saved" | "version_restored" | "run_submitted" | "run_cancelled" | "run_finished" | "shared_resource_created" | "shared_resource_updated" | "shared_resource_version_published" | "grant_created" | "grant_revoked";
+        ActivityAction: "workspace_created" | "workspace_updated" | "user_group_created" | "user_group_updated" | "member_invited" | "member_joined" | "member_left" | "member_removed" | "member_role_changed" | "ownership_transferred" | "project_created" | "project_updated" | "project_forked" | "version_saved" | "version_restored" | "run_submitted" | "run_cancelled" | "run_finished" | "shared_resource_created" | "shared_resource_updated" | "shared_resource_version_published";
         /**
          * ActivityOut
          * @description 活动流里的一条。
@@ -2556,7 +2556,7 @@ export interface components {
          *     分成两个枚举只会让前端的跳转逻辑写两遍。
          * @enum {string}
          */
-        TargetType: "workspace" | "user_group" | "member" | "project" | "project_version" | "run" | "shared_resource" | "shared_resource_version" | "grant";
+        TargetType: "workspace" | "user_group" | "member" | "project" | "project_version" | "run" | "shared_resource" | "shared_resource_version";
         /** UnreadCountOut */
         UnreadCountOut: {
             /** Unread */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -84,6 +84,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/grants": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 列出指向某资产的 Grant
+         * @description List all Grants for a target asset.  Only the asset Owner may list.
+         */
+        get: operations["list_grants_api_v1_grants_get"];
+        put?: never;
+        /**
+         * 创建跨 Owner USE Grant
+         * @description Create a USE Grant allowing ``grantee`` to reference the target asset.
+         *
+         *     Only the target asset's Owner may create a Grant.  The target must be a
+         *     top-level Environment or Shared Resource (not a version).
+         */
+        post: operations["create_grant_api_v1_grants_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/grants/{grant_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 撤销 USE Grant
+         * @description Revoke a Grant.  Only the target asset's Owner may revoke.
+         */
+        delete: operations["revoke_grant_api_v1_grants__grant_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/health": {
         parameters: {
             query?: never;
@@ -1353,7 +1400,7 @@ export interface components {
          *     取值只增不改。已经写进库的活动会一直用旧值，改名等于让历史记录读不出来。
          * @enum {string}
          */
-        ActivityAction: "workspace_created" | "workspace_updated" | "user_group_created" | "user_group_updated" | "member_invited" | "member_joined" | "member_left" | "member_removed" | "member_role_changed" | "ownership_transferred" | "project_created" | "project_updated" | "project_forked" | "version_saved" | "version_restored" | "run_submitted" | "run_cancelled" | "run_finished" | "shared_resource_created" | "shared_resource_updated" | "shared_resource_version_published";
+        ActivityAction: "workspace_created" | "workspace_updated" | "user_group_created" | "user_group_updated" | "member_invited" | "member_joined" | "member_left" | "member_removed" | "member_role_changed" | "ownership_transferred" | "project_created" | "project_updated" | "project_forked" | "version_saved" | "version_restored" | "run_submitted" | "run_cancelled" | "run_finished" | "shared_resource_created" | "shared_resource_updated" | "shared_resource_version_published" | "grant_created" | "grant_revoked";
         /**
          * ActivityOut
          * @description 活动流里的一条。
@@ -1669,6 +1716,47 @@ export interface components {
             /** Source Workspace Id */
             source_workspace_id: string;
         };
+        /** GrantCreateIn */
+        GrantCreateIn: {
+            grantee: components["schemas"]["OwnerReferenceIn"];
+            /** Target Id */
+            target_id: string;
+            /**
+             * Target Kind
+             * @enum {string}
+             */
+            target_kind: "environment" | "shared_resource";
+        };
+        /** GrantOut */
+        GrantOut: {
+            /**
+             * Action
+             * @constant
+             */
+            action: "use";
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            granted_by: components["schemas"]["OwnerSummaryOut"];
+            grantee: components["schemas"]["OwnerSummaryOut"];
+            /** Id */
+            id: string;
+            /** Target Id */
+            target_id: string;
+            /**
+             * Target Kind
+             * @enum {string}
+             */
+            target_kind: "environment" | "shared_resource";
+        };
+        /**
+         * GrantTargetKind
+         * @description Grant 指向的资产种类。仅限顶层资产，不包含 version。
+         * @enum {string}
+         */
+        GrantTargetKind: "environment" | "shared_resource";
         /** HealthOut */
         HealthOut: {
             /** Env */
@@ -2468,7 +2556,7 @@ export interface components {
          *     分成两个枚举只会让前端的跳转逻辑写两遍。
          * @enum {string}
          */
-        TargetType: "workspace" | "user_group" | "member" | "project" | "project_version" | "run" | "shared_resource" | "shared_resource_version";
+        TargetType: "workspace" | "user_group" | "member" | "project" | "project_version" | "run" | "shared_resource" | "shared_resource_version" | "grant";
         /** UnreadCountOut */
         UnreadCountOut: {
             /** Unread */
@@ -2820,6 +2908,243 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["EnvironmentOut"][];
                 };
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    list_grants_api_v1_grants_get: {
+        parameters: {
+            query: {
+                /** @description 资产种类：environment 或 shared_resource */
+                target_kind: components["schemas"]["GrantTargetKind"];
+                /** @description 顶层资产 ID */
+                target_id: string;
+            };
+            header?: {
+                "X-User"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantOut"][];
+                };
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    create_grant_api_v1_grants_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GrantCreateIn"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GrantOut"];
+                };
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    revoke_grant_api_v1_grants__grant_id__delete: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-User"?: string | null;
+            };
+            path: {
+                grant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description 请求不合法 */
             400: {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -92,17 +92,21 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * 列出指向某资产的 Grant
-         * @description List all Grants for a target asset.  Only the asset Owner may list.
+         * 列出 Grant
+         * @description List Grants.
+         *
+         *     Filter by target asset (``target_kind`` + ``target_id``) or by Grantor
+         *     (``grantor_kind`` + ``grantor_id``).  Exactly one filter pair must be given.
          */
         get: operations["list_grants_api_v1_grants_get"];
         put?: never;
         /**
          * 创建跨 Owner USE Grant
-         * @description Create a USE Grant allowing ``grantee`` to reference the target asset.
+         * @description Create a USE Grant allowing ``grantee`` to reference the Grantor's asset(s).
          *
-         *     Only the target asset's Owner may create a Grant.  The target must be a
-         *     top-level Environment or Shared Resource (not a version).
+         *     For asset grants (environment/shared_resource), the Grantor is derived from
+         *     the target asset's current owner.  For ALL grants, ``grantor`` must be
+         *     supplied explicitly and the caller must have GRANT_MANAGE on that Grantor.
          */
         post: operations["create_grant_api_v1_grants_post"];
         delete?: never;
@@ -123,7 +127,7 @@ export interface paths {
         post?: never;
         /**
          * 撤销 USE Grant
-         * @description Revoke a Grant.  Only the target asset's Owner may revoke.
+         * @description Revoke a Grant.  Requires GRANT_MANAGE on the Grant's Grantor.
          */
         delete: operations["revoke_grant_api_v1_grants__grant_id__delete"];
         options?: never;
@@ -1519,7 +1523,7 @@ export interface components {
          *     命名统一为 ``对象.动作``，方便在日志和错误信息里直接读。
          * @enum {string}
          */
-        Capability: "user_group.view" | "user_group.update" | "member.view" | "member.manage" | "ownership.transfer" | "config.view" | "config.manage" | "entitlement.view" | "project.view" | "project.create" | "project.update" | "project.content.write" | "run_configuration.manage" | "run.view" | "run.submit" | "run.cancel" | "shared_resource.view" | "shared_resource.manage" | "shared_resource.version.create";
+        Capability: "user_group.view" | "user_group.update" | "member.view" | "member.manage" | "ownership.transfer" | "config.view" | "config.manage" | "entitlement.view" | "project.view" | "project.create" | "project.update" | "project.content.write" | "run_configuration.manage" | "run.view" | "run.submit" | "run.cancel" | "shared_resource.view" | "shared_resource.manage" | "shared_resource.version.create" | "grant.manage";
         /**
          * ChangeKind
          * @description 文件在两次快照之间的变化类型。
@@ -1719,13 +1723,21 @@ export interface components {
         /** GrantCreateIn */
         GrantCreateIn: {
             grantee: components["schemas"]["OwnerReferenceIn"];
-            /** Target Id */
+            /**
+             * @description Required for ALL grants (who issues the grant); omitted for asset grants
+             *     (derived from the target asset's current owner).
+             */
+            grantor?: components["schemas"]["OwnerReferenceIn"] | null;
+            /**
+             * Target Id
+             * @default
+             */
             target_id: string;
             /**
              * Target Kind
              * @enum {string}
              */
-            target_kind: "environment" | "shared_resource";
+            target_kind: "environment" | "shared_resource" | "all";
         };
         /** GrantOut */
         GrantOut: {
@@ -1741,6 +1753,7 @@ export interface components {
             created_at: string;
             granted_by: components["schemas"]["OwnerSummaryOut"];
             grantee: components["schemas"]["OwnerSummaryOut"];
+            grantor: components["schemas"]["OwnerSummaryOut"];
             /** Id */
             id: string;
             /** Target Id */
@@ -1749,14 +1762,18 @@ export interface components {
              * Target Kind
              * @enum {string}
              */
-            target_kind: "environment" | "shared_resource";
+            target_kind: "environment" | "shared_resource" | "all";
         };
         /**
          * GrantTargetKind
-         * @description Grant 指向的资产种类。仅限顶层资产，不包含 version。
+         * @description Grant 指向的资产范围。
+         *
+         *     ``ALL`` 表示授权 Grantor 当前及未来拥有的全部可授权 Environment /
+         *     Shared Resource；此时 ``target_id`` 为空字符串。
+         *     ``ENVIRONMENT`` / ``SHARED_RESOURCE`` 表示仅授权具体顶层资产。
          * @enum {string}
          */
-        GrantTargetKind: "environment" | "shared_resource";
+        GrantTargetKind: "all" | "environment" | "shared_resource";
         /** HealthOut */
         HealthOut: {
             /** Env */
@@ -2967,11 +2984,15 @@ export interface operations {
     };
     list_grants_api_v1_grants_get: {
         parameters: {
-            query: {
-                /** @description 资产种类：environment 或 shared_resource */
-                target_kind: components["schemas"]["GrantTargetKind"];
+            query?: {
+                /** @description 按资产种类过滤：environment 或 shared_resource */
+                target_kind?: components["schemas"]["GrantTargetKind"] | null;
                 /** @description 顶层资产 ID */
-                target_id: string;
+                target_id?: string | null;
+                /** @description 按 Grantor 种类过滤 */
+                grantor_kind?: components["schemas"]["OwnerKind"] | null;
+                /** @description Grantor ID */
+                grantor_id?: string | null;
             };
             header?: {
                 "X-User"?: string | null;

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -96,7 +96,8 @@ export interface paths {
          * @description List Grants.
          *
          *     Filter by target asset (``target_kind`` + ``target_id``) or by Grantor
-         *     (``grantor_kind`` + ``grantor_id``).  Exactly one filter pair must be given.
+         *     (``grantor_kind`` + ``grantor_id``).  Exactly one complete filter pair must
+         *     be given; partial pairs or both pairs simultaneously are rejected with 422.
          */
         get: operations["list_grants_api_v1_grants_get"];
         put?: never;


### PR DESCRIPTION
## 关联 Issue

Ref #40

## 背景

Issue #40 实现跨 Owner Environment / Shared Resource 的统一 USE Grant 模型，使资产 Ownership 与使用资格明确分离。依赖的 #35（PR #57）、#39（PR #58）已合并到 `main`。

## 核心语义

### grantor 是业务实体而非快照

`grantor` 记录的是签发 Grant 的业务实体（User/UserGroup），而非创建时的资产 Owner 快照。`exists_use_grant` 在校验时比较 `grant.grantor == asset.current_owner`，因此：
- Ownership 转移后旧 Grant 自然失效（新 Owner 不是 grantor）
- 新 Owner 可以重新签发 Grant
- 不需要额外快照列或失效逻辑

### ALL target 覆盖当前及未来资产

`target_kind = "all"`（`target_id = ""`）覆盖 grantor 当前及未来拥有的全部可授权资产（Environment + Shared Resource）。`exists_use_grant` 使用 `OR(target_kind == ALL, AND(target_kind == exact, target_id == exact))` 匹配。

### GRANT_MANAGE 能力替代 OWNER 角色检查

- 新增 `Capability.GRANT_MANAGE` 到 `_ADMINISTER` frozenset（ADMIN + OWNER 角色拥有，MEMBER 没有）
- User 拥有的资产自动获得 OWNER 角色 → 有 GRANT_MANAGE
- UserGroup grantor 的 GRANT_MANAGE 检查通过 `capabilities_of(access.role)` 手动判断

### Cross-field invariant（grantor/target 组合锁死）

- **ALL target**: `target_id` 必须为空，`grantor` 必须显式提供，caller 必须有 GRANT_MANAGE on grantor
- **Environment/SharedResource target**: `target_id` 必须非空，`grantor` 始终从 target asset 的当前 owner 推导（显式 grantor 被 reject 422）

这防止了 grantor 不拥有 target asset 的非法 Grant 进入数据库。

## 实现内容

### Domain
- `domain/grant.py`：`Grant` frozen dataclass，含 `grantor: OwnerReference`、`grantee: OwnerReference`、`target_kind` (ALL/ENVIRONMENT/SHARED_RESOURCE)、`target_id`、`action` (USE)、`granted_by`、`created_at`
- `domain/capabilities.py`：`GRANT_MANAGE` 加入 `_ADMINISTER` frozenset

### Database
- `migrations/1f61cd1dc3ac_grants.py`：`grants` 表，`grantor_kind`/`grantor_id` 列（判别联合），`target_kind` 支持 `"all"`，`target_id` 默认 `""`，unique constraint 包含 grantor，`ix_grants_grantor` 索引
- **Migration chain**: `c471ac39f002 → f37c0a1e2b9d (scoped_config, #60) → 1f61cd1dc3ac (grants, #40)` — 单一 head，无分叉
- Grant target 无 FK（Grant 可超越资产生命周期），应用层清理

### Repository
- `GrantRepositoryImpl`：`add`/`get`/`list_for_target`/`list_for_grantee`/`list_for_grantor`/`delete`/`exists_use_grant`
- `exists_use_grant`：校验 `grantor == current asset owner`，ALL 匹配通过 OR 子句

### Use Authorization (`application/asset_use.py`)
- 两路径：同 Owner discovery (#39) + 跨 Owner Grant
- 双重 grantee 检查：project owner (UserGroup) + acting user (personal User-level Grant)
- fail-closed（无 fail-open fallback）

### Service (`application/grant_service.py`)
- `create()`：cross-field invariant — ALL 需显式 grantor，资产 grant 从 target owner 推导（显式 grantor 被 reject）
- `_require_grant_manage()`：User grantor → caller == grantor；UserGroup grantor → `AccessGuard.user_group(user_id, grantor.id)` + `GRANT_MANAGE in capabilities_of(role)`
- `_resolve_grantor()`：ALL → ValidationFailed；资产 → `AccessGuard.environment()/shared_resource()` with `needs=GRANT_MANAGE`
- `list_for_target()`：按 grantor 客户端过滤；docstring 明确不包含 ALL grants
- `list_for_grantor()`：列出 grantor 签发的全部 Grant（ALL + 资产）
- `revoke()`：使用 `grant.grantor` 做 GRANT_MANAGE 校验
- `_validate_grantee_exists()`：不存在的 User/UserGroup 返回 404

### API (`api/routes/grants.py`)
- `POST /grants`：`grantor` 可选（ALL Grant 必须提供，资产 Grant 被 reject）
- `GET /grants`：必须且只能提供一组完整过滤条件 (target 或 grantor)，不合法组合返回 422
- `DELETE /grants/{id}`

### Contract
- OpenAPI + `schema.d.ts` 已同步

## 测试（14 个行为测试 + 1 个迁移测试）

| # | 测试 | 验证内容 |
|---|------|----------|
| 1-3 | 跨 Owner Grant 基础行为 | User/UserGroup grantee、Shared Resource/Environment target |
| 4 | `test_grant_target_must_be_top_level_not_version` | Schema 层 422 拦截非法 target_kind |
| 5 | `test_grant_does_not_grant_management_permission` | Grant 不扩大管理权限 |
| 6 | `test_revoke_grant_blocks_subsequent_use` | 撤销后引用资产 → 404 |
| 7-9 | Issue #39 回归 | 同 Owner 使用不需要 Grant |
| 10 | `test_all_grant_covers_current_and_future_assets` | **通过 POST /grants API 创建 ALL Grant**；覆盖现有资源 + 未来新建资源 + Environment |
| 11 | `test_new_owner_can_re_grant_after_transfer` | **通过 POST /grants API 创建初始 grant 和 re-grant**；Ownership 转移后旧 Grant 失效，新 Owner re-grant → 201 |
| 12 | `test_usergroup_owner_role_transfer_preserves_grant` | UserGroup 内部 OWNER 角色转移不影响 Grant |
| 13 | `test_all_grant_with_nonempty_target_id_rejected` | ALL + 非空 target_id → 422 |
| 14 | `test_explicit_grantor_for_asset_grant_rejected` | 资产 Grant + 显式 grantor → 422 |
| Migration | `test_grants_migration` | grantor 列、ALL target_kind、unique constraint、索引、up/down/up 链路 |

## 验证证据

- `make check`：全部通过（backend: 228 passed, 2 skipped; contract: ✓; frontend: ✓）
- `alembic heads`：单一 head `1f61cd1dc3ac`（链路 `c471 → f37c → 1f61`）
- 分支已 rebase 到最新 main (`5dbeab4`，含 #60 scoped config)
- PR mergeable_state: `clean`

## Rebase 历史

| Rebase | 基线 | 处理 |
|--------|------|------|
| 1st | `0c25bf0` (#68 + #67 + #56) | 清洁 rebase，Viewer 角色移除 |
| 2nd | `5dbeab4` (#60 scoped config) | 3 文件冲突 (deps/routes/repositories ports)，两边保留；migration chain 调整为 `f37c → 1f61`；contract 重新生成 |