### PR TITLE
refactor(authz): 收敛 User Group Owner / Admin / Member 治理权限

### DIFF
--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -91,6 +91,7 @@ def member_out(view: MemberView) -> s.MemberOut:
         display_name=view.user.display_name,
         role=view.membership.role.value,
         status=view.membership.status.value,
+        capabilities=sorted(view.capabilities),
     )
 
 

--- a/backend/src/workspace107/api/routes/user_groups.py
+++ b/backend/src/workspace107/api/routes/user_groups.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from fastapi import APIRouter, status
 
-from ...domain.enums import MembershipRole
 from .. import presenters as p
 from .. import schemas as s
 from ..deps import CurrentUser, ServicesDep
@@ -76,9 +75,7 @@ async def invite_member(
     user: CurrentUser,
     services: ServicesDep,
 ) -> s.MemberOut:
-    await services.user_groups.invite_member(
-        user.id, user_group_id, payload.username, MembershipRole(payload.role)
-    )
+    await services.user_groups.invite_member(user.id, user_group_id, payload.username)
     views = await services.user_groups.list_members(user.id, user_group_id)
     return p.member_out(next(view for view in views if view.user.username == payload.username))
 

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -101,11 +101,12 @@ class MemberOut(Model):
     display_name: str
     role: MembershipRole
     status: MembershipStatus
+    capabilities: list[UserGroupCapability] = Field(default_factory=list)
 
 
 class MemberInviteIn(Model):
+    model_config = ConfigDict(extra="forbid")
     username: str
-    role: MembershipRole = MembershipRole.MEMBER
 
 
 class MemberRoleUpdateIn(Model):

--- a/backend/src/workspace107/application/user_group_service.py
+++ b/backend/src/workspace107/application/user_group_service.py
@@ -38,6 +38,7 @@ class UserGroupView:
 class MemberView:
     membership: Membership
     user: User
+    capabilities: frozenset[UserGroupCapability]
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,12 +188,36 @@ class UserGroupService:
         return result
 
     async def list_members(self, user_id: str, user_group_id: str) -> list[MemberView]:
-        await self._guard.user_group(user_id, user_group_id, needs=UserGroupCapability.MEMBER_VIEW)
+        access = await self._guard.user_group(
+            user_id, user_group_id, needs=UserGroupCapability.MEMBER_VIEW
+        )
         result: list[MemberView] = []
         for membership in await self._repos.memberships.list_for_user_group(user_group_id):
             user = await self._repos.users.get(membership.user_id)
-            if user is not None:
-                result.append(MemberView(membership=membership, user=user))
+            if user is None:
+                continue
+            capabilities: set[UserGroupCapability] = set()
+            if (
+                access.can(UserGroupCapability.MEMBER_REMOVE)
+                and membership.role is not MembershipRole.OWNER
+                and (
+                    access.role is MembershipRole.OWNER or membership.role is MembershipRole.MEMBER
+                )
+            ):
+                capabilities.add(UserGroupCapability.MEMBER_REMOVE)
+            if (
+                access.can(UserGroupCapability.MEMBER_ROLE_MANAGE)
+                and membership.is_active
+                and membership.role in {MembershipRole.ADMIN, MembershipRole.MEMBER}
+            ):
+                capabilities.add(UserGroupCapability.MEMBER_ROLE_MANAGE)
+            result.append(
+                MemberView(
+                    membership=membership,
+                    user=user,
+                    capabilities=frozenset(capabilities),
+                )
+            )
         return result
 
     async def invite_member(
@@ -200,12 +225,11 @@ class UserGroupService:
         user_id: str,
         user_group_id: str,
         username: str,
-        role: MembershipRole,
     ) -> Membership:
         access = await self._lock_and_authorize_mutation(
-            user_id, user_group_id, needs=UserGroupCapability.MEMBER_MANAGE
+            user_id, user_group_id, needs=UserGroupCapability.MEMBER_INVITE
         )
-        _reject_owner_role(role)
+        role = MembershipRole.MEMBER
         invitee = await self._repos.users.get_by_username(username)
         if invitee is None:
             raise ObjectNotFound("User", username)
@@ -266,14 +290,16 @@ class UserGroupService:
 
     async def remove_member(self, user_id: str, user_group_id: str, target_user_id: str) -> None:
         access = await self._lock_and_authorize_mutation(
-            user_id, user_group_id, needs=UserGroupCapability.MEMBER_MANAGE
+            user_id, user_group_id, needs=UserGroupCapability.MEMBER_REMOVE
         )
