### PR TITLE
docs(environment): 记录真实 Apptainer 发布证据

### DIFF
--- a/docs/archive/2026-08-29-1615-issue46-environment-publication.md
+++ b/docs/archive/2026-08-29-1615-issue46-environment-publication.md
@@ -1,6 +1,6 @@
 # issue46-environment-publication
 
-- 状态：最终候选（未提交、未推送、未建 PR）
+- 状态：已完成并归档（Issue #46 post-merge closure evidence）
 - 认领：August（本 worktree 唯一文件与 Git writer）
 - 上下文：Issue #46；worktree `/home/august/Projects/ustc_107/107-workspace-46-environment`；branch `feat/46-environment-publication`
 - 开始：2026-08-29 16:15 +0800
@@ -72,3 +72,72 @@ Owned browser/API 进程、临时 DB 与存储目录均已停止或删除。未�
 - Architecture remediation reverify：Environment publication 5 passed；targeted Ruff 与 contract check 通过；ARM inspect 成功返回但发布失败且无 Version，`amd64` 成功路径继续到达真实 CAS scheduler path。
 - Targeted independent re-review：PASS；无剩余 finding。
 - Honest limits：未用真实 Apptainer CLI 做成功发布；这项证据仍由 #46 负责，不转交 #7。#7 只负责下游 Workspace 身份、共享挂载、独立 Worker 与 Slurm 执行接缝。未运行专用 PostgreSQL；未取得 Environment route 的可信浏览器视觉证据；未访问 live 107。
