### PR TITLE
feat(backend): 为 Run 输出发起用户 username

### DIFF
--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -11,6 +11,7 @@ from ..application.catalog_service import EnvironmentView
 from ..application.entitlement_service import EntitlementView
 from ..application.grant_service import GrantView
 from ..application.ownership import OwnerSummary
+from ..application.run_service import RunView
 from ..application.shared_resource_service import (
     SharedResourceAccessView,
     SharedResourceView,
@@ -30,7 +31,6 @@ from ..domain.models import (
     Project,
     ProjectFile,
     ProjectVersion,
-    Run,
     RunConfiguration,
     RunEvent,
     SharedResourcePublicationAttempt,
@@ -242,7 +242,8 @@ def run_configuration_out(configuration: RunConfiguration) -> s.RunConfiguration
     )
 
 
-def run_out(run: Run, *, capabilities: Iterable[Capability] = ()) -> s.RunOut:
+def run_out(view: RunView, *, capabilities: Iterable[Capability] = ()) -> s.RunOut:
+    run = view.run
     queued_seconds: float | None = None
     running_seconds: float | None = None
     if run.submitted_at and run.started_at:
@@ -264,6 +265,7 @@ def run_out(run: Run, *, capabilities: Iterable[Capability] = ()) -> s.RunOut:
         exit_code=run.exit_code,
         failure_reason=run.failure_reason,
         initiated_by_user_id=run.initiated_by_user_id,
+        initiated_by_username=view.initiated_by_username,
         created_at=run.created_at,
         submitted_at=run.submitted_at,
         started_at=run.started_at,

--- a/backend/src/workspace107/api/routes/runs.py
+++ b/backend/src/workspace107/api/routes/runs.py
@@ -86,14 +86,14 @@ async def create_run(
     )
     if not submission.created:
         response.status_code = status.HTTP_200_OK
-    return p.run_out(submission.run)
+    return p.run_out(await services.runs.view(submission.run))
 
 
 @router.get("/runs/{run_id}", response_model=s.RunDetailOut, summary="获取 Run 详情")
 async def get_run(run_id: str, user: CurrentUser, services: ServicesDep) -> s.RunDetailOut:
     """Return a Run only when the current User has owner-scope Project authority."""
     detail = await services.runs.get_detail(user.id, run_id)
-    project_access = await services.projects.get(user.id, detail.run.project_id)
+    project_access = await services.projects.get(user.id, detail.run.run.project_id)
     return s.RunDetailOut(
         run=p.run_out(detail.run, capabilities=project_access.capabilities),
         snapshot=p.snapshot_out(detail.snapshot),
@@ -124,7 +124,7 @@ async def cancel_run(run_id: str, user: CurrentUser, services: ServicesDep) -> s
     会直接标记为已取消。
     """
     run = await services.runs.cancel(user.id, run_id)
-    return p.run_out(run)
+    return p.run_out(await services.runs.view(run))
 
 
 @router.post(
@@ -149,7 +149,7 @@ async def rerun(
     submission = await services.runs.rerun(user.id, run_id, idempotency_key=idempotency_key)
     if not submission.created:
         response.status_code = status.HTTP_200_OK
-    return p.run_out(submission.run)
+    return p.run_out(await services.runs.view(submission.run))
 
 
 @router.post("/runs/sync", response_model=s.SyncOut, summary="同步 Run 状态")

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -535,6 +535,8 @@ class RunOut(Model):
     failure_reason: str
     initiated_by_user_id: str
     """发起本次 Run 的 User（GR-307）：执行身份、并发额度与通知接收方。"""
+    initiated_by_username: str | None
+    """当前权威 User.username；User 记录无法解析时为 null。"""
     created_at: datetime | None
     submitted_at: datetime | None
     started_at: datetime | None

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -114,8 +114,16 @@ class RunSubmission:
 
 
 @dataclass(frozen=True, slots=True)
-class RunDetail:
+class RunView:
+    """A Run plus its current authoritative User username projection."""
+
     run: Run
+    initiated_by_username: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RunDetail:
+    run: RunView
     snapshot: RunSnapshot
     events: list[RunEvent]
     artifacts: list[Artifact]
@@ -146,12 +154,43 @@ class RunService:
 
     # -- 查询 -----------------------------------------------------------
 
-    async def list_for_project(self, user_id: str, project_id: str, page: PageRequest) -> Page[Run]:
+    async def list_for_project(
+        self, user_id: str, project_id: str, page: PageRequest
+    ) -> Page[RunView]:
         await self._guard.project(user_id, project_id, owner_scope=True)
-        return await self._repos.runs.list_for_project(project_id, page)
+        runs = await self._repos.runs.list_for_project(project_id, page)
+        return Page(
+            items=await self._views(runs.items),
+            page=runs.page,
+            page_size=runs.page_size,
+            total=runs.total,
+        )
 
-    async def list_recent_for_user(self, user_id: str, *, limit: int = 10) -> list[Run]:
-        return await self._repos.runs.list_for_user(user_id, limit=limit)
+    async def list_recent_for_user(self, user_id: str, *, limit: int = 10) -> list[RunView]:
+        return await self._views(await self._repos.runs.list_for_user(user_id, limit=limit))
+
+    async def view(self, run: Run) -> RunView:
+        """Resolve one Run without substituting the current viewer's identity."""
+
+        user = await self._repos.users.get(run.initiated_by_user_id)
+        return RunView(
+            run=run,
+            initiated_by_username=user.username if user is not None else None,
+        )
+
+    async def _views(self, runs: list[Run]) -> list[RunView]:
+        users = await self._repos.users.list_by_ids({run.initiated_by_user_id for run in runs})
+        return [
+            RunView(
+                run=run,
+                initiated_by_username=(
+                    users[run.initiated_by_user_id].username
+                    if run.initiated_by_user_id in users
+                    else None
+                ),
+            )
+            for run in runs
+        ]
 
     async def get_detail(self, user_id: str, run_id: str) -> RunDetail:
         access = await self._guard.run(user_id, run_id)
@@ -159,7 +198,7 @@ class RunService:
         if snapshot is None:  # pragma: no cover - 数据损坏才会发生
             raise ObjectNotFound("Run Snapshot", access.run.snapshot_id)
         return RunDetail(
-            run=access.run,
+            run=await self.view(access.run),
             snapshot=snapshot,
             events=await self._repos.run_events.list_for_run(run_id),
             artifacts=await self._repos.artifacts.list_for_run(run_id),

--- a/backend/tests/integration/test_run_initiated_by_user.py
+++ b/backend/tests/integration/test_run_initiated_by_user.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import httpx
+from sqlalchemy import event, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.helpers import (
@@ -24,6 +25,7 @@ from tests.helpers import (
     process_shared_resource_publication,
     wait_for_run,
 )
+from workspace107.api.deps import AppContext
 from workspace107.application.run_service import RunDraft
 from workspace107.domain import ids
 from workspace107.domain.config_scope import ConfigScope
@@ -36,8 +38,10 @@ from workspace107.infrastructure.db.tables import (
     EnvironmentRow,
     EnvironmentVersionRow,
     ProjectRow,
+    RunRow,
     SharedResourceRow,
     SharedResourceVersionFileRow,
+    UserRow,
 )
 
 ALICE = {"X-User": "alice"}
@@ -169,7 +173,7 @@ async def _preflight(
 
 
 async def test_run_records_initiating_user_end_to_end(
-    client: httpx.AsyncClient, session: AsyncSession
+    client: httpx.AsyncClient, session: AsyncSession, context: AppContext
 ) -> None:
     group = await _create_group(client, "Initiator Group")
     _, environment_version_id = await _create_environment(session, owner_user_group_id=group)
@@ -186,12 +190,14 @@ async def test_run_records_initiating_user_end_to_end(
     assert created.status_code == 201, created.text
     body = created.json()
     assert body["initiated_by_user_id"] == alice_id
+    assert body["initiated_by_username"] == "alice"
     assert "created_by" not in body
 
     detail = await client.get(f"/api/v1/runs/{body['id']}", headers=ALICE)
     detail.raise_for_status()
     assert detail.json()["run"]["initiated_by_user_id"] == alice_id
     assert detail.json()["snapshot"]["initiated_by_user_id"] == alice_id
+    assert detail.json()["run"]["initiated_by_username"] == "alice"
 
     # 同一 User Group 的另一个成员提交同一个运行方案：身份跟着发起人走。
     await _join_group(client, group)
@@ -204,6 +210,58 @@ async def test_run_records_initiating_user_end_to_end(
     )
     assert bob_run.status_code == 201, bob_run.text
     assert bob_run.json()["initiated_by_user_id"] == bob_id
+    assert bob_run.json()["initiated_by_username"] == "bob"
+
+    # History resolves every Run's recorded User, not the current viewer.
+    user_projection_selects = 0
+
+    def count_user_projection(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        nonlocal user_projection_selects
+        if "FROM users" in statement and "users.id IN" in statement:
+            user_projection_selects += 1
+
+    event.listen(context.engine.sync_engine, "before_cursor_execute", count_user_projection)
+    try:
+        history = await client.get(
+            f"/api/v1/projects/{project['id']}/runs?page_size=20", headers=ALICE
+        )
+    finally:
+        event.remove(context.engine.sync_engine, "before_cursor_execute", count_user_projection)
+    history.raise_for_status()
+    assert {
+        item["initiated_by_user_id"]: item["initiated_by_username"]
+        for item in history.json()["items"]
+    } == {alice_id: "alice", bob_id: "bob"}
+    assert user_projection_selects == 1
+
+    # Username is a current authoritative User projection, not a Run snapshot.
+    await session.execute(
+        update(UserRow).where(UserRow.id == bob_id).values(username="bob-renamed")
+    )
+    await session.commit()
+    bob_detail = await client.get(f"/api/v1/runs/{bob_run.json()['id']}", headers=ALICE)
+    bob_detail.raise_for_status()
+    assert bob_detail.json()["run"]["initiated_by_username"] == "bob-renamed"
+
+    # A broken historical reference remains explicit: retain the canonical ID and
+    # return null instead of presenting that internal ID as an account name.
+    await session.execute(
+        update(RunRow)
+        .where(RunRow.id == bob_run.json()["id"])
+        .values(initiated_by_user_id="usr_missing")
+    )
+    await session.commit()
+    missing_detail = await client.get(f"/api/v1/runs/{bob_run.json()['id']}", headers=ALICE)
+    missing_detail.raise_for_status()
+    assert missing_detail.json()["run"]["initiated_by_user_id"] == "usr_missing"
+    assert missing_detail.json()["run"]["initiated_by_username"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -436,7 +494,7 @@ async def test_execution_context_revalidates_current_identity_and_exact_referenc
     repos = SqlRepositories(session)
     version = await repos.project_versions.get(detail.snapshot.project_version_id)
     assert version is not None
-    await services.runs.validate_execution_context(detail.run, detail.snapshot)
+    await services.runs.validate_execution_context(detail.run.run, detail.snapshot)
 
     prepare_calls: list[str] = []
     scheduler_calls: list[str] = []
@@ -455,9 +513,9 @@ async def test_execution_context_revalidates_current_identity_and_exact_referenc
     async def assert_execution_rejected(message: str) -> None:
         prepare_count = len(prepare_calls)
         scheduler_count = len(scheduler_calls)
-        await services.runs._submit(detail.run, detail.snapshot, version)
-        assert detail.run.status.value == "submit_failed"
-        assert message in detail.run.failure_reason
+        await services.runs._submit(detail.run.run, detail.snapshot, version)
+        assert detail.run.run.status.value == "submit_failed"
+        assert message in detail.run.run.failure_reason
         assert len(prepare_calls) == prepare_count
         assert len(scheduler_calls) == scheduler_count
 

--- a/backend/tests/unit/application/test_run_version_fields.py
+++ b/backend/tests/unit/application/test_run_version_fields.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 
 from workspace107.api import presenters as p
 from workspace107.api import schemas as s
+from workspace107.application.run_service import RunView
 from workspace107.domain.enums import RunStatus
 from workspace107.domain.models import Run
 
@@ -42,24 +43,28 @@ def _make_run(
     )
 
 
+def _view(run: Run) -> RunView:
+    return RunView(run=run, initiated_by_username="alice")
+
+
 def test_run_out_includes_project_version_id() -> None:
     """RunOut 必须带上 project_version_id，Run History 才能链接到版本详情。"""
     run = _make_run(project_version_id="pv-abc")
-    out = p.run_out(run)
+    out = p.run_out(_view(run))
     assert out.project_version_id == "pv-abc"
 
 
 def test_run_out_includes_project_version_label() -> None:
     """RunOut 必须带上 project_version_label，Run History 才能直接显示 v3 而非 raw id。"""
     run = _make_run(project_version_label="v7")
-    out = p.run_out(run)
+    out = p.run_out(_view(run))
     assert out.project_version_label == "v7"
 
 
 def test_run_out_preserves_both_fields_together() -> None:
     """id 和 label 必须一起传，不能只传一个——否则列表里要么没链接要么没文字。"""
     run = _make_run(project_version_id="pv-xyz", project_version_label="v12")
-    out = p.run_out(run)
+    out = p.run_out(_view(run))
     assert out.project_version_id == "pv-xyz"
     assert out.project_version_label == "v12"
     assert isinstance(out, s.RunOut)

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -2383,6 +2383,18 @@
             "title": "Initiated By User Id",
             "type": "string"
           },
+          "initiated_by_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "当前权威 User.username；User 记录无法解析时为 null。",
+            "title": "Initiated By Username"
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -2500,6 +2512,7 @@
           "exit_code",
           "failure_reason",
           "initiated_by_user_id",
+          "initiated_by_username",
           "created_at",
           "submitted_at",
           "started_at",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2559,6 +2559,11 @@ export interface components {
              * @description 发起本次 Run 的 User（GR-307）：执行身份、并发额度与通知接收方。
              */
             initiated_by_user_id: string;
+            /**
+             * Initiated By Username
+             * @description 当前权威 User.username；User 记录无法解析时为 null。
+             */
+            initiated_by_username: string | null;
             /** Name */
             name: string;
             /** Project Id */

--- a/frontend/src/components/run/RunTable.tsx
+++ b/frontend/src/components/run/RunTable.tsx
@@ -26,6 +26,16 @@ const columns: ColumnsType<Run> = [
     render: (name: string, run) => <Link to={`/runs/${run.id}`}>{name}</Link>,
   },
   {
+    title: '发起用户',
+    dataIndex: field<Run>('initiated_by_username'),
+    width: 120,
+    render: (username: string | null) => (
+      <Typography.Text type={username ? undefined : 'secondary'}>
+        {username ?? '未知用户'}
+      </Typography.Text>
+    ),
+  },
+  {
     title: '版本',
     dataIndex: field<Run>('project_version_label'),
     width: 80,

--- a/frontend/src/pages/RunPage.tsx
+++ b/frontend/src/pages/RunPage.tsx
@@ -143,6 +143,11 @@ export function RunPage() {
               style={{ marginTop: 16 }}
               items={[
                 {
+                  key: 'initiator',
+                  label: '发起用户',
+                  children: run.initiated_by_username ?? '未知用户',
+                },
+                {
                   key: 'job',
                   label: '调度任务',
                   children: run.scheduler_job_id ? (

--- a/frontend/tests/component/HomePage.test.tsx
+++ b/frontend/tests/component/HomePage.test.tsx
@@ -60,6 +60,7 @@ const homeData: Home = {
       snapshot_id: 's-1',
       status: 'succeeded',
       initiated_by_user_id: 'u-1',
+      initiated_by_username: 'student',
       created_at: '2026-08-15T10:00:00Z',
       submitted_at: null,
       started_at: null,

--- a/frontend/tests/component/RunFromVersionModal.test.tsx
+++ b/frontend/tests/component/RunFromVersionModal.test.tsx
@@ -78,6 +78,7 @@ function makeRun(): Run {
     project_id: 'prj-1',
     capabilities: ['run.submit'],
     initiated_by_user_id: 'student',
+    initiated_by_username: 'student',
     created_at: '2026-08-12T10:00:00Z',
     started_at: null,
     finished_at: null,

--- a/frontend/tests/component/RunPage.test.tsx
+++ b/frontend/tests/component/RunPage.test.tsx
@@ -21,7 +21,8 @@ const runDetailFixture = (): RunDetail => ({
     source_run_id: null,
     source_run_configuration_id: null,
     status: 'succeeded',
-    initiated_by_user_id: 'student',
+    initiated_by_user_id: 'usr_internal_student',
+    initiated_by_username: 'student',
     created_at: '2026-08-15T08:00:00Z',
     submitted_at: '2026-08-15T08:01:00Z',
     started_at: '2026-08-15T08:02:00Z',
@@ -135,5 +136,29 @@ describe('RunPage backend unavailable', () => {
       expect(screen.queryByText('无法加载这个 Run。')).not.toBeInTheDocument()
     })
     expect(screen.getByRole('heading', { name: 'test-run' })).toBeInTheDocument()
+    expect(screen.getByText('student')).toBeInTheDocument()
+    expect(screen.queryByText('usr_internal_student')).not.toBeInTheDocument()
+  })
+
+  it('shows an explicit fallback instead of a missing User ID', async () => {
+    const missingUserDetail = runDetailFixture()
+    missingUserDetail.run = {
+      ...missingUserDetail.run,
+      initiated_by_user_id: 'usr_missing',
+      initiated_by_username: null,
+    }
+    vi.spyOn(api, 'getRun').mockResolvedValue(missingUserDetail)
+    vi.spyOn(api, 'readLogs').mockResolvedValue([] as LogChunk[])
+
+    render(
+      <Wrapper>
+        <RunPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('未知用户')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('usr_missing')).not.toBeInTheDocument()
   })
 })

--- a/frontend/tests/component/RunTable.test.tsx
+++ b/frontend/tests/component/RunTable.test.tsx
@@ -20,6 +20,7 @@ function makeRun(overrides: Partial<Run> = {}): Run {
     status: 'succeeded',
     project_id: 'proj-1',
     initiated_by_user_id: 'user-1',
+    initiated_by_username: 'alice',
     created_at: '2026-08-12T10:00:00Z',
     started_at: null,
     finished_at: null,
@@ -36,7 +37,7 @@ function makeRun(overrides: Partial<Run> = {}): Run {
   }
 }
 
-describe('RunTable 版本列', () => {
+describe('RunTable visible identity and version', () => {
   it('显示 project_version_label 并链接到 /versions/:id', () => {
     const runs = [makeRun()]
 
@@ -64,5 +65,49 @@ describe('RunTable 版本列', () => {
 
     expect(screen.getByRole('link', { name: 'v1' })).toHaveAttribute('href', '/versions/ver-1')
     expect(screen.getByRole('link', { name: 'v2' })).toHaveAttribute('href', '/versions/ver-2')
+  })
+
+  it('shows each initiator username and never uses the raw User ID as normal text', () => {
+    render(
+      <MemoryRouter>
+        <RunTable
+          runs={[
+            makeRun({
+              id: 'run-a',
+              initiated_by_user_id: 'usr_internal_alice',
+              initiated_by_username: 'alice',
+            }),
+            makeRun({
+              id: 'run-b',
+              initiated_by_user_id: 'usr_internal_bob',
+              initiated_by_username: 'bob',
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getAllByText('alice').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('bob').length).toBeGreaterThan(0)
+    expect(screen.queryByText('usr_internal_alice')).not.toBeInTheDocument()
+    expect(screen.queryByText('usr_internal_bob')).not.toBeInTheDocument()
+  })
+
+  it('shows an explicit fallback when the recorded User cannot be resolved', () => {
+    render(
+      <MemoryRouter>
+        <RunTable
+          runs={[
+            makeRun({
+              initiated_by_user_id: 'usr_missing',
+              initiated_by_username: null,
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('未知用户')).toBeInTheDocument()
+    expect(screen.queryByText('usr_missing')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 关联 Issue

Closes #87

## 修改内容

- 保留 `initiated_by_user_id` 作为 canonical ID；新增 `initiated_by_username`，投影当前权威 `User.username`，并统一用于 Run 列表、详情及创建、取消、重跑等 action 输出。
- Run 列表以一次批量 User 查询解析全部发起用户，避免逐条查询。
- 前端 History 与 Detail 展示 username；User 无法解析时显示「未知用户」，不回退展示内部 ID。
- 同步 OpenAPI 与生成的前端类型。

## 验证证据

- 最终树已执行 `make check`：后端 330 passed / 3 skipped；前端 146 tests passed；contracts 与 build 均通过。
- 未捕获界面截图；History、Detail 及「未知用户」fallback 由前端组件测试覆盖，production build 通过。

## 影响范围

- API：Run 输出新增 nullable `initiated_by_username`；canonical `initiated_by_user_id` 保持不变。
- Fallback：当前没有 disabled/deleted User 模型；无法解析 User 时后端返回 `null`，前端显示「未知用户」。
- 数据库：无 schema 变化，因此无需 migration。

## 延后事项与实现妥协

- Deferred ID：无

## 按需检查

- [x] API 发生变化：OpenAPI 与前端生成类型已同步并提交