-        owner = await self._repos.memberships.get_active_owner(user_group_id)
-        if owner is not None and owner.user_id == target_user_id:
-            raise ConflictError("不能移除 User Group Owner，请先转让所有权")
         membership = await self._repos.memberships.get(user_group_id, target_user_id)
         if membership is None:
             raise ObjectNotFound("Membership", target_user_id)
+        if access.role is MembershipRole.ADMIN and membership.role is not MembershipRole.MEMBER:
+            raise PermissionDenied("Admin 只能移除普通 Member")
+        owner = await self._repos.memberships.get_active_owner(user_group_id)
+        if owner is not None and owner.user_id == target_user_id:
+            raise ConflictError("不能移除 User Group Owner，请先转让所有权")
         if membership.status is MembershipStatus.REMOVED:
             return
         membership.status = MembershipStatus.REMOVED
@@ -299,7 +325,7 @@ class UserGroupService:
         role: MembershipRole,
     ) -> Membership:
         access = await self._lock_and_authorize_mutation(
-            user_id, user_group_id, needs=UserGroupCapability.MEMBER_MANAGE
+            user_id, user_group_id, needs=UserGroupCapability.MEMBER_ROLE_MANAGE
         )
         _reject_owner_role(role)
         owner = await self._repos.memberships.get_active_owner(user_group_id)

--- a/backend/src/workspace107/domain/capabilities.py
+++ b/backend/src/workspace107/domain/capabilities.py
@@ -13,7 +13,9 @@ class UserGroupCapability(StrEnum):
     USER_GROUP_VIEW = "user_group.view"
     USER_GROUP_UPDATE = "user_group.update"
     MEMBER_VIEW = "member.view"
-    MEMBER_MANAGE = "member.manage"
+    MEMBER_INVITE = "member.invite"
+    MEMBER_REMOVE = "member.remove"
+    MEMBER_ROLE_MANAGE = "member.role.manage"
     OWNERSHIP_TRANSFER = "ownership.transfer"
 
 