+
+## Post-merge closure：本机真实 Apptainer SIF publication
+
+2026-08-30 在 `origin/main` 提交 `c989f6d1324b893c63923b20f2c58164b5646a7c`
+（#85 已合并）上完成 #46 剩余的真实成功证据。此前“当前机器未安装 Apptainer”的记录
+保留为当时事实；本节是安装 Apptainer 后的新证据，不改写旧观察。
+
+### 环境与输入
+
+- 主机：Arch Linux x86_64；`uname -m` 为 `x86_64`。
+- CLI：Arch package `apptainer 1.5.3-2`，`/usr/bin/apptainer version` 为 `1.5.3`，
+  实际路径 `/usr/bin/apptainer`。
+- OCI 来源：Docker Hub 官方 `library/alpine` 的固定 multi-architecture index
+  `sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1`；
+  使用
+  `docker://docker.io/library/alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1`
+  和 `--arch amd64 --disable-cache` 构建 SIF。任务建议值末尾多一个 `f`，共有 65 个十六
+  进制字符，Apptainer 以 `invalid checksum digest length` 拒绝；去掉多出的末尾字符后，
+  SIF 内 `org.opencontainers.image.base.digest` 和 `from` label 均回报上述固定 digest。
+- 上传 SIF：3,719,168 bytes；
+  SHA-256 `a2954245e29538cd18cb7edbd6d06ef58fa8d4743324bf739261acb4d4bdc695`。
+  独立执行 `/usr/bin/apptainer inspect --json` 成功，标准
+  `org.label-schema.build-arch` 为 `amd64`，构建工具 label 为 Apptainer `1.5.3`。
+
+### 真实 API 与 background processor
+
+- 使用隔离 SQLite database、storage 与 Apptainer cache；配置
+  `WORKSPACE107_AUTH_MODE=dev`、
+  `WORKSPACE107_ENVIRONMENT_PUBLICATION_INTERVAL_SECONDS=0.1`，先执行 Alembic
+  `upgrade head` 和 demo seed，再启动真实 Uvicorn factory app。没有 monkeypatch、CLI double、
+  processor 直调或伪 SIF。
+- 以 `X-User: student` 对 `env_demo_python_2026` 提交真实 multipart
+  `POST /api/v1/catalog/environments/env_demo_python_2026/publication-attempts/apptainer-sif`。
+  HTTP 返回 `202`，attempt `evpa_44938a8dbe7e4ed78df2` 初始状态为 `pending`。
+- Uvicorn lifespan 内的 background loop 随后把 attempt 更新为 `succeeded`，
+  `version_id=ev_0910adbd8b7443d2974a`，没有直接调用 processor。版本标签
+  `issue46-alpine-3.22.1-amd64` 在该 Environment 下计数为 `1`。
+- Version 为 `runtime_kind=apptainer_sif`、`availability=available`；
+  definition 的 `sha256` 与 `locator` 均为上传 SIF SHA-256，`size=3719168`，
+  `architecture=x86_64`、`launcher_module=apptainer/1.4.5`、
+  `exec_policy=apptainer_exec_v1`。`definition_hash` 为
+  `c2933281d52c65e95389580ac39027c736f229a969108efe7dd421ecbbe1a3b7`。
+- validation evidence 为 `validator=apptainer_inspect_v1`、`cli=/usr/bin/apptainer`、
+  `inspect_architecture=amd64`、规范化 `architecture=x86_64`、
+  `byte_size=3719168`；`inspect_sha256` 为
+  `d7b697984c127c8c57d60f9df13ffde1dfcb667c0ae62ce9f43cf0e3963f8134`，
+  `canonical_definition_sha256` 与 Version `definition_hash` 相同。
+
+### CAS、refresh 与不可变性
+
+- CAS 文件位于内容寻址 shard
+  `storage/blobs/a2/a2954245e29538cd18cb7edbd6d06ef58fa8d4743324bf739261acb4d4bdc695`。
+  `cmp` 证明它与上传 SIF byte-for-byte 相同；重新计算 SHA-256 仍为
+  `a2954245e29538cd18cb7edbd6d06ef58fa8d4743324bf739261acb4d4bdc695`，
+  对 CAS 文件再次执行真实 `apptainer inspect --json` 成功且 build arch 仍为 `amd64`。
+- 两次真实 availability refresh 均保持 `available`，reason 更新为
+  `refresh_validated`。refresh 前后以 canonical JSON 计算的不可变字段
+  `definition`、`definition_hash`、`execution_spec`、`validation_summary` 和
+  `validation_evidence` 整体 SHA-256 都是
+  `3e173cdf28aea6a12a51f515b6b3a7cc7b2f8d741cd4d72a55d68db9a6fb2f60`；
+  definition、evidence 与内容 hash 未漂移。
+
+### 证据边界与清理
+
+该证据证明 Arch Linux x86_64、Apptainer `1.5.3` 的本机真实 SIF publication 闭环；
+它不证明 live 107 的 `apptainer/1.4.5` module、共享挂载、Workspace UID/GID、独立 Worker
+或 Slurm 执行，这些端到端边界仍属于 #7。Uvicorn 已停止；隔离 database、storage、cache、
+SIF、其他 `/tmp` 材料和本 worktree 临时 Python environment 均已删除。仓库未保留 SIF、
+日志、数据库或 secret。

--- a/docs/decisions/0004-environment-runtime-publication-contract.md
+++ b/docs/decisions/0004-environment-runtime-publication-contract.md
@@ -5,7 +5,7 @@
 
 ## 背景
 
-107 平台当前运行 Ubuntu 24.04.3，节点共享 `/public` 与 `/home`，使用 Environment Modules，普通用户无 sudo。`docs/references/platform/` 中的平台 PDF 是本决定的平台事实来源。真实 Apptainer CLI 成功发布证据仍由 #46 负责；#7 只负责下游 Workspace 身份、共享挂载、独立 Worker 与 Slurm 执行接缝。
+107 平台当前运行 Ubuntu 24.04.3，节点共享 `/public` 与 `/home`，使用 Environment Modules，普通用户无 sudo。`docs/references/platform/` 中的平台 PDF 是本决定的平台事实来源；live 107 的 Workspace 身份、共享挂载、独立 Worker 与 Slurm 执行接缝仍由 #7 验收。
 
 旧模型把任意 `image` 和 `setup_command` 当作 Environment Version。它既不能证明运行基础确实存在，也允许把任意 shell 注入调度脚本，无法提供可重放的精确运行语义。
 
