### PR TITLE
refactor(frontend): 收敛 AppShell Project Context 导航

### DIFF
--- a/backend/src/workspace107/api/routes/projects.py
+++ b/backend/src/workspace107/api/routes/projects.py
@@ -10,7 +10,8 @@ from fastapi.responses import Response
 
 from ...application.run_configuration_service import RunConfigurationInput
 from ...domain.enums import ProjectStatus
-from ...domain.ownership import OwnerReference
+from ...domain.errors import ValidationFailed
+from ...domain.ownership import OwnerKind, OwnerReference
 from .. import presenters as p
 from .. import schemas as s
 from ..deps import CurrentUser, PageDep, ServicesDep
@@ -24,10 +25,27 @@ MAX_TEXT_PREVIEW = 256 * 1024
     "/projects", response_model=s.PageOut[s.ProjectOut], summary="列出当前用户可发现的 Project"
 )
 async def list_discoverable_projects(
-    user: CurrentUser, services: ServicesDep, page: PageDep
+    user: CurrentUser,
+    services: ServicesDep,
+    page: PageDep,
+    owner_kind: OwnerKind | None = Query(None, description="按 Owner 种类过滤"),
+    owner_id: str | None = Query(None, description="按 Owner ID 过滤"),
+    query: str | None = Query(None, description="按 Project 名称搜索", max_length=255),
 ) -> s.PageOut[s.ProjectOut]:
     """列出当前用户可发现的 Project：自己 / 所属 User Group 拥有的，以及 PUBLIC Project。"""