@@ -26,11 +28,16 @@ _USER_GROUP_VIEW: frozenset[UserGroupCapability] = frozenset(
 
 _USER_GROUP_ADMINISTER: frozenset[UserGroupCapability] = _USER_GROUP_VIEW | {
     UserGroupCapability.USER_GROUP_UPDATE,
-    UserGroupCapability.MEMBER_MANAGE,
+    UserGroupCapability.MEMBER_INVITE,
+    UserGroupCapability.MEMBER_REMOVE,
 }
 
 USER_GROUP_ROLE_CAPABILITIES: dict[MembershipRole, frozenset[UserGroupCapability]] = {
-    MembershipRole.OWNER: _USER_GROUP_ADMINISTER | {UserGroupCapability.OWNERSHIP_TRANSFER},
+    MembershipRole.OWNER: _USER_GROUP_ADMINISTER
+    | {
+        UserGroupCapability.MEMBER_ROLE_MANAGE,
+        UserGroupCapability.OWNERSHIP_TRANSFER,
+    },
     MembershipRole.ADMIN: _USER_GROUP_ADMINISTER,
     MembershipRole.MEMBER: _USER_GROUP_VIEW,
 }
@@ -54,8 +61,9 @@ class Capability(StrEnum):
 
     # -- 成员 ------------------------------------------------------------
     MEMBER_VIEW = "member.view"
-    MEMBER_MANAGE = "member.manage"
-    """邀请、移除、修改角色。"""
+    MEMBER_INVITE = "member.invite"
+    MEMBER_REMOVE = "member.remove"
+    MEMBER_ROLE_MANAGE = "member.role.manage"
     OWNERSHIP_TRANSFER = "ownership.transfer"
 
     # -- 配置 ------------------------------------------------------------
@@ -115,17 +123,21 @@ _CONTRIBUTE: frozenset[Capability] = _VIEW_ONLY | {
     Capability.SHARED_RESOURCE_VERSION_CREATE,
 }
 
-# 管空间需要的能力：改设置、管人、管配置。
+# 管空间需要的能力：改设置、邀请和移除普通成员、管配置。
 _ADMINISTER: frozenset[Capability] = _CONTRIBUTE | {
     Capability.USER_GROUP_UPDATE,
-    Capability.MEMBER_MANAGE,
+    Capability.MEMBER_INVITE,
+    Capability.MEMBER_REMOVE,
     Capability.CONFIG_MANAGE,
     Capability.GRANT_MANAGE,
 }
 
 ROLE_CAPABILITIES: dict[MembershipRole, frozenset[Capability]] = {
-    # Owner 比 Admin 只多一样：转让所有权。这件事不可逆，只能由所有者本人做。
-    MembershipRole.OWNER: _ADMINISTER | {Capability.OWNERSHIP_TRANSFER},
+    MembershipRole.OWNER: _ADMINISTER
+    | {
+        Capability.MEMBER_ROLE_MANAGE,
+        Capability.OWNERSHIP_TRANSFER,
+    },
     MembershipRole.ADMIN: _ADMINISTER,
     MembershipRole.MEMBER: _CONTRIBUTE,
 }
@@ -135,7 +147,9 @@ CAPABILITY_LABELS: dict[Capability, str] = {
     Capability.USER_GROUP_VIEW: "查看 User Group",
     Capability.USER_GROUP_UPDATE: "修改 User Group 设置",
     Capability.MEMBER_VIEW: "查看成员",
-    Capability.MEMBER_MANAGE: "管理成员",
+    Capability.MEMBER_INVITE: "邀请成员",
+    Capability.MEMBER_REMOVE: "移除成员",
+    Capability.MEMBER_ROLE_MANAGE: "修改成员角色",
     Capability.OWNERSHIP_TRANSFER: "转让 User Group 所有权",
     Capability.CONFIG_VIEW: "查看配置",
     Capability.CONFIG_MANAGE: "管理配置变量与 Secret",
@@ -157,7 +171,9 @@ USER_GROUP_CAPABILITY_LABELS: dict[UserGroupCapability, str] = {
     UserGroupCapability.USER_GROUP_VIEW: "查看 User Group",
     UserGroupCapability.USER_GROUP_UPDATE: "修改 User Group 设置",
     UserGroupCapability.MEMBER_VIEW: "查看成员",
-    UserGroupCapability.MEMBER_MANAGE: "管理成员",
+    UserGroupCapability.MEMBER_INVITE: "邀请成员",
+    UserGroupCapability.MEMBER_REMOVE: "移除成员",
+    UserGroupCapability.MEMBER_ROLE_MANAGE: "修改成员角色",
     UserGroupCapability.OWNERSHIP_TRANSFER: "转让 User Group 所有权",
 }
 

--- a/backend/tests/contract/test_api_contract.py
+++ b/backend/tests/contract/test_api_contract.py
@@ -15,14 +15,22 @@ async def test_user_group_and_legacy_capability_contracts_are_separate(
         "user_group.view",
         "user_group.update",
         "member.view",
-        "member.manage",
+        "member.invite",
+        "member.remove",
+        "member.role.manage",
         "ownership.transfer",
     ]
     assert models["UserGroupOut"]["properties"]["capabilities"]["items"] == {
         "$ref": "#/components/schemas/UserGroupCapability"
     }
+    assert models["MemberOut"]["properties"]["capabilities"]["items"] == {
+        "$ref": "#/components/schemas/UserGroupCapability"
+    }
+    assert set(models["MemberInviteIn"]["properties"]) == {"username"}
+    assert models["MemberInviteIn"]["additionalProperties"] is False
     assert models["LegacyWorkspaceContextOut"]["properties"]["capabilities"]["items"] == {
         "$ref": "#/components/schemas/Capability"
     }
     assert "project.create" in models["Capability"]["enum"]
+    assert "member.manage" not in models["Capability"]["enum"]
     assert "run.submit" in models["Capability"]["enum"]

--- a/backend/tests/integration/identity/test_user_groups.py
+++ b/backend/tests/integration/identity/test_user_groups.py
@@ -32,11 +32,10 @@ async def _invite(
     username: str,
     *,
     headers: dict[str, str] = ALICE,
-    role: str = "member",
 ) -> httpx.Response:
     return await client.post(
         f"/api/v1/user-groups/{group_id}/members",
-        json={"username": username, "role": role},
+        json={"username": username},
         headers=headers,
     )
 
@@ -127,14 +126,17 @@ async def test_user_group_capabilities_are_governance_only_for_every_role(
     group_id = str(group["id"])
     expected = {
         "owner": [
-            "member.manage",
+            "member.invite",
+            "member.remove",
+            "member.role.manage",
             "member.view",
             "ownership.transfer",
             "user_group.update",
             "user_group.view",
         ],
         "admin": [
-            "member.manage",
+            "member.invite",
+            "member.remove",
             "member.view",
             "user_group.update",
             "user_group.view",
@@ -143,11 +145,8 @@ async def test_user_group_capabilities_are_governance_only_for_every_role(
     }
     assert group["capabilities"] == expected["owner"]
 
-    for username, role, headers in (
-        ("bob", "admin", BOB),
-        ("carol", "member", CAROL),
-    ):
-        assert (await _invite(client, group_id, username, role=role)).status_code == 201
+    for username, headers in (("bob", BOB), ("carol", CAROL)):
+        assert (await _invite(client, group_id, username)).status_code == 201
         assert (
             await client.post(
                 f"/api/v1/user-groups/{group_id}/invitation",
@@ -155,6 +154,16 @@ async def test_user_group_capabilities_are_governance_only_for_every_role(
                 headers=headers,
             )
         ).status_code == 204
+
+    members = (await client.get(f"/api/v1/user-groups/{group_id}/members", headers=ALICE)).json()
+    bob_id = next(member["user_id"] for member in members if member["username"] == "bob")
+    assert (
+        await client.patch(
+            f"/api/v1/user-groups/{group_id}/members/{bob_id}",
+            json={"role": "admin"},
+            headers=ALICE,
+        )
+    ).status_code == 200
 
     for role, headers in (
         ("owner", ALICE),
@@ -227,28 +236,117 @@ async def test_invitation_accept_reject_and_cross_group_404(
 
 
 @pytest.mark.asyncio
-async def test_admin_and_member_roles_change_through_ordinary_update(
+async def test_owner_changes_roles_and_admin_cannot(
     client: httpx.AsyncClient,
 ) -> None:
+    for headers in (BOB, CAROL):
+        await client.get("/api/v1/me", headers=headers)
     group_id, bob_id = await _group_with_active_bob(client, "Role Change Lab")
+    assert (await _invite(client, group_id, "carol")).status_code == 201
+    assert (
+        await client.post(
+            f"/api/v1/user-groups/{group_id}/invitation",
+            json={"accept": True},
+            headers=CAROL,
+        )
+    ).status_code == 204
+    members = (await client.get(f"/api/v1/user-groups/{group_id}/members", headers=ALICE)).json()
+    carol_id = next(member["user_id"] for member in members if member["username"] == "carol")
+
+    assert (
+        await client.patch(
+            f"/api/v1/user-groups/{group_id}/members/{bob_id}",
+            json={"role": "admin"},
+            headers=ALICE,
+        )
+    ).status_code == 200
+    assert (
+        await client.patch(
+            f"/api/v1/user-groups/{group_id}/members/{carol_id}",
+            json={"role": "admin"},
+            headers=BOB,
+        )
+    ).status_code == 403
 
     promoted = await client.patch(
-        f"/api/v1/user-groups/{group_id}/members/{bob_id}",
+        f"/api/v1/user-groups/{group_id}/members/{carol_id}",
         json={"role": "admin"},
         headers=ALICE,
     )
     assert promoted.status_code == 200
-    members = (await client.get(f"/api/v1/user-groups/{group_id}/members", headers=ALICE)).json()
-    assert next(member for member in members if member["user_id"] == bob_id)["role"] == "admin"
-
+    assert promoted.json()["role"] == "admin"
     demoted = await client.patch(
-        f"/api/v1/user-groups/{group_id}/members/{bob_id}",
+        f"/api/v1/user-groups/{group_id}/members/{carol_id}",
         json={"role": "member"},
         headers=ALICE,
     )
     assert demoted.status_code == 200
+    assert demoted.json()["role"] == "member"
+
+
+@pytest.mark.asyncio
+async def test_admin_governs_only_ordinary_members(client: httpx.AsyncClient) -> None:
+    for headers in (BOB, CAROL, DAVE):
+        await client.get("/api/v1/me", headers=headers)
+    group_id, bob_id = await _group_with_active_bob(client, "Admin Governance Lab")
+    assert (await _invite(client, group_id, "carol")).status_code == 201
+    assert (
+        await client.post(
+            f"/api/v1/user-groups/{group_id}/invitation",
+            json={"accept": True},
+            headers=CAROL,
+        )
+    ).status_code == 204
     members = (await client.get(f"/api/v1/user-groups/{group_id}/members", headers=ALICE)).json()
-    assert next(member for member in members if member["user_id"] == bob_id)["role"] == "member"
+    alice_id = next(member["user_id"] for member in members if member["username"] == "alice")
+    carol_id = next(member["user_id"] for member in members if member["username"] == "carol")
+    assert (
+        await client.patch(
+            f"/api/v1/user-groups/{group_id}/members/{bob_id}",
+            json={"role": "admin"},
+            headers=ALICE,
+        )
+    ).status_code == 200
+
+    admin_members = (
+        await client.get(f"/api/v1/user-groups/{group_id}/members", headers=BOB)
+    ).json()
+    assert (
+        next(member for member in admin_members if member["user_id"] == alice_id)["capabilities"]
+        == []
+    )
+    assert (
+        next(member for member in admin_members if member["user_id"] == bob_id)["capabilities"]
+        == []
+    )
+    assert next(member for member in admin_members if member["user_id"] == carol_id)[
+        "capabilities"
+    ] == ["member.remove"]
+
+    assert (
+        await client.post(
+            f"/api/v1/user-groups/{group_id}/members",
+            json={"username": "dave", "role": "admin"},
+            headers=BOB,
+        )
+    ).status_code == 422
+    invited = await _invite(client, group_id, "dave", headers=BOB)
+    assert invited.status_code == 201
+    assert invited.json()["role"] == "member"
+    assert (await _invite(client, group_id, "dave", headers=CAROL)).status_code == 403
+
+    assert (
+        await client.delete(f"/api/v1/user-groups/{group_id}/members/{bob_id}", headers=BOB)
+    ).status_code == 403
+    assert (
+        await client.delete(f"/api/v1/user-groups/{group_id}/members/{alice_id}", headers=BOB)
+    ).status_code == 403
+    assert (
+        await client.delete(f"/api/v1/user-groups/{group_id}/members/{carol_id}", headers=BOB)
+    ).status_code == 204
+    assert (
+        await client.delete(f"/api/v1/user-groups/{group_id}/members/{bob_id}", headers=ALICE)
+    ).status_code == 204
 
 
 @pytest.mark.asyncio
@@ -258,7 +356,13 @@ async def test_owner_role_only_changes_through_atomic_transfer(client: httpx.Asy
     group = await _create_group(client, ALICE, "Transfer Lab")
     group_id = str(group["id"])
 
-    assert (await _invite(client, group_id, "bob", role="owner")).status_code == 409
+    assert (
+        await client.post(
+            f"/api/v1/user-groups/{group_id}/members",
+            json={"username": "bob", "role": "owner"},
+            headers=ALICE,
+        )
+    ).status_code == 422
     assert (await _invite(client, group_id, "bob")).status_code == 201
     assert (await _invite(client, group_id, "carol")).status_code == 201
     for headers in (BOB, CAROL):
@@ -368,7 +472,7 @@ async def test_concurrent_transfer_and_remove_preserve_an_active_owner(
         client.delete(f"/api/v1/user-groups/{group_id}/members/{bob_id}", headers=ALICE),
     )
 
-    assert (transfer.status_code, remove.status_code) in {(204, 409), (404, 204)}
+    assert (transfer.status_code, remove.status_code) in {(204, 403), (404, 204)}
     await _assert_exactly_one_active_owner(client, group_id)
 
 
@@ -402,5 +506,5 @@ async def test_concurrent_transfer_and_role_change_preserve_an_active_owner(
         ),
     )
 
-    assert (transfer.status_code, role_change.status_code) in {(204, 409), (204, 200)}
+    assert (transfer.status_code, role_change.status_code) in {(204, 403), (204, 200)}
     await _assert_exactly_one_active_owner(client, group_id)

--- a/backend/tests/integration/postgres/test_user_group_postgres.py
+++ b/backend/tests/integration/postgres/test_user_group_postgres.py
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from workspace107.api.deps import build_services
 from workspace107.config import Settings, get_settings
-from workspace107.domain.enums import MembershipRole
 from workspace107.domain.errors import ConflictError, ObjectNotFound, PermissionDenied
 from workspace107.main import build_context
 
@@ -258,9 +257,7 @@ async def test_postgresql_owner_race_serializes_transfer_and_removal(tmp_path: P
             alice = await services.identity.ensure_user("race_alice", "Race Alice")
             bob = await services.identity.ensure_user("race_bob", "Race Bob")
             group = await services.user_groups.create(alice.id, "Race Group")
-            await services.user_groups.invite_member(
-                alice.id, group.user_group.id, bob.username, MembershipRole.ADMIN
-            )
+            await services.user_groups.invite_member(alice.id, group.user_group.id, bob.username)
             await services.user_groups.respond_to_invitation(
                 bob.id, group.user_group.id, accept=True
             )

--- a/backend/tests/integration/test_seed.py
+++ b/backend/tests/integration/test_seed.py
@@ -101,7 +101,6 @@ async def test_issue_39_demo_seed_uses_explicit_bootstrap_owner_and_preserves_tr
         initial_owner_id,
         PLATFORM_ASSET_GROUP_ID,
         successor.username,
-        MembershipRole.ADMIN,
     )
     await services.user_groups.respond_to_invitation(
         successor.id, PLATFORM_ASSET_GROUP_ID, accept=True

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -280,7 +280,9 @@
           "user_group.view",
           "user_group.update",
           "member.view",
-          "member.manage",
+          "member.invite",
+          "member.remove",
+          "member.role.manage",
           "ownership.transfer",
           "config.view",
           "config.manage",
@@ -1072,11 +1074,8 @@
         "type": "string"
       },
       "MemberInviteIn": {
+        "additionalProperties": false,
         "properties": {
-          "role": {
-            "$ref": "#/components/schemas/MembershipRole",
-            "default": "member"
-          },
           "username": {
             "title": "Username",
             "type": "string"
@@ -1090,6 +1089,13 @@
       },
       "MemberOut": {
         "properties": {
+          "capabilities": {
+            "items": {
+              "$ref": "#/components/schemas/UserGroupCapability"
+            },
+            "title": "Capabilities",
+            "type": "array"
+          },
           "display_name": {
             "title": "Display Name",
             "type": "string"
@@ -2948,7 +2954,9 @@
           "user_group.view",
           "user_group.update",
           "member.view",
-          "member.manage",
+          "member.invite",
+          "member.remove",
+          "member.role.manage",
           "ownership.transfer"
         ],
         "title": "UserGroupCapability",

--- a/docs/product/design.md
+++ b/docs/product/design.md
@@ -85,6 +85,8 @@
 
 User Group 是平台中的用户协作组织。User 可通过独立 Membership 加入多个 User Group。跨 Owner 使用资产需要显式 USE Grant。
 
+当前治理角色采用 Owner / Admin / Member 三级模型。所有有效成员均可查看成员列表；Owner 可以邀请普通 Member、移除 Member 或 Admin，并可在 Member 与 Admin 之间显式变更角色；Admin 只能邀请普通 Member、移除普通 Member，不能变更任何成员角色或移除 Admin / Owner；Member 不具有成员治理权限。普通邀请只创建 Member，Owner 只能通过所有权转移用例产生或取消，不能通过普通角色变更完成。
+
 ```text
 User Group、成员与共享资产
 │
@@ -1735,7 +1737,7 @@ User 必须通过对应 User Group 的有效 Membership，才能以该组成员�
 
 ##### **GR-103 — Membership Role 权限**
 
-User 在一个 User Group 中可执行的操作必须受该 Membership 的 Role 和 Status 约束；同一 User 在其他 User Group 中的 Membership、Role 或 Status 不参与判断。
+User 在一个 User Group 中可执行的操作必须受该 Membership 的 Role 和 Status 约束；同一 User 在其他 User Group 中的 Membership、Role 或 Status 不参与判断。所有有效角色均可查看成员；Owner 可以邀请普通 Member、移除 Member 或 Admin、在 Member 与 Admin 之间变更角色并转移所有权；Admin 只能邀请和移除普通 Member；Member 不具有成员治理权限。普通邀请只产生 Member，Owner 身份只能通过所有权转移改变。
 
 ##### **GR-104 — User Group 所有权**
 
@@ -1957,7 +1959,7 @@ Activity 没有未读、完成或送达状态，也不替代 Notification、Audi
 
 ##### 管理 Membership
 
-User Group 可以建立 Membership、变更 Role 和 Status、退出或移除成员；变更仅影响对应 User 在该组中的成员身份和操作权限，不改变组拥有的对象，并须保持唯一有效 Owner。
+User Group 可以建立 Membership、变更 Role 和 Status、退出或移除成员；变更仅影响对应 User 在该组中的成员身份和操作权限，不改变组拥有的对象，并须保持唯一有效 Owner。普通邀请只建立 Member；只有 Owner 可以在 Member 与 Admin 之间变更 Role，Admin 只能邀请和移除普通 Member；Owner 不得通过普通 Role 变更产生或取消。
 
 ##### 转移 User Group Owner
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -230,11 +230,11 @@ export const api = {
       }),
     ),
 
-  inviteMember: async (id: string, username: string, role: MembershipRole): Promise<Member> =>
+  inviteMember: async (id: string, username: string): Promise<Member> =>
     unwrap(
       await http.POST('/api/v1/user-groups/{user_group_id}/members', {
         params: { path: { user_group_id: id } },
-        body: { username, role },
+        body: { username },
       }),
     ),
 

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1524,7 +1524,7 @@ export interface components {
          *     命名统一为 ``对象.动作``，方便在日志和错误信息里直接读。
          * @enum {string}
          */
-        Capability: "user_group.view" | "user_group.update" | "member.view" | "member.manage" | "ownership.transfer" | "config.view" | "config.manage" | "project.view" | "project.create" | "project.update" | "project.content.write" | "run_configuration.manage" | "run.view" | "run.submit" | "run.cancel" | "shared_resource.view" | "shared_resource.manage" | "shared_resource.version.create" | "grant.manage";
+        Capability: "user_group.view" | "user_group.update" | "member.view" | "member.invite" | "member.remove" | "member.role.manage" | "ownership.transfer" | "config.view" | "config.manage" | "project.view" | "project.create" | "project.update" | "project.content.write" | "run_configuration.manage" | "run.view" | "run.submit" | "run.cancel" | "shared_resource.view" | "shared_resource.manage" | "shared_resource.version.create" | "grant.manage";
         /**
          * ChangeKind
          * @description 文件在两次快照之间的变化类型。
@@ -1895,13 +1895,13 @@ export interface components {
         LogStream: "stdout" | "stderr";
         /** MemberInviteIn */
         MemberInviteIn: {
-            /** @default member */
-            role: components["schemas"]["MembershipRole"];
             /** Username */
             username: string;
         };
         /** MemberOut */
         MemberOut: {
+            /** Capabilities */
+            capabilities?: components["schemas"]["UserGroupCapability"][];
             /** Display Name */
             display_name: string;
             role: components["schemas"]["MembershipRole"];
@@ -2585,7 +2585,7 @@ export interface components {
          * @description Stable public capabilities for User Group and Membership governance.
          * @enum {string}
          */
-        UserGroupCapability: "user_group.view" | "user_group.update" | "member.view" | "member.manage" | "ownership.transfer";
+        UserGroupCapability: "user_group.view" | "user_group.update" | "member.view" | "member.invite" | "member.remove" | "member.role.manage" | "ownership.transfer";
         /** UserGroupCreateIn */
         UserGroupCreateIn: {
             /**

--- a/frontend/src/components/workspace/MemberPanel.tsx
+++ b/frontend/src/components/workspace/MemberPanel.tsx
@@ -1,4 +1,4 @@
-import { Button, Form, Input, Popconfirm, Select, Space, Table, Tag, message } from 'antd'
+import { Button, Form, Input, Popconfirm, Space, Table, Tag, message } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { useState } from 'react'
 
@@ -12,12 +12,9 @@ import { AsyncSection } from '../common/AsyncSection'
 import { RoleTag } from '../common/RoleTag'
 
 /**
- * 可以指派的角色。
- *
- * Owner 不在其中：换所有者是一次明确的交接，走转让流程，
- * 不能靠改角色造出第二个所有者。
+ * Membership roles are static identity information in the table. The server
+ * projects contextual governance capabilities for each target member.
  */
-const ASSIGNABLE_ROLES = ['admin', 'member'] as const satisfies readonly MembershipRole[]
 
 interface Props {
   userGroup: UserGroup
@@ -25,15 +22,16 @@ interface Props {
 
 export function MemberPanel({ userGroup }: Props) {
   const members = useAsync<Member[]>(() => api.listMembers(userGroup.id), [userGroup.id])
-  const [form] = Form.useForm<{ username: string; role: MembershipRole }>()
+  const [form] = Form.useForm<{ username: string }>()
   const [inviting, setInviting] = useState(false)
-  const canManage = can(userGroup, 'member.manage')
+  const canInvite = can(userGroup, 'member.invite')
+  const canGovernMembers = can(userGroup, 'member.remove') || can(userGroup, 'member.role.manage')
 
   const invite = async () => {
     const values = await form.validateFields()
     setInviting(true)
     try {
-      await api.inviteMember(userGroup.id, values.username, values.role ?? 'member')
+      await api.inviteMember(userGroup.id, values.username)
       message.success(`已向 ${values.username} 发送邀请`)
       form.resetFields()
       members.reload()
@@ -71,23 +69,7 @@ export function MemberPanel({ userGroup }: Props) {
       title: '角色',
       dataIndex: field<Member>('role'),
       width: 160,
-      render: (role: MembershipRole, member) => {
-        if (!canManage || role === 'owner') {
-          return <RoleTag role={role} />
-        }
-        return (
-          <Select
-            size="small"
-            value={role}
-            style={{ width: 120 }}
-            onChange={(next) => changeRole(member, next)}
-            options={ASSIGNABLE_ROLES.map((value) => ({
-              value,
-              label: roleLabel(value),
-            }))}
-          />
-        )
-      },
+      render: (role: MembershipRole) => <RoleTag role={role} />,
     },
     {
       title: '状态',
@@ -98,46 +80,54 @@ export function MemberPanel({ userGroup }: Props) {
     },
   ]
 
-  if (canManage) {
+  if (canGovernMembers) {
     columns.push({
       title: '操作',
-      width: 100,
-      render: (_, member) =>
-        member.role === 'owner' ? null : (
-          <Popconfirm
-            title={`移除 ${member.username}？`}
-            description="移除后该成员立刻失去这个 User Group 的访问权。"
-            okText="移除"
-            cancelText="取消"
-            onConfirm={() => remove(member)}
-          >
-            <Button type="link" danger size="small">
-              移除
-            </Button>
-          </Popconfirm>
-        ),
+      width: 180,
+      render: (_, member) => {
+        const canChangeRole = can(member, 'member.role.manage')
+        const canRemove = can(member, 'member.remove')
+        if (!canChangeRole && !canRemove) return null
+        return (
+          <Space size="small">
+            {canChangeRole && (
+              <Button
+                type="link"
+                size="small"
+                onClick={() => changeRole(member, member.role === 'admin' ? 'member' : 'admin')}
+              >
+                {member.role === 'admin' ? '设为普通成员' : '设为管理员'}
+              </Button>
+            )}
+            {canRemove && (
+              <Popconfirm
+                title={`移除 ${member.username}？`}
+                description="移除后该成员立刻失去这个 User Group 的访问权。"
+                okText="移除"
+                cancelText="取消"
+                onConfirm={() => remove(member)}
+              >
+                <Button type="link" danger size="small">
+                  移除
+                </Button>
+              </Popconfirm>
+            )}
+          </Space>
+        )
+      },
     })
   }
 
   return (
     <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-      {canManage && (
-        <Form form={form} layout="inline" initialValues={{ role: 'member' }}>
+      {canInvite && (
+        <Form form={form} layout="inline">
           <Form.Item
             name="username"
             rules={[{ required: true, message: '请填写用户名' }]}
             style={{ minWidth: 220 }}
           >
             <Input placeholder="要邀请的用户名" />
-          </Form.Item>
-          <Form.Item name="role">
-            <Select
-              style={{ width: 120 }}
-              options={ASSIGNABLE_ROLES.map((value) => ({
-                value,
-                label: roleLabel(value),
-              }))}
-            />
           </Form.Item>
           <Form.Item>
             <Button type="primary" onClick={invite} loading={inviting}>

--- a/frontend/tests/component/UserGroupBoundary.test.tsx
+++ b/frontend/tests/component/UserGroupBoundary.test.tsx
@@ -22,7 +22,13 @@ const group: UserGroup = {
   created_by_id: 'usr_alice',
   created_at: '2026-08-17T00:00:00Z',
   role: 'owner',
-  capabilities: ['user_group.view', 'member.view', 'member.manage'],
+  capabilities: [
+    'user_group.view',
+    'member.view',
+    'member.invite',
+    'member.remove',
+    'member.role.manage',
+  ],
 }
 
 const homeState = {


### PR DESCRIPTION
## 关联 Issue

Closes #70

## 修改内容

- 收敛 User Group Owner / Admin / Member 治理权限，明确服务端授权边界与 capability projection，确保越权路径 fail closed。
- 更新生成的 API contract / OpenAPI 与前端类型及相关文档，迁移调用方到 canonical contract。
- 保持 User Group owner/member 治理语义一致：服务端逐请求授权，前端只投影服务端返回的 capability。

## 验证证据

- focused HTTP/contract：13 passed。
- `make contract-check`：通过。
- targeted frontend component：3 passed；typecheck 通过。
- full `make check`：通过（backend 271 passed，3 skipped；frontend 116 passed）。
- independent authz/public-contract review：PASS。
- 证据边界：无 live PostgreSQL 时跳过 PostgreSQL-specific locking test；browser smoke 使用 intercepted API，而非 live backend。

## 影响范围

- 认证/授权：User Group Owner / Admin / Member 治理与 capability projection 收敛；服务端授权为最终边界。
- API contract：生成的 contract/docs 与前端类型已同步更新。
- 前端：相关组件按 capability 渲染并完成 targeted component/typecheck 验证。

## 延后事项与实现妥协

- Deferred ID：无

## 按需检查

- [x] API 发生变化：OpenAPI 与前端生成类型已同步并提交
- [x] 认证或授权发生变化：正常路径与越权路径均有验证证据