@@ -29,8 +29,16 @@ Environment publication 使用持久 `EnvironmentPublicationAttempt`，状态仅
 ## 后果
 
 - 好：发布结果可审计、可重放；调度脚本不再执行 Environment 任意 shell；Run 精确语义没有隐式回退。
-- 坏：新增 runtime kind 必须形成新的产品决定；本地缺少 Apptainer 时 SIF publication 只能得到真实失败证据。
+- 坏：新增 runtime kind 必须形成新的产品决定；SIF publication 依赖部署环境提供受支持的 Apptainer CLI，CLI 不可用时只能明确失败。
 - **反悔成本**：高 —— 涉及持久 schema、OpenAPI、Run Snapshot 和调度执行协议。
+
+## 后续验证范围
+
+Issue #46 已在本机 Arch Linux x86_64 上通过真实 Apptainer、HTTP API 与 lifespan background
+processor 完成 SIF publication、CAS identity 和 availability refresh 验证；完整证据见
+[`2026-08-29-1615-issue46-environment-publication.md`](../archive/2026-08-29-1615-issue46-environment-publication.md)。
+该证据不证明 live 107 的 `apptainer/1.4.5` module、共享挂载或 Slurm 执行，相关端到端边界
+仍属于 #7。
 
 ## 重新评估的条件
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -41,11 +41,11 @@ API 容器启动时会执行 Alembic 升级和幂等的本地开发 Compute Plan
 `WORKSPACE107_SEED_DEMO=true` 才额外创建演示资产与 Project。该流程假设单个 API
 实例；扩展到多副本之前，必须把迁移拆成独立的一次性任务。
 
-同一 API 实例的 lifespan 内还运行 Shared Resource publication loop：HTTP 上传只持久化
-publication attempt，loop 随后校验已接受 candidate 的内容寻址 blob，并在成功时发布不可变
-Version；进程重启后可重新认领超过恢复阈值的中断 attempt。它不是独立 Worker，也不支持多个
-API replica 共同处理；当前支持边界仍是上面的单 API 拓扑，不能据此宣称生产就绪或 Issue #46
-全部完成。
+同一 API 实例的 lifespan 内还运行 Environment 与 Shared Resource publication loop：HTTP
+请求只持久化 publication attempt，loop 随后校验候选并在成功时发布不可变 Version。
+只有 Shared Resource loop 会重新认领超过恢复阈值的中断 attempt；两条 loop 都不是独立 Worker，
+也不支持多个 API replica 共同处理。当前支持边界仍是上面的单 API 拓扑，不能据此宣称
+生产就绪。
 
 ## 关键配置
 
@@ -129,8 +129,10 @@ WORKSPACE107_SLURM_JWT=<secret>
 CAS SIF；SIF 发布从 Apptainer `inspect --json` 的标准 build-arch label 读取实际架构，只接受
 `amd64`/`x86_64`，提交前会重新校验摘要并把 CAS locator 解析为计算节点可见的共享存储路径。
 Environment 与 Shared Resource publication processor 当前都是 API 进程内的 durable loop，
-不是独立或多副本 Worker。真实 Apptainer CLI 成功发布证据仍由 #46 负责；#7 只负责下游
-Workspace 身份、共享挂载、独立 Worker、Slurm 凭据和执行接缝的 107 平台端到端验收。
+不是独立或多副本 Worker。Issue #46 的本机真实 Apptainer publication closure 证据见
+[`2026-08-29-1615-issue46-environment-publication.md`](../archive/2026-08-29-1615-issue46-environment-publication.md)；
+它不覆盖 live 107。Workspace 身份、共享挂载、独立 Worker、Slurm 凭据和执行接缝的 107
+平台端到端验收仍属于 #7。
 
 ## 探针和排障
 