-    result = await services.projects.list_discoverable_for_user(user.id, page)
+    if (owner_kind is None) != (owner_id is None):
+        raise ValidationFailed("owner_kind 与 owner_id 必须同时提供")
+    owner = (
+        OwnerReference(kind=owner_kind, id=owner_id)
+        if owner_kind is not None and owner_id is not None
+        else None
+    )
+    result = await services.projects.list_discoverable_for_user(
+        user.id,
+        page,
+        owner=owner,
+        query=query,
+    )
     summaries = await services.projects.owner_summaries(result.items)
     return p.page_out(
         result,

--- a/backend/src/workspace107/application/project_service.py
+++ b/backend/src/workspace107/application/project_service.py
@@ -160,8 +160,20 @@ class ProjectService:
     async def list_recent_for_user(self, user_id: str, *, limit: int = 10) -> list[Project]:
         return await self._repos.projects.list_for_user(user_id, limit=limit)
 
-    async def list_discoverable_for_user(self, user_id: str, page: PageRequest) -> Page[Project]:
-        return await self._repos.projects.list_discoverable_for_user(user_id, page)
+    async def list_discoverable_for_user(
+        self,
+        user_id: str,
+        page: PageRequest,
+        *,
+        owner: OwnerReference | None = None,
+        query: str | None = None,
+    ) -> Page[Project]:
+        return await self._repos.projects.list_discoverable_for_user(
+            user_id,
+            page,
+            owner=owner,
+            query=query,
+        )
 
     async def get(self, user_id: str, project_id: str) -> ProjectAccess:
         return await self._guard.project(user_id, project_id)

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -84,8 +84,15 @@ class ProjectRepository(Protocol):
         """按最近更新时间列出用户可见的 Project，用于个人首页。"""
         ...
 
-    async def list_discoverable_for_user(self, user_id: str, page: PageRequest) -> Page[Project]:
-        """列出用户可发现的 Project：Owner scope + PUBLIC。"""
+    async def list_discoverable_for_user(
+        self,
+        user_id: str,
+        page: PageRequest,
+        *,
+        owner: OwnerReference | None = None,
+        query: str | None = None,
+    ) -> Page[Project]:
+        """列出用户可发现的 Project，可按 Owner 与名称过滤。"""
         ...
 
     async def name_exists(self, owner: OwnerReference, name: str) -> bool: ...

--- a/backend/src/workspace107/infrastructure/db/repositories.py
+++ b/backend/src/workspace107/infrastructure/db/repositories.py
@@ -440,7 +440,14 @@ class ProjectRepositoryImpl:
         rows = (await self._session.execute(stmt)).scalars().all()
         return [_to_project(row) for row in rows]
 
-    async def list_discoverable_for_user(self, user_id: str, page: PageRequest) -> Page[Project]:
+    async def list_discoverable_for_user(
+        self,
+        user_id: str,
+        page: PageRequest,
+        *,
+        owner: OwnerReference | None = None,
+        query: str | None = None,
+    ) -> Page[Project]:
         # Owner scope + PUBLIC projects the User can discover.
         group_ids = select(t.MembershipRow.user_group_id).where(
             t.MembershipRow.user_id == user_id,
@@ -449,11 +456,20 @@ class ProjectRepositoryImpl:
         owner_scope = (
             t.ProjectRow.owner_user_id == user_id
         ) | t.ProjectRow.owner_user_group_id.in_(group_ids)
-        stmt = (
-            select(t.ProjectRow)
-            .where((t.ProjectRow.visibility == ProjectVisibility.PUBLIC.value) | owner_scope)
-            .order_by(t.ProjectRow.updated_at.desc())
+        stmt = select(t.ProjectRow).where(
+            (t.ProjectRow.visibility == ProjectVisibility.PUBLIC.value) | owner_scope
         )
+        if owner is not None:
+            owner_column = (
+                t.ProjectRow.owner_user_id
+                if owner.kind is OwnerKind.USER
+                else t.ProjectRow.owner_user_group_id
+            )
+            stmt = stmt.where(owner_column == owner.id)
+        normalized_query = query.strip() if query else ""
+        if normalized_query:
+            stmt = stmt.where(t.ProjectRow.name.icontains(normalized_query, autoescape=True))
+        stmt = stmt.order_by(t.ProjectRow.updated_at.desc())
         return await _paginate(self._session, stmt, page, _to_project)
 
     async def name_exists(self, owner: OwnerReference, name: str) -> bool:

--- a/backend/tests/integration/test_project_ownership.py
+++ b/backend/tests/integration/test_project_ownership.py
@@ -175,6 +175,48 @@ async def test_discovery_lists_public_projects_but_home_feed_does_not(client) ->
 
 
 @pytest.mark.asyncio
+async def test_project_discovery_filters_by_owner_and_name(client) -> None:
+    owner_id = await ensure_user_group(client, headers=ALICE)
+    other_owner = await client.post(
+        "/api/v1/user-groups",
+        json={"name": "Other Owner", "description": ""},
+        headers=ALICE,
+    )
+    assert other_owner.status_code == 201, other_owner.text
+    other_owner_id = other_owner.json()["id"]
+    for group_id, name in (
+        (owner_id, "Target Training"),
+        (owner_id, "Other Work"),
+        (other_owner_id, "Target Elsewhere"),
+    ):
+        created = await client.post(
+            "/api/v1/projects",
+            json={"owner": {"kind": "user_group", "id": group_id}, "name": name},
+            headers=ALICE,
+        )
+        assert created.status_code == 201, created.text
+
+    response = await client.get(
+        "/api/v1/projects",
+        params={
+            "owner_kind": "user_group",
+            "owner_id": owner_id,
+            "query": "training",
+        },
+        headers=ALICE,
+    )
+    assert response.status_code == 200, response.text
+    assert [item["name"] for item in response.json()["items"]] == ["Target Training"]
+
+    incomplete = await client.get(
+        "/api/v1/projects",
+        params={"owner_kind": "user_group"},
+        headers=ALICE,
+    )
+    assert incomplete.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_public_version_can_be_forked_to_requesting_user_owner(client, session) -> None:
     group_id = await ensure_user_group(client, headers=ALICE)
     env_version_id = await _group_environment_version(session, group_id)

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -6204,6 +6204,61 @@
         "operationId": "list_discoverable_projects_api_v1_projects_get",
         "parameters": [
           {
+            "description": "按 Owner 种类过滤",
+            "in": "query",
+            "name": "owner_kind",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OwnerKind"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按 Owner 种类过滤",
+              "title": "Owner Kind"
+            }
+          },
+          {
+            "description": "按 Owner ID 过滤",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按 Owner ID 过滤",
+              "title": "Owner Id"
+            }
+          },
+          {
+            "description": "按 Project 名称搜索",
+            "in": "query",
+            "name": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 255,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "按 Project 名称搜索",
+              "title": "Query"
+            }
+          },
+          {
             "description": "页码，从 1 开始",
             "in": "query",
             "name": "page",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,10 @@
 import { App as AntdApp, ConfigProvider } from 'antd'
 import zhCN from 'antd/locale/zh_CN'
 import { lazy, Suspense, useCallback, useRef, useState } from 'react'
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { matchPath, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
 import { api, getCurrentUser, setCurrentUser } from './api/client'
-import type { Home } from './api/types'
+import type { Home, Project } from './api/types'
 import { useAsync, type AsyncState as AsyncResource } from './api/useAsync'
 import { AppShell } from './components/layout/AppShell'
 import { ArtifactFilePreviewPage } from './pages/ArtifactFilePreviewPage'
@@ -76,6 +76,7 @@ function ProductSession({
   username: string
   onUsernameChange: (username: string) => void
 }) {
+  const location = useLocation()
   const homeRequest = useRef<Promise<Home> | null>(null)
   const loadHome = () => {
     if (homeRequest.current) return homeRequest.current
@@ -88,15 +89,37 @@ function ProductSession({
     return request
   }
   const home = useAsync<Home>(loadHome, [username])
+  const projectId = matchPath('/projects/:projectId/*', location.pathname)?.params.projectId
+  const project = useAsync<Project | undefined>(
+    () => (projectId ? api.getProject(projectId) : Promise.resolve(undefined)),
+    [username, projectId],
+  )
+  const routedProject: AsyncResource<Project | undefined> = {
+    ...project,
+    data: project.data?.id === projectId ? project.data : undefined,
+  }
 
   return (
-    <AppShell username={username} onUsernameChange={onUsernameChange} home={home}>
-      <ProductRoutes username={username} home={home} />
+    <AppShell
+      username={username}
+      onUsernameChange={onUsernameChange}
+      home={home}
+      project={routedProject}
+    >
+      <ProductRoutes username={username} home={home} project={routedProject} />
     </AppShell>
   )
 }
 
-export function ProductRoutes({ username, home }: { username: string; home: AsyncResource<Home> }) {
+export function ProductRoutes({
+  username,
+  home,
+  project,
+}: {
+  username: string
+  home: AsyncResource<Home>
+  project: AsyncResource<Project | undefined>
+}) {
   return (
     <Routes>
       <Route path="/" element={<HomePage username={username} home={home} />} />
@@ -107,8 +130,16 @@ export function ProductRoutes({ username, home }: { username: string; home: Asyn
         path="/environment-versions/:versionId"
         element={<EnvironmentVersionPage key={username} />}
       />
-      <Route path="/projects/:projectId" element={<ProjectPage key={username} />} />
-      <Route path="/projects/:projectId/runs/:runId" element={<RunPage key={username} />} />
+      <Route
+        path="/projects/:projectId"
+        element={<ProjectPage key={username} project={project} />}
+      />
+      <Route
+        path="/projects/:projectId/runs/:runId"
+        element={
+          <RunPage key={username} />
+        }
+      />
       <Route
         path="/projects/:projectId/runs/:runId/artifacts/:artifactId/file"
         element={<ArtifactFilePreviewPage key={username} />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -134,12 +134,7 @@ export function ProductRoutes({
         path="/projects/:projectId"
         element={<ProjectPage key={username} project={project} />}
       />
-      <Route
-        path="/projects/:projectId/runs/:runId"
-        element={
-          <RunPage key={username} />
-        }
-      />
+      <Route path="/projects/:projectId/runs/:runId" element={<RunPage key={username} />} />
       <Route
         path="/projects/:projectId/runs/:runId/artifacts/:artifactId/file"
         element={<ArtifactFilePreviewPage key={username} />}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -34,7 +34,9 @@ import type {
   PreflightResult,
   PageQuery,
   ForkSource,
+  OwnerReference,
   Project,
+  ProjectPage,
   ProjectFile,
   ProjectVersion,
   ProjectVersionPage,
@@ -338,6 +340,21 @@ export const api = {
     unwrap(await http.GET('/api/v1/me/entitlements')),
 
   // -- Project -----------------------------------------------------------
+  listOwnerProjects: async (
+    owner: OwnerReference,
+    options: PageQuery & { query?: string } = {},
+  ): Promise<ProjectPage> =>
+    unwrap(
+      await http.GET('/api/v1/projects', {
+        params: {
+          query: {
+            ...options,
+            owner_kind: owner.kind,
+            owner_id: owner.id,
+          },
+        },
+      }),
+    ),
 
   getProject: async (id: string): Promise<Project> =>
     unwrap(

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4891,6 +4891,12 @@ export interface operations {
     list_discoverable_projects_api_v1_projects_get: {
         parameters: {
             query?: {
+                /** @description 按 Owner 种类过滤 */
+                owner_kind?: components["schemas"]["OwnerKind"] | null;
+                /** @description 按 Owner ID 过滤 */
+                owner_id?: string | null;
+                /** @description 按 Project 名称搜索 */
+                query?: string | null;
                 /** @description 页码，从 1 开始 */
                 page?: number;
                 /** @description 每页条数 */

--- a/frontend/src/components/layout/AppShell.module.css
+++ b/frontend/src/components/layout/AppShell.module.css
@@ -9,9 +9,13 @@
   border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
 }
 
+.projectHeader {
+  border-bottom: 0;
+}
+
 .headerInner {
-  min-height: var(--base-size-48);
-  padding: var(--base-size-8) var(--base-size-24);
+  padding-block: var(--base-size-12);
+  padding-inline: var(--base-size-16);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -28,23 +32,118 @@
   gap: var(--base-size-8);
 }
 
-.brand {
+.homeMarkVisual {
+  display: inline-flex;
+  width: var(--base-size-24);
+  height: var(--base-size-24);
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-body-size-small);
+  font-weight: var(--base-text-weight-semibold);
+  line-height: 1;
+}
+
+.homeContext {
   min-width: 0;
   overflow: hidden;
   color: var(--fgColor-default);
-  font-size: var(--text-title-size-small);
-  font-weight: var(--text-title-weight-small);
-  text-decoration: none;
+  font-size: var(--text-body-size-medium);
+  font-weight: var(--base-text-weight-semibold);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.brand:focus-visible {
-  outline: var(--borderWidth-thick) solid var(--focus-outlineColor);
-  outline-offset: 2px;
+
+.projectContext {
+  display: flex;
+  flex: 1 1 auto;
+  height: var(--base-size-32);
+  min-width: 0;
+  align-items: center;
+  gap: var(--base-size-2);
+  overflow: hidden;
+  white-space: nowrap;
+  color: var(--fgColor-default);
 }
 
-.brand:hover {
-  color: var(--fgColor-default);
+.projectContextItem,
+.projectContextLabel {
+  min-width: 0;
+}
+
+.projectContext a.projectContextItem {
+  color: inherit;
+}
+.projectContextItem [data-component='buttonContent'] {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.projectContextItem [data-component='text'] {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+.projectContextLabel {
+  display: block;
+  min-width: 3ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.projectOwner,
+.projectName {
+  min-width: calc(3ch + 2 * var(--control-medium-paddingInline-normal));
+}
+
+.projectOwner {
+  flex: 0 2 auto;
+  min-width: calc(3ch + 2 * var(--base-size-6));
+  padding-inline: var(--base-size-6);
+}
+
+.projectName {
+  flex: 0 1 auto;
+  font-weight: var(--base-text-weight-semibold);
+}
+
+.projectSelector {
+  flex: 0 1 auto;
+  min-width: calc(3ch + var(--base-size-8) + var(--base-size-4) + var(--base-size-24));
+}
+
+.projectSelector > :first-child {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.projectSelector > :last-child {
+  flex: 0 0 auto;
+}
+
+.projectSelector .projectName {
+  width: 100%;
+  padding-inline: var(--base-size-8) var(--base-size-4);
+}
+
+.projectSelector .projectSwitcherTrigger {
+  width: var(--base-size-24);
+  min-width: var(--base-size-24);
+  flex: 0 0 var(--base-size-24);
+}
+
+.projectSeparator,
+.projectLoading {
+  color: var(--fgColor-muted);
+}
+
+.projectRetry {
+  min-width: 0;
+  max-width: 100%;
+  color: var(--fgColor-danger);
 }
 
 .actions {
@@ -75,9 +174,35 @@
   min-width: 0;
 }
 
+.projectNavigationSurface {
+  height: var(--base-size-40);
+  overflow: hidden;
+  background: var(--bgColor-muted);
+}
+
+.projectNavigation {
+  transform: translateY(calc(-1 * var(--base-size-8)));
+}
+
+.projectNavigation a:hover {
+  color: var(--fgColor-default);
+}
+
+.projectNavigation a:hover [data-component='text'] {
+  font-weight: var(--base-text-weight-semibold);
+}
+
+.projectSelectPanel [data-component='ActionList.Item']::after {
+  display: none;
+}
+
+.projectSelectPanel [data-component='FilteredActionList.Header'] {
+  box-shadow: none;
+}
+
 .contextGuide {
   min-height: var(--base-size-44);
-  padding: var(--base-size-8) 50px;
+  padding: var(--base-size-8) var(--base-size-48);
   border-top: var(--borderWidth-thin) solid var(--borderColor-default);
   box-sizing: border-box;
   display: flex;
@@ -87,22 +212,29 @@
   color: var(--fgColor-muted);
 }
 
-/* Primer PageLayout narrow 边界：小于 48rem。 */
-@media (max-width: calc(48rem - 0.02px)) {
+/* Primer viewportRange.narrow, excluding the medium breakpoint itself. */
+@media not all and (min-width: 48rem) {
   .persistentSidebar {
     display: none;
   }
 
   .headerInner {
-    padding-inline: var(--base-size-8);
+    align-items: stretch;
+    flex-wrap: wrap;
     gap: var(--base-size-8);
+  }
+
+  .headerStart,
+  .actions {
+    flex-basis: 100%;
+  }
+
+  .actions {
+    justify-content: flex-end;
+    gap: var(--base-size-4);
   }
 
   .contextGuide {
     padding-inline: var(--base-size-16);
-  }
-
-  .actions {
-    gap: var(--base-size-4);
   }
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,15 +1,29 @@
-import { PlusIcon, ThreeBarsIcon } from '@primer/octicons-react'
-import { defaultPaneWidth, IconButton, PageLayout } from '@primer/react'
+import {
+  FileDirectoryIcon,
+  GearIcon,
+  PlayIcon,
+  PlusIcon,
+  ThreeBarsIcon,
+} from '@primer/octicons-react'
+import {
+  Button,
+  ButtonGroup,
+  defaultPaneWidth,
+  IconButton,
+  PageLayout,
+  UnderlineNav,
+} from '@primer/react'
 import { useEffect, useId, useRef, useState, type CSSProperties, type ReactNode } from 'react'
-import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom'
+import { Link as RouterLink, matchPath, useLocation, useNavigate } from 'react-router-dom'
 
-import type { Home } from '../../api/types'
+import type { Home, Project } from '../../api/types'
 import type { AsyncState as AsyncResource } from '../../api/useAsync'
 import { GlobalNavigationDrawer } from './GlobalNavigationDrawer'
 import { NotificationBell } from '../notification/NotificationBell'
 import { CreateUserGroupDialog } from '../workspace/CreateUserGroupDialog'
 import { ContextGuide } from './ContextGuide'
 import { appShellCopy } from './copy'
+import { ProjectSwitcher } from './ProjectSwitcher'
 import { UserSwitcher } from './UserSwitcher'
 import { WorkNavigation } from './WorkNavigation'
 import styles from './AppShell.module.css'
@@ -18,7 +32,16 @@ interface Props {
   username: string
   onUsernameChange: (username: string) => void
   home: AsyncResource<Home>
+  project: AsyncResource<Project | undefined>
   children: ReactNode
+}
+
+function HomeMarkVisual() {
+  return (
+    <span className={styles.homeMarkVisual} aria-hidden>
+      {appShellCopy.homeMark}
+    </span>
+  )
 }
 
 type AppShellStyle = CSSProperties & { '--app-shell-sidebar-width': string }
@@ -27,13 +50,23 @@ const appShellStyle: AppShellStyle = {
   '--app-shell-sidebar-width': `${defaultPaneWidth.medium}px`,
 }
 
-export function AppShell({ username, onUsernameChange, home, children }: Props) {
+export function AppShell({ username, onUsernameChange, home, project, children }: Props) {
   const navigate = useNavigate()
   const location = useLocation()
   const navigationId = useId()
   const navigationButtonRef = useRef<HTMLButtonElement>(null)
   const [createOpen, setCreateOpen] = useState(false)
   const [navigationOpen, setNavigationOpen] = useState(false)
+  const projectId = matchPath('/projects/:projectId/*', location.pathname)?.params.projectId
+  const currentProject = project.data?.id === projectId ? project.data : undefined
+  const requestedTab = new URLSearchParams(location.search).get('tab')
+  const projectArea = location.pathname.includes('/runs/')
+    ? 'runs'
+    : requestedTab === 'runs' || requestedTab === 'configurations'
+      ? 'runs'
+      : requestedTab === 'activities'
+        ? 'settings'
+        : 'files'
 
   useEffect(() => {
     setNavigationOpen(false)
@@ -41,7 +74,7 @@ export function AppShell({ username, onUsernameChange, home, children }: Props) 
 
   return (
     <div className={styles.shell} style={appShellStyle}>
-      <header className={styles.header}>
+      <header className={`${styles.header} ${projectId ? styles.projectHeader : ''}`}>
         <div className={styles.headerInner}>
           <div className={styles.headerStart}>
             <IconButton
@@ -53,9 +86,67 @@ export function AppShell({ username, onUsernameChange, home, children }: Props) 
               aria-controls={navigationId}
               onClick={() => setNavigationOpen(true)}
             />
-            <RouterLink to="/" className={styles.brand}>
-              {appShellCopy.brand}
-            </RouterLink>
+            <IconButton
+              as={RouterLink}
+              to="/"
+              icon={HomeMarkVisual}
+              variant="default"
+              aria-label={appShellCopy.homeMarkLabel}
+            />
+            {projectId ? (
+              <div
+                className={styles.projectContext}
+                role="group"
+                aria-label={appShellCopy.projectContextLabel}
+              >
+                {currentProject ? (
+                  <>
+                    <Button
+                      as={RouterLink}
+                      to={
+                        currentProject.owner.kind === 'user_group'
+                          ? `/user-groups/${currentProject.owner.id}`
+                          : '/'
+                      }
+                      variant="invisible"
+                      className={`${styles.projectContextItem} ${styles.projectOwner}`}
+                    >
+                      <span className={styles.projectContextLabel}>
+                        {currentProject.owner.display_name}
+                      </span>
+                    </Button>
+                    <span className={styles.projectSeparator} aria-hidden>
+                      /
+                    </span>
+                    <ButtonGroup className={styles.projectSelector}>
+                      <Button
+                        as={RouterLink}
+                        to={`/projects/${projectId}`}
+                        variant="invisible"
+                        className={`${styles.projectContextItem} ${styles.projectName}`}
+                      >
+                        <span className={styles.projectContextLabel}>{currentProject.name}</span>
+                      </Button>
+                      <ProjectSwitcher project={currentProject} />
+                    </ButtonGroup>
+                  </>
+                ) : project.error ? (
+                  <Button
+                    variant="invisible"
+                    className={styles.projectRetry}
+                    onClick={() => void project.reload()}
+                  >
+                    {appShellCopy.projectError}
+                  </Button>
+                ) : (
+                  <span className={styles.projectLoading} role="status">
+                    {appShellCopy.projectLoading}
+                  </span>
+                )}
+              </div>
+            ) : location.pathname === '/' ? (
+              <span className={styles.homeContext}>{appShellCopy.homeContext}</span>
+            ) : null}
           </div>
           <div className={styles.actions}>
             <IconButton
@@ -70,6 +161,40 @@ export function AppShell({ username, onUsernameChange, home, children }: Props) 
             <UserSwitcher value={username} onChange={onUsernameChange} />
           </div>
         </div>
+        {projectId ? (
+          <div className={styles.projectNavigationSurface}>
+            <UnderlineNav
+              aria-label={appShellCopy.projectNavigationLabel}
+              className={styles.projectNavigation}
+              hideIconsBreakpoint={null}
+            >
+              <UnderlineNav.Item
+                as={RouterLink}
+                to={`/projects/${projectId}?tab=files`}
+                leadingVisual={<FileDirectoryIcon />}
+                aria-current={projectArea === 'files' ? 'page' : undefined}
+              >
+                {appShellCopy.files}
+              </UnderlineNav.Item>
+              <UnderlineNav.Item
+                as={RouterLink}
+                to={`/projects/${projectId}?tab=runs`}
+                leadingVisual={<PlayIcon />}
+                aria-current={projectArea === 'runs' ? 'page' : undefined}
+              >
+                {appShellCopy.runs}
+              </UnderlineNav.Item>
+              <UnderlineNav.Item
+                as={RouterLink}
+                to={`/projects/${projectId}?tab=activities`}
+                leadingVisual={<GearIcon />}
+                aria-current={projectArea === 'settings' ? 'page' : undefined}
+              >
+                {appShellCopy.settings}
+              </UnderlineNav.Item>
+            </UnderlineNav>
+          </div>
+        ) : null}
       </header>
 
       <div className={styles.body}>

--- a/frontend/src/components/layout/ProjectSwitcher.tsx
+++ b/frontend/src/components/layout/ProjectSwitcher.tsx
@@ -1,0 +1,115 @@
+import { TriangleDownIcon } from '@primer/octicons-react'
+import { Button, IconButton, SelectPanel, Text } from '@primer/react'
+import type { ActionListItemInput } from '@primer/react/deprecated'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { api } from '../../api/client'
+import { toAsyncError } from '../../api/errors'
+import type { Project, ProjectPage } from '../../api/types'
+import { useAsync } from '../../api/useAsync'
+import styles from './AppShell.module.css'
+
+const EMPTY_PAGE: ProjectPage = {
+  items: [],
+  page: 1,
+  page_size: 50,
+  total: 0,
+  has_more: false,
+}
+
+export function ProjectSwitcher({ project }: { project: Project }) {
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedQuery(query), 200)
+    return () => window.clearTimeout(timeout)
+  }, [query])
+  const projects = useAsync<ProjectPage>(
+    () =>
+      open
+        ? api.listOwnerProjects(project.owner, {
+            page_size: 50,
+            query: debouncedQuery.trim() || undefined,
+          })
+        : Promise.resolve(EMPTY_PAGE),
+    [open, project.owner.kind, project.owner.id, debouncedQuery],
+  )
+  const error = toAsyncError(projects.error)
+  const options: ActionListItemInput[] = (projects.data?.items ?? []).map((item) => ({
+    id: item.id,
+    text: item.name,
+  }))
+  const selected = options.find((item) => item.id === project.id)
+  const message = error
+    ? {
+        variant: 'error' as const,
+        title: '无法加载 Project。',
+        body: <Text size="small">{error.problems?.join(' ') || '请重试。'}</Text>,
+        action: <Button onClick={() => void projects.reload()}>重试</Button>,
+      }
+    : !projects.loading && projects.data && options.length === 0
+      ? {
+          variant: 'empty' as const,
+          title: '没有匹配的 Project。',
+          body: '尝试搜索其他名称。',
+        }
+      : undefined
+
+  const close = () => {
+    setOpen(false)
+    setQuery('')
+    setDebouncedQuery('')
+  }
+
+  return (
+    <SelectPanel
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) setOpen(true)
+        else close()
+      }}
+      renderAnchor={({ children: _children, ...anchorProps }) => (
+        <IconButton
+          {...anchorProps}
+          className={styles.projectSwitcherTrigger}
+          icon={TriangleDownIcon}
+          variant="invisible"
+          aria-label="切换 Project"
+          aria-haspopup="dialog"
+        />
+      )}
+      title="切换 Project"
+      placeholder={project.name}
+      placeholderText="搜索 Project"
+      inputLabel="搜索 Project"
+      filterValue={query}
+      onFilterChange={(value) => setQuery(value)}
+      loading={projects.loading}
+      initialLoadingType="spinner"
+      items={options}
+      selected={selected}
+      onSelectedChange={(item: ActionListItemInput | undefined) => {
+        if (!item) return
+        close()
+        navigate(`/projects/${item.id}`)
+      }}
+      message={message}
+      className={styles.projectSelectPanel}
+      notice={
+        projects.data?.has_more
+          ? { text: '还有更多 Project，请输入名称继续搜索。', variant: 'info' }
+          : undefined
+      }
+      width="auto"
+      height="auto"
+      overlayProps={{ maxWidth: 'small', maxHeight: 'medium' }}
+      align="end"
+      disableFullscreenOnNarrow
+      aria-label={`${project.owner.display_name} 的 Projects`}
+    />
+  )
+}

--- a/frontend/src/components/layout/copy.ts
+++ b/frontend/src/components/layout/copy.ts
@@ -1,8 +1,17 @@
 export const appShellCopy = {
-  brand: '107 Workspace',
+  homeMark: '107',
+  homeMarkLabel: '107 Workspace 首页',
+  homeContext: '107 Workspace',
   openNavigation: '打开导航',
   createUserGroup: '创建 User Group',
   sidebarLabel: '首页工作入口',
+  projectContextLabel: '当前 Project',
+  projectNavigationLabel: 'Project navigation',
+  projectLoading: '正在加载 Project context…',
+  projectError: 'Project context 加载失败，重试',
+  files: 'Files',
+  runs: 'Runs',
+  settings: 'Settings',
 } as const
 
 export const globalNavigationCopy = {

--- a/frontend/src/pages/ProjectPage.tsx
+++ b/frontend/src/pages/ProjectPage.tsx
@@ -6,7 +6,7 @@ import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { api } from '../api/client'
 import { toAsyncError } from '../api/errors'
 import type { ActivityPage, ForkSource, Project, RunConfiguration, RunPage } from '../api/types'
-import { useAsync } from '../api/useAsync'
+import { useAsync, type AsyncState as AsyncResource } from '../api/useAsync'
 import { ActivityFeed } from '../components/activity/ActivityFeed'
 import { AsyncSection } from '../components/common/AsyncSection'
 import { AsyncState } from '../components/common/AsyncState'
@@ -21,12 +21,20 @@ import { SubmitRunModal } from '../components/run/SubmitRunModal'
 import { RunConfigurationPanel } from '../components/runconfig/RunConfigurationPanel'
 import { tablePagination } from '../utils/pagination'
 
+const PAGE_TITLES: Record<string, string> = {
+  files: 'Working State',
+  versions: 'Version history',
+  configurations: 'Run configurations',
+  runs: 'Run history',
+  activities: 'Project activity',
+}
+
 /**
  * Project 页面：文件、版本、运行方案和 Run 历史。
  *
  * 页面顺序对应核心闭环：准备代码 -> 保存版本 -> 配置运行方案 -> 提交 Run。
  */
-export function ProjectPage() {
+export function ProjectPage({ project }: { project: AsyncResource<Project | undefined> }) {
   const { projectId = '' } = useParams()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -37,9 +45,11 @@ export function ProjectPage() {
       ? requestedTab
       : 'files'
   const [token, setToken] = useState(0)
-  const bump = () => setToken((value) => value + 1)
+  const bump = () => {
+    setToken((value) => value + 1)
+    void project.reload({ silent: true })
+  }
 
-  const project = useAsync<Project>(() => api.getProject(projectId), [projectId, token])
   const [runPage, setRunPage] = useState(1)
   const runs = useAsync<RunPage>(
     () => api.listRuns(projectId, { page: runPage }),
@@ -59,21 +69,7 @@ export function ProjectPage() {
       <AsyncSection loading={project.loading} error={project.error}>
         {project.data && (
           <PageHeader
-            breadcrumb={[
-              { title: <Link to="/">首页</Link> },
-              {
-                title:
-                  project.data.owner.kind === 'user_group' ? (
-                    <Link to={`/user-groups/${project.data.owner.id}`}>
-                      {project.data.owner.display_name}
-                    </Link>
-                  ) : (
-                    project.data.owner.display_name
-                  ),
-              },
-              { title: project.data.name },
-            ]}
-            title={project.data.name}
+            title={PAGE_TITLES[activeTab]}
             description={project.data.description || '这个 Project 还没有填写说明'}
             tags={forkSource.data ? <ForkSourceTag source={forkSource.data} /> : null}
           />

--- a/frontend/tests/component/AppShell.test.tsx
+++ b/frontend/tests/component/AppShell.test.tsx
@@ -7,7 +7,7 @@ import { StrictMode } from 'react'
 import { MemoryRouter, useLocation } from 'react-router-dom'
 
 import { api, setCurrentUser } from '../../src/api/client'
-import type { Home } from '../../src/api/types'
+import type { Home, Project } from '../../src/api/types'
 import type { AsyncState } from '../../src/api/useAsync'
 import { App } from '../../src/App'
 import { AppShell } from '../../src/components/layout/AppShell'
@@ -62,7 +62,31 @@ const manyHomeItems: Home = {
   })),
 }
 
+const projectData: Project = {
+  id: 'p-1',
+  name: 'LJ 流体模拟',
+  description: '',
+  owner: { kind: 'user_group', id: 'grp-1', display_name: '计算物理课题组' },
+  visibility: 'owner_scope',
+  status: 'active',
+  created_by: 'u-1',
+  created_at: '2026-08-15T10:00:00Z',
+  updated_at: '2026-08-16T10:00:00Z',
+  default_run_configuration_id: null,
+  environment_version_id: null,
+}
+
+const secondProject: Project = {
+  ...projectData,
+  id: 'p-2',
+  name: '第二个 Project',
+}
+
 function readyHome(data = homeData): AsyncState<Home> {
+  return { data, loading: false, error: undefined, reload: vi.fn() }
+}
+
+function readyProject(data: Project | undefined = projectData): AsyncState<Project | undefined> {
   return { data, loading: false, error: undefined, reload: vi.fn() }
 }
 
@@ -84,11 +108,16 @@ function LocationProbe() {
   return <output data-testid="location">{location.pathname}</output>
 }
 
-function renderShell(username: string, home = readyHome(), initialEntry = '/') {
+function renderShell(
+  username: string,
+  home = readyHome(),
+  initialEntry = '/',
+  project = readyProject(),
+) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <PrimerRoot>
-        <AppShell username={username} onUsernameChange={() => {}} home={home}>
+        <AppShell username={username} onUsernameChange={() => {}} home={home} project={project}>
           <p>页面内容</p>
           <LocationProbe />
         </AppShell>
@@ -129,6 +158,123 @@ describe('AppShell 壳层', () => {
     },
   )
 
+  it('首页在 Home Mark 后显示产品名 context', () => {
+    renderShell('student')
+
+    const header = screen.getByRole('banner')
+    expect(within(header).getByText('107 Workspace')).toBeVisible()
+    expect(within(header).getByRole('link', { name: '107 Workspace 首页' })).toHaveAttribute(
+      'href',
+      '/',
+    )
+    expect(screen.queryByRole('navigation', { name: 'Project navigation' })).toBeNull()
+  })
+
+  it('用独立 Home Mark、Project context 和三级本地导航表达壳层层级', () => {
+    renderShell('student', readyHome(), '/projects/p-1/runs/r-1')
+
+    const header = screen.getByRole('banner')
+    expect(within(header).getByRole('link', { name: '107 Workspace 首页' })).toHaveAttribute(
+      'href',
+      '/',
+    )
+    const context = within(header).getByRole('group', { name: '当前 Project' })
+    expect(within(context).getByRole('link', { name: '计算物理课题组' })).toHaveAttribute(
+      'href',
+      '/user-groups/grp-1',
+    )
+    expect(within(context).getByRole('link', { name: 'LJ 流体模拟' })).toHaveAttribute(
+      'href',
+      '/projects/p-1',
+    )
+
+    const navigation = screen.getByRole('navigation', { name: 'Project navigation' })
+    expect(within(navigation).getByRole('link', { name: 'Files' })).toHaveAttribute(
+      'href',
+      '/projects/p-1?tab=files',
+    )
+    expect(within(navigation).getByRole('link', { name: 'Runs' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    )
+    expect(within(navigation).getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      '/projects/p-1?tab=activities',
+    )
+    expect(within(navigation).queryByRole('link', { name: '版本' })).toBeNull()
+    expect(within(navigation).queryByRole('link', { name: '运行方案' })).toBeNull()
+  })
+
+  it('在当前 Owner namespace 内搜索并切换 Project', async () => {
+    const listOwnerProjects = vi.spyOn(api, 'listOwnerProjects').mockResolvedValue({
+      items: [projectData, secondProject],
+      page: 1,
+      page_size: 50,
+      total: 2,
+      has_more: false,
+    })
+    renderShell('student', readyHome(), '/projects/p-1')
+
+    fireEvent.click(screen.getByRole('button', { name: '切换 Project' }))
+    const search = await screen.findByPlaceholderText('搜索 Project')
+    const panel = search.closest<HTMLElement>('[role="dialog"]')
+    expect(panel).not.toBeNull()
+    expect(within(panel!).getByRole('heading', { name: '切换 Project' })).toBeVisible()
+    expect(within(panel!).queryByText('计算物理课题组')).toBeNull()
+    await waitFor(() =>
+      expect(listOwnerProjects).toHaveBeenCalledWith(projectData.owner, {
+        page_size: 50,
+        query: undefined,
+      }),
+    )
+    fireEvent.change(search, { target: { value: '第二个' } })
+    await waitFor(() =>
+      expect(listOwnerProjects).toHaveBeenLastCalledWith(projectData.owner, {
+        page_size: 50,
+        query: '第二个',
+      }),
+    )
+    fireEvent.click(await screen.findByText('第二个 Project'))
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/projects/p-2')
+    expect(screen.queryByPlaceholderText('搜索 Project')).toBeNull()
+  })
+
+  it('Project SelectPanel 加载失败后可重试', async () => {
+    const listOwnerProjects = vi
+      .spyOn(api, 'listOwnerProjects')
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({
+        items: [projectData, secondProject],
+        page: 1,
+        page_size: 50,
+        total: 2,
+        has_more: false,
+      })
+    renderShell('student', readyHome(), '/projects/p-1')
+
+    fireEvent.click(screen.getByRole('button', { name: '切换 Project' }))
+    expect(await screen.findByText('无法加载 Project。')).toBeVisible()
+    fireEvent.click(screen.getByText('重试'))
+
+    await waitFor(() => expect(listOwnerProjects).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('第二个 Project')).toBeVisible()
+  })
+
+  it('Project context 加载失败时保留壳层导航并提供重试', () => {
+    const reload = vi.fn()
+    renderShell('student', readyHome(), '/projects/p-1', {
+      data: undefined,
+      loading: false,
+      error: new Error('offline'),
+      reload,
+    })
+
+    expect(screen.getByRole('navigation', { name: 'Project navigation' })).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Project context 加载失败，重试' }))
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('页面内容')).toBeVisible()
+  })
   it('非首页 Body 仅直接包含 main，Primer Content 在 main 内负责正文居中', () => {
     renderShell('student', readyHome(), '/projects/p-1')
     const body = screen.getByRole('banner').nextElementSibling
@@ -379,7 +525,12 @@ describe('AppShell 身份切换的乱序防护', () => {
     rerender(
       <MemoryRouter>
         <PrimerRoot>
-          <AppShell username="teacher" onUsernameChange={() => {}} home={readyHome()}>
+          <AppShell
+            username="teacher"
+            onUsernameChange={() => {}}
+            home={readyHome()}
+            project={readyProject()}
+          >
             <p>页面内容</p>
           </AppShell>
         </PrimerRoot>

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -33,3 +33,28 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
     value: ResizeObserverStub,
   })
 }
+
+// Primer SelectPanel 会滚动 active option；jsdom 没有 HTMLElement.scrollTo。
+if (typeof HTMLElement !== 'undefined' && !HTMLElement.prototype.scrollTo) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+    writable: true,
+    configurable: true,
+    value: () => {},
+  })
+}
+
+// Primer SelectPanel 的测试模式直接调用 live-region element；jsdom 只创建普通 HTMLElement。
+if (typeof HTMLElement !== 'undefined' && !('announce' in HTMLElement.prototype)) {
+  Object.defineProperties(HTMLElement.prototype, {
+    announce: {
+      writable: true,
+      configurable: true,
+      value: () => {},
+    },
+    clear: {
+      writable: true,
+      configurable: true,
+      value: () => {},
+    },
+  })
+}


### PR DESCRIPTION
## 变更

- AppShell 使用独立 Home Mark、`Owner / Project` context 和 Primer `Files / Runs / Settings` local navigation；AppShell/ContextGuide 不导入 Ant Design。
- Home route 在 Home Mark 后显示非交互的 `107 Workspace` 产品名 context；Home Mark 继续独立负责 `/` 导航，Home 不渲染 Project local nav。
- AppHeader 使用对称 `base-size-12` block padding；Owner、Project label 与 24×32px chevron 使用紧凑 token spacing。
- Project 名称与 chevron 使用 Primer `ButtonGroup` 组成无框 split control；左段保留 Project 根页 RouterLink，右段打开 Owner-scoped Project Switcher。
- Project Switcher 使用 Primer anchored `SelectPanel`，直接锚定 chevron；815/375/320px 均保持 anchored。复用原生 combobox、single-selection listbox、键盘导航、focus return、outside/Escape close、loading/message/notice。
- SelectPanel 标题为 `切换 Project`，不重复 Owner subtitle；Owner scope 通过 AppHeader breadcrumb 和 listbox aria-label 表达。搜索区与列表间的 divider shadow 仅在此面板隐藏。
- Project items 不重复 Project icon；当前项保留原生 check，移除常驻蓝色 active indicator bar，hover/keyboard active 保留浅背景。
- Panel 使用 auto width + small max-width、auto height + medium max-height、end alignment；Owner-scoped search、200ms debounce、selected、error/retry、empty、has-more 和导航保持。
- Error retry 使用 SelectPanel message.action；has-more 使用 info notice。
- 长名称渐进收缩并至少保留 3ch；Context hover 文字不变色，local nav hover 只加粗。
- Local navigation surface 使用 `base-size-40`，原生 UnderlineNav 上移 `base-size-8`；item、focus、selected underline 与 overflow 保持完整。
- `GET /api/v1/projects` 支持 Owner 成对过滤和 query 搜索；repository 层叠加 discovery predicate。
- Run Detail 不再重复 Project shell；Version/Run Configuration 保留为页面内子层级。

## 验证

- Backend owner/name filter integration：通过；不完整 Owner 参数返回 422。
- AppShell 24 tests passed；完整 frontend 136 tests passed；backend 289 passed / 3 skipped。
- Home browser：1568/375/320px 显示 `107 Workspace` context，无 Project nav、无横向溢出。
- Project browser：SelectPanel title 简洁、subtitle 不存在、divider shadow none、option 32px、Project icon 0、check 保留、蓝色 bar 隐藏。
- Panel anchored gap 4px；815/375/320px 无横向溢出；输入自动 focus，Escape 关闭后 focus 返回 trigger。
- Search no-result、error retry、has-more notice 已验证。
- Fresh-context Home context 与 SelectPanel chrome reviews：PASS。
- format、lint、typecheck、frontend tests、build、API contract 通过；完整 frontend suite 的一次无关 VersionDetail timing 失败已在 targeted 与完整重跑中通过。

这是基于 114August514/107-workspace#76 (`refactor/19-run-primer`) 的 stacked PR；#76 合并后再将 base 收敛到 `main`。

Closes 114August514/107-workspace#82