@@ -159,7 +161,7 @@ docker compose --project-directory . --file deploy/compose.yaml exec api alembic
 - 建立数据库和用户存储的备份、恢复、保留与清理流程。
 - 在前置网关启用 HTTPS、访问控制、限流和日志采集。
 - 验证 API 请求体上限与 nginx `client_max_body_size` 一致。
-- 多副本部署前拆分数据库迁移、Run 后台状态同步和 Shared Resource publication loop 职责。
+- 多副本部署前拆分数据库迁移、Run 后台状态同步及 Environment / Shared Resource publication loop 职责。
 
 当前 Compose 没有提供 HTTPS、自动备份、多副本编排、监控告警或生产级 Secret
 管理。这些缺口必须显式完成，不能依赖默认配置补齐。

--- a/docs/product/design.md
+++ b/docs/product/design.md
@@ -314,6 +314,9 @@ Project 派生、模板发布与复用
 
 运行环境是由 User 或 User Group 拥有、供 Project 执行代码时复用的独立资产。Run Configuration 与 Run Snapshot 均引用确定的 Environment Version。
 
+Environment Version 当前只支持 `modules` 与 `apptainer_sif` 两种显式 runtime；发布必须通过对应类型校验，失败不得形成可用 Version。
+Run Configuration 与 Run Snapshot 使用确定的 Environment Version；版本不可用或不兼容时明确失败，不自动回退或替换为其他版本。
+
 ```text
 运行环境
 │

--- a/docs/product/design.md
+++ b/docs/product/design.md
@@ -314,22 +314,6 @@ Project 派生、模板发布与复用
 
 运行环境是由 User 或 User Group 拥有、供 Project 执行代码时复用的独立资产。Run Configuration 与 Run Snapshot 均引用确定的 Environment Version。
 
-Environment Version 只允许两种显式 runtime kind：`modules` 与 `apptainer_sif`。
-`modules` 固定使用 107 cluster profile、Environment Modules、`purge_then_ordered_load_v1`
-并按用户选择顺序加载平台精确 allowlist；不接受任意 setup shell 或用户 modulefile。
-`apptainer_sif` 固定记录 CAS 中精确 SIF 字节的 SHA-256、大小、locator、来源、x86_64
-架构、`apptainer/1.4.5` launcher 与固定 exec policy。发布用真实 Apptainer CLI 验证，并从
-`inspect --json` 的标准 build-arch label 读取实际 SIF 架构；只把 `amd64` 与 `x86_64`
-归一为固定 `x86_64`，元数据缺失、格式错误、其他架构或 CLI 不存在时均失败，不降级。
-
-发布由持久 Attempt 驱动，状态为 `pending -> processing -> succeeded|failed`。成功原子创建
-一个不可变 Version，失败不创建 Version并保存原因和证据。不可变定义/验证证据与可变
-`available|unavailable|deprecated` 状态分离。Run Snapshot 冻结精确 Version ID、definition
-hash 与 execution spec；执行前按当前 User、Project Owner、USE Grant 和 availability 重检，
-不回退到其他版本。当前处理循环是单 API 实例能力，不是多副本生产 Worker。真实 Apptainer
-CLI 成功发布证据仍由 #46 负责；#7 只负责下游 Workspace 身份、共享挂载、独立 Worker 与
-Slurm REST、凭据和执行接缝。
-
 ```text
 运行环境
 │


### PR DESCRIPTION
## 关联 Issue

Closes #46

- 关联 #75：保留原实现阶段与审查上下文
- 关联 #85：在其已合并实现上补齐真实 Apptainer 成功证据

## 修改内容

- 将 Issue #46 journal 从活动队列移入 `docs/archive/`，保留当时“未安装 Apptainer”的历史观察，并新增 post-merge closure 段
- 在 deployment 与 ADR 0004 中指向归档证据，移除“真实成功证据仍由 #46 负责”的过期状态
- 从 `docs/product/design.md` 移除 #85 的实现/部署/Issue ownership 叙事，仅保留两条最小产品规则
- 明确保留 live 107 / #7 边界，不修改根 README 的真实集群 milestone 表述

## 环境与命令

- Host：Arch Linux x86_64，`uname -m` = `x86_64`
- Package：`apptainer 1.5.3-2`；CLI：`/usr/bin/apptainer`，version `1.5.3`
- OCI：`docker://docker.io/library/alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1`，`--arch amd64 --disable-cache`
- 上传 SIF：3,719,168 bytes；SHA-256 `a2954245e29538cd18cb7edbd6d06ef58fa8d4743324bf739261acb4d4bdc695`
- 隔离 SQLite / storage / Apptainer cache；Alembic `upgrade head`；demo seed；Uvicorn factory app；`WORKSPACE107_AUTH_MODE=dev`；Environment publication interval `0.1`
- 通过 `X-User: student` multipart HTTP POST、GET 轮询、Version detail、availability refresh、`cmp`、`sha256sum` 与真实 `apptainer inspect --json` 完成验证

任务建议 digest 末尾多一个 `f`（65 个十六进制字符），Apptainer 真实返回 `invalid checksum digest length`；实际使用并由 SIF base labels 回报的是上面的 64 字符固定 digest。

## 关键结果

- POST：HTTP `202`，attempt `evpa_44938a8dbe7e4ed78df2` 初始 `pending`
- Uvicorn lifespan background loop：`succeeded`，`version_id=ev_0910adbd8b7443d2974a`
- Version：`runtime_kind=apptainer_sif`、`available`、`architecture=x86_64`、`launcher_module=apptainer/1.4.5`
- definition `sha256` / `locator` 与上传 SHA 和 CAS identity 完全一致；同标签 Version 数量为 `1`
- validation evidence：`cli=/usr/bin/apptainer`、inspect arch `amd64`、canonical arch `x86_64`
- CAS 文件与上传 SIF byte-for-byte 相同，真实 inspect 成功
- 两次 refresh 均保持 `available`；不可变 definition / evidence / execution spec 合集 SHA-256 前后均为 `3e173cdf28aea6a12a51f515b6b3a7cc7b2f8d741cd4d72a55d68db9a6fb2f60`

## 验证证据

- 真实 Apptainer SIF → HTTP API → lifespan background processor → immutable Version → CAS → refresh smoke：通过
- 原 closure 阶段的 fresh-context review + targeted re-review：PASS，无剩余 BLOCKER / IMPORTANT finding（不代表本轮 remediation 已完成独立复审）
- 本轮 remediation fresh checks：`make check` 通过；`git diff --check` 通过；design 分层检查确认 design 仅保留 WHAT，ADR/ops/archive 分别承载 engineering/deployment/evidence

## 影响范围

- 仅文档与 journal 生命周期收敛
- 不修改产品代码、API、OpenAPI、数据库 schema 或运行时配置
- 不提交 SIF、日志、数据库、storage/cache/temp 或 secret
- 文件清单：`docs/product/design.md`、`docs/archive/2026-08-29-1615-issue46-environment-publication.md`、`docs/decisions/0004-environment-runtime-publication-contract.md`、`docs/operations/deployment.md`

## 延后事项与实现妥协

- Deferred ID：无

## Honest limits

本证据只覆盖本机 Arch Linux x86_64 与 Apptainer 1.5.3。它不证明 live 107 的 `apptainer/1.4.5` module、Workspace UID/GID、共享挂载、独立 Worker、Slurm 凭据或 Slurm 执行；这些平台端到端边界仍属于 #7。未访问 live 107，也不据此宣称生产就绪。