### PR TITLE
feat(run): support adjusted reruns and full downloads

### DIFF
--- a/backend/src/workspace107/api/routes/runs.py
+++ b/backend/src/workspace107/api/routes/runs.py
@@ -6,8 +6,10 @@ from typing import Annotated
 from urllib.parse import quote
 
 from fastapi import APIRouter, Header, Query, Response, status
+from fastapi.responses import StreamingResponse
 
 from ...application.run_service import RunDraft
+from ...domain.models import InputBinding
 from .. import presenters as p
 from .. import schemas as s
 from ..deps import CurrentUser, PageDep, ServicesDep
@@ -116,6 +118,33 @@ async def read_logs(run_id: str, user: CurrentUser, services: ServicesDep) -> li
     ]
 
 
+@router.get(
+    "/runs/{run_id}/logs/download",
+    summary="下载 Run 日志",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "description": "完整 Run 日志",
+            "content": {"text/plain": {"schema": {"type": "string", "format": "binary"}}},
+        }
+    },
+)
+async def download_logs(
+    run_id: str,
+    user: CurrentUser,
+    services: ServicesDep,
+    stream: str = Query(default="combined", pattern="^(stdout|stderr|combined)$"),
+) -> StreamingResponse:
+    """下载完整 stdout、stderr 或合并日志，不受页面尾部预览上限影响。"""
+    body = await services.runs.stream_logs(user.id, run_id, stream)
+    filename = f"{stream}.log"
+    return StreamingResponse(
+        body,
+        media_type="text/plain; charset=utf-8",
+        headers={"Content-Disposition": _content_disposition(filename)},
+    )
+
+
 @router.post("/runs/{run_id}/cancel", response_model=s.RunOut, summary="取消 Run")
 async def cancel_run(run_id: str, user: CurrentUser, services: ServicesDep) -> s.RunOut:
     """需要取消 Run 权限，且 Run 尚未进入终态。
@@ -132,7 +161,7 @@ async def cancel_run(run_id: str, user: CurrentUser, services: ServicesDep) -> s
     response_model=s.RunOut,
     status_code=status.HTTP_201_CREATED,
     summary="重新运行 Run",
-    responses={200: {"model": s.RunOut, "description": "幂等重放，返回上一次重跑的 Run"}},
+    responses={200: {"model": s.RunOut, "description": "幂等重放"}},
 )
 async def rerun(
     run_id: str,
@@ -141,12 +170,46 @@ async def rerun(
     response: Response,
     idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
 ) -> s.RunOut:
-    """需要提交 Run 权限；基于来源快照创建新的 Run 与不可变快照。
-
-    重跑不会修改或重启原 Run，并会按当前权限和资源权益重新校验。带
-    ``Idempotency-Key`` 时，同一个键的重复请求不会产生第二次计算。
-    """
+    """基于历史 Snapshot 精确重跑，来源 Run 不变。"""
     submission = await services.runs.rerun(user.id, run_id, idempotency_key=idempotency_key)
+    if not submission.created:
+        response.status_code = status.HTTP_200_OK
+    return p.run_out(await services.runs.view(submission.run))
+
+
+@router.post(
+    "/runs/{run_id}/rerun/adjusted",
+    response_model=s.RunOut,
+    status_code=status.HTTP_201_CREATED,
+    summary="调整后重新运行 Run",
+    responses={200: {"model": s.RunOut, "description": "幂等重放"}},
+)
+async def adjusted_rerun(
+    run_id: str,
+    payload: s.AdjustedRerunIn,
+    user: CurrentUser,
+    services: ServicesDep,
+    response: Response,
+    idempotency_key: Annotated[str | None, Header(alias="Idempotency-Key")] = None,
+) -> s.RunOut:
+    """以历史 Snapshot 为初始值，调整后创建新的 Run；来源 Run 不变。"""
+    submission = await services.runs.adjusted_rerun(
+        user.id,
+        run_id,
+        RunDraft(
+            run_configuration_id="",
+            project_version_id=payload.project_version_id,
+            name=payload.name,
+            command_override=payload.command,
+            working_directory_override=payload.working_directory,
+            environment_version_id_override=payload.environment_version_id,
+            input_bindings_override=tuple(
+                _to_input_binding(item) for item in payload.input_bindings
+            ),
+            compute_request_override=payload.compute_request.model_dump(),
+        ),
+        idempotency_key=idempotency_key,
+    )
     if not submission.created:
         response.status_code = status.HTTP_200_OK
     return p.run_out(await services.runs.view(submission.run))
@@ -183,14 +246,11 @@ async def list_artifact_files(
 # 生成的前端类型会跟着错，调用方只能靠强制转换绕过去。
 @router.get(
     "/artifacts/{artifact_id}/download",
-    summary="下载 Artifact 文件",
-    # response_class 决定契约里默认写哪种 media type。不写的话默认是
-    # JSONResponse，即使这里又声明了 octet-stream，契约也会同时留着
-    # application/json——等于告诉调用方「可能返回 JSON」，而它从来不会。
-    response_class=Response,
+    summary="下载 Artifact 文件或完整归档",
+    response_class=StreamingResponse,
     responses={
         200: {
-            "description": "产物文件内容",
+            "description": "产物文件或 ZIP 归档",
             "content": {
                 "application/octet-stream": {"schema": {"type": "string", "format": "binary"}}
             },
@@ -201,12 +261,12 @@ async def download_artifact_file(
     artifact_id: str,
     user: CurrentUser,
     services: ServicesDep,
-    path: str = Query(min_length=1),
-) -> Response:
-    """仅对可访问所属 Run 的用户，将 ``path`` 指定的已收集文件作为二进制附件返回。"""
-    data, filename = await services.runs.read_artifact_file(user.id, artifact_id, path)
-    return Response(
-        content=data,
+    path: str | None = Query(default=None, min_length=1),
+) -> StreamingResponse:
+    """下载单文件，或省略 path 下载保持原结构的完整 ZIP 归档。"""
+    body, filename = await services.runs.stream_artifact(user.id, artifact_id, path)
+    return StreamingResponse(
+        body,
         media_type="application/octet-stream",
         headers={"Content-Disposition": _content_disposition(filename)},
     )
@@ -227,6 +287,15 @@ def _content_disposition(filename: str) -> str:
     return f"attachment; filename=\"{fallback}\"; filename*=UTF-8''{quoted}"
 
 
+def _to_input_binding(payload: s.InputBindingModel) -> InputBinding:
+    return InputBinding(
+        source_type=payload.source_type,
+        source_id=payload.source_id,
+        access_path=payload.access_path,
+        source_subpath=payload.source_subpath,
+    )
+
+
 def _to_draft(payload: s.RunDraftIn) -> RunDraft:
     return RunDraft(
         run_configuration_id=payload.run_configuration_id,
@@ -234,6 +303,12 @@ def _to_draft(payload: s.RunDraftIn) -> RunDraft:
         name=payload.name or "",
         command_override=payload.command_override or "",
         working_directory_override=payload.working_directory_override or "",
+        environment_version_id_override=payload.environment_version_id_override or "",
+        input_bindings_override=(
+            tuple(_to_input_binding(item) for item in payload.input_bindings_override)
+            if payload.input_bindings_override is not None
+            else None
+        ),
         compute_request_override=(
             payload.compute_request_override.model_dump()
             if payload.compute_request_override

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -527,19 +527,29 @@ class RunConfigurationOut(Model):
 
 
 class RunDraftIn(Model):
-    """一次提交意图。
-
-    除 run_configuration_id 外都可以不传——不传就用运行方案里的值。
-    这些字段用 ``| None`` 而不是空字符串默认值，是为了让契约如实表达
-    「可以不传」，生成的前端类型才不会要求调用方硬塞一个空串。
-    """
+    """一次提交意图。"""
 
     run_configuration_id: str
     project_version_id: str | None = None
+    """None 表示使用 Project 的最新版本。"""
     name: str | None = None
     command_override: str | None = None
     working_directory_override: str | None = None
+    environment_version_id_override: str | None = None
+    input_bindings_override: list[InputBindingModel] | None = None
     compute_request_override: ComputeRequestModel | None = None
+
+
+class AdjustedRerunIn(Model):
+    """从历史 Run Snapshot 调整后创建新 Run 的完整提交事实。"""
+
+    name: str = Field(min_length=1, max_length=255)
+    project_version_id: str = Field(min_length=1)
+    environment_version_id: str = Field(min_length=1)
+    working_directory: str = "."
+    command: str = Field(min_length=1)
+    input_bindings: list[InputBindingModel] = Field(default_factory=list)
+    compute_request: ComputeRequestModel
 
 
 class PreflightOut(Model):

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -1197,17 +1197,6 @@ def _secret_prefix_suffix_length(text: str, secret_values: list[str]) -> int:
     return longest
 
 
-def _secret_prefix_suffix_length(text: str, secret_values: list[str]) -> int:
-    """Return the longest suffix that can still grow into a known Secret."""
-    longest = 0
-    for value in secret_values:
-        for length in range(min(len(value) - 1, len(text)), longest, -1):
-            if text.endswith(value[:length]):
-                longest = length
-                break
-    return longest
-
-
 def _as_resolved_env(
     literals: dict[str, str], secret_refs: dict[str, SecretReference]
 ) -> ResolvedEnv:

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import codecs
+import re
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
@@ -264,36 +265,40 @@ class RunService:
         self, run_id: str, stream: LogStream, secret_values: list[str]
     ) -> AsyncIterator[bytes]:
         """Redact complete secrets while retaining only possible secret prefixes."""
-        if not secret_values:
+        values = [value for value in secret_values if value]
+        if not values:
             async for raw in self._storage.iter_log(run_id, stream, chunk_size=64 * 1024):
                 yield raw
             return
 
+        pattern = re.compile(
+            "|".join(
+                re.escape(value) for value in sorted(dict.fromkeys(values), key=len, reverse=True)
+            )
+        )
         pending = ""
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         async for raw in self._storage.iter_log(run_id, stream, chunk_size=64 * 1024):
             pending += decoder.decode(raw)
-            complete_end = _last_secret_end(pending, secret_values)
-            if complete_end:
-                remainder = pending[complete_end:]
-                keep = _secret_prefix_suffix_length(remainder, secret_values)
-                if keep:
-                    safe = pending[:complete_end] + remainder[:-keep]
-                    pending = remainder[-keep:]
+            while pending:
+                uncertain_start = len(pending) - _secret_prefix_suffix_length(pending, values)
+                match = pattern.search(pending)
+                if match is None:
+                    if uncertain_start == 0:
+                        break
+                    safe, pending = pending[:uncertain_start], pending[uncertain_start:]
+                elif match.end() <= uncertain_start:
+                    safe, pending = pending[: match.end()], pending[match.end() :]
+                elif uncertain_start and match.start() >= uncertain_start:
+                    safe, pending = pending[:uncertain_start], pending[uncertain_start:]
                 else:
-                    safe, pending = pending, ""
-            else:
-                keep = _secret_prefix_suffix_length(pending, secret_values)
-                if keep:
-                    safe, pending = pending[:-keep], pending[-keep:]
-                else:
-                    safe, pending = pending, ""
-            if safe:
-                yield redact(safe, secret_values).encode("utf-8")
+                    break
+                if safe:
+                    yield redact(safe, values).encode("utf-8")
 
         pending += decoder.decode(b"", final=True)
         if pending:
-            yield redact(pending, secret_values).encode("utf-8")
+            yield redact(pending, values).encode("utf-8")
 
     async def list_artifact_files(self, user_id: str, artifact_id: str) -> list[ArtifactEntry]:
         artifact = await self._require_artifact(user_id, artifact_id)
@@ -1181,20 +1186,15 @@ class RunService:
         return problems
 
 
-def _last_secret_end(text: str, secret_values: list[str]) -> int:
-    """Return the furthest end position of any complete known Secret."""
-    furthest = 0
+def _secret_prefix_suffix_length(text: str, secret_values: list[str]) -> int:
+    """Return the longest suffix that can still grow into a known Secret."""
+    longest = 0
     for value in secret_values:
-        if not value:
-            continue
-        start = 0
-        while True:
-            found = text.find(value, start)
-            if found < 0:
+        for length in range(min(len(value) - 1, len(text)), longest, -1):
+            if text.endswith(value[:length]):
+                longest = length
                 break
-            furthest = max(furthest, found + len(value))
-            start = found + 1
-    return furthest
+    return longest
 
 
 def _secret_prefix_suffix_length(text: str, secret_values: list[str]) -> int:

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -11,6 +11,8 @@
 
 from __future__ import annotations
 
+import codecs
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
 from ..domain import ids
@@ -80,6 +82,8 @@ class RunDraft:
     name: str = ""
     command_override: str = ""
     working_directory_override: str = ""
+    environment_version_id_override: str = ""
+    input_bindings_override: tuple[InputBinding, ...] | None = None
     compute_request_override: dict[str, int] | None = None
 
 
@@ -211,15 +215,7 @@ class RunService:
         """
         access = await self._guard.run(user_id, run_id)
         snapshot = await self._repos.run_snapshots.get(access.run.snapshot_id)
-        secret_values: list[str] = []
-        if snapshot is not None:
-            secret_values = await self._secrets.redaction_values(access.run.id)
-            if (
-                access.run.submitted_at is not None
-                and snapshot.env_secret_refs
-                and not secret_values
-            ):
-                raise ValidationFailed("Run Secret redaction retention is unavailable")
+        secret_values = await self._log_secret_values(access.run, snapshot)
 
         chunks: list[RunLogChunk] = []
         for stream in (LogStream.STDOUT, LogStream.STDERR):
@@ -235,7 +231,52 @@ class RunService:
             )
         return chunks
 
-    # -- Artifact 内容 --------------------------------------------------
+    async def stream_logs(self, user_id: str, run_id: str, stream: str) -> AsyncIterator[bytes]:
+        """授权后流式返回完整日志，避免下载受尾部预览限制或占满内存。"""
+        access = await self._guard.run(user_id, run_id)
+        snapshot = await self._repos.run_snapshots.get(access.run.snapshot_id)
+        secret_values = await self._log_secret_values(access.run, snapshot)
+        streams = (
+            (LogStream.STDOUT, LogStream.STDERR) if stream == "combined" else (LogStream(stream),)
+        )
+
+        async def chunks() -> AsyncIterator[bytes]:
+            for index, selected in enumerate(streams):
+                if index and stream == "combined":
+                    yield b"\n\n--- stderr ---\n"
+                async for chunk in self._redacted_log_chunks(run_id, selected, secret_values):
+                    yield chunk
+
+        return chunks()
+
+    async def _log_secret_values(self, run: Run, snapshot: RunSnapshot | None) -> list[str]:
+        secret_values = await self._secrets.redaction_values(run.id)
+        if (
+            run.submitted_at is not None
+            and snapshot is not None
+            and snapshot.env_secret_refs
+            and not secret_values
+        ):
+            raise ValidationFailed("Run Secret redaction retention is unavailable")
+        return secret_values
+
+    async def _redacted_log_chunks(
+        self, run_id: str, stream: LogStream, secret_values: list[str]
+    ) -> AsyncIterator[bytes]:
+        overlap = max((len(value) for value in secret_values), default=0) - 1
+        carry = ""
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        async for raw in self._storage.iter_log(run_id, stream, chunk_size=64 * 1024):
+            if overlap <= 0:
+                yield raw
+                continue
+            carry += decoder.decode(raw)
+            if len(carry) > overlap:
+                safe, carry = carry[:-overlap], carry[-overlap:]
+                yield redact(safe, secret_values).encode("utf-8")
+        carry += decoder.decode(b"", final=True)
+        if carry:
+            yield redact(carry, secret_values).encode("utf-8")
 
     async def list_artifact_files(self, user_id: str, artifact_id: str) -> list[ArtifactEntry]:
         artifact = await self._require_artifact(user_id, artifact_id)
@@ -248,6 +289,21 @@ class RunService:
         artifact = await self._require_artifact(user_id, artifact_id)
         data = await self._storage.read_artifact_file(artifact.id, path)
         return data, path.rsplit("/", 1)[-1]
+
+    async def stream_artifact(
+        self, user_id: str, artifact_id: str, path: str | None
+    ) -> tuple[AsyncIterator[bytes], str]:
+        artifact = await self._require_artifact(user_id, artifact_id)
+        if path:
+            return (
+                self._storage.iter_artifact_file(artifact.id, path, chunk_size=64 * 1024),
+                path.rsplit("/", 1)[-1],
+            )
+        filename = f"{artifact.name or artifact.id}.zip"
+        return (
+            self._storage.iter_artifact_archive(artifact.id, chunk_size=64 * 1024),
+            filename,
+        )
 
     async def _require_artifact(self, user_id: str, artifact_id: str) -> Artifact:
         """取 Artifact 并校验访问权。
@@ -289,6 +345,7 @@ class RunService:
             configuration,
             access.project.owner,
             problems,
+            draft.environment_version_id_override,
         )
 
         plan = await self._repos.compute_plans.get(configuration.compute_plan_id)
@@ -317,7 +374,14 @@ class RunService:
         )
         problems.extend(resolved.problems)
 
-        problems.extend(await self._check_inputs(user_id, configuration, access.project.owner))
+        problems.extend(
+            await self._check_inputs(
+                user_id,
+                configuration,
+                access.project.owner,
+                draft.input_bindings_override,
+            )
+        )
 
         return PreflightResult(
             problems=problems,
@@ -387,7 +451,11 @@ class RunService:
             resolved_env=_as_resolved_env(
                 result.resolved_env_literals, result.resolved_env_secret_refs
             ),
-            input_bindings=configuration.input_bindings,
+            input_bindings=(
+                draft.input_bindings_override
+                if draft.input_bindings_override is not None
+                else configuration.input_bindings
+            ),
             compute_plan_id=result.compute_plan.id,
             compute_request=result.compute_request,
             scheduler=resolve_scheduler_configuration(result.compute_plan, result.compute_request),
@@ -396,7 +464,6 @@ class RunService:
             created_at=now,
         )
         await self._repos.run_snapshots.add(snapshot)
-
         run = Run(
             id=ids.new_id(ids.RUN),
             project_id=project_id,
@@ -511,6 +578,109 @@ class RunService:
             access.project.owner,
             ActivityAction.RUN_SUBMITTED,
             detail=f"重跑自 {access.run.name}",
+        )
+        return RunSubmission(run=run, created=True)
+
+    async def adjusted_rerun(
+        self,
+        user_id: str,
+        run_id: str,
+        draft: RunDraft,
+        *,
+        idempotency_key: str | None = None,
+    ) -> RunSubmission:
+        """以历史 Snapshot 为基线，调整配置后创建新的 Run。"""
+        access = await self._guard.run(user_id, run_id, needs=Capability.RUN_SUBMIT)
+        replayed = await self._replay_or_reserve(
+            user_id, idempotency_key, "adjusted_rerun", source_run_id=run_id
+        )
+        if replayed is not None:
+            return RunSubmission(run=replayed, created=False)
+
+        source = await self._repos.run_snapshots.get(access.run.snapshot_id)
+        if source is None:  # pragma: no cover - 数据损坏才会发生
+            raise ObjectNotFound("Run Snapshot", access.run.snapshot_id)
+        await self._repos.entitlements.lock_for_plan(user_id, source.compute_plan_id)
+
+        project_version = await self._repos.project_versions.get(draft.project_version_id or "")
+        environment_version = await environment_version_for_owner_use(
+            self._repos,
+            user_id,
+            draft.environment_version_id_override or source.environment_version_id,
+            access.project.owner,
+        )
+        plan = await self._repos.compute_plans.get(source.compute_plan_id)
+        problems: list[str] = []
+        if not draft.command_override.strip():
+            problems.append("执行命令不能为空")
+        if project_version is None or project_version.project_id != source.project_id:
+            problems.append("调整后的 Project Version 不存在或不属于当前 Project")
+        if environment_version is None:
+            problems.append("调整后的运行环境版本不存在或无权供当前 Project 使用")
+        elif environment_version.availability.value != "available":
+            problems.append(f"运行环境版本 {environment_version.version} 当前不可用")
+        if plan is None:
+            problems.append("来源算力方案已不存在")
+        if problems:
+            raise PreflightRejected(problems)
+        assert project_version is not None and environment_version is not None and plan is not None
+
+        request = (
+            ComputeRequest(**draft.compute_request_override)
+            if draft.compute_request_override is not None
+            else source.compute_request
+        )
+        bindings = draft.input_bindings_override
+        candidate = build_snapshot(
+            snapshot_id=ids.new_id(ids.RUN_SNAPSHOT),
+            project_id=source.project_id,
+            project_version_id=project_version.id,
+            source_run_configuration_id=source.source_run_configuration_id,
+            working_directory=draft.working_directory_override or source.working_directory,
+            command=(draft.command_override or source.command).strip(),
+            environment_version_id=environment_version.id,
+            environment_definition_hash=environment_version.definition_hash,
+            environment_execution_spec=environment_version.execution_spec,
+            resolved_env=_as_resolved_env(source.env_literals, source.env_secret_refs),
+            input_bindings=bindings if bindings is not None else source.input_bindings,
+            compute_plan_id=plan.id,
+            compute_request=request,
+            scheduler=resolve_scheduler_configuration(plan, request),
+            artifact_rules=source.artifact_rules,
+            initiated_by_user_id=user_id,
+            created_at=self._clock.now(),
+        )
+        problems = await self._revalidate_snapshot(candidate, access, user_id)
+        if problems:
+            raise PreflightRejected(problems)
+
+        await self._repos.run_snapshots.add(candidate)
+        run = Run(
+            id=ids.new_id(ids.RUN),
+            project_id=source.project_id,
+            project_version_id=project_version.id,
+            project_version_label=project_version.label,
+            snapshot_id=candidate.id,
+            compute_plan_id=candidate.compute_plan_id,
+            source_run_configuration_id=source.source_run_configuration_id,
+            source_run_id=access.run.id,
+            name=draft.name.strip() or access.run.name,
+            status=RunStatus.QUEUED,
+            initiated_by_user_id=user_id,
+            created_at=candidate.created_at,
+        )
+        await self._repos.runs.add(run)
+        await self._record_event(
+            run.id, RunEventType.CREATED, f"基于 Run {access.run.id} 调整后重新运行"
+        )
+        await self._attach_idempotency(user_id, idempotency_key, run.id)
+        await self._submit(run, candidate, project_version)
+        await self._record_run_activity(
+            user_id,
+            run,
+            access.project.owner,
+            ActivityAction.RUN_SUBMITTED,
+            detail=f"调整后重跑自 {access.run.name}",
         )
         return RunSubmission(run=run, created=True)
 
@@ -720,13 +890,12 @@ class RunService:
         configuration: RunConfiguration,
         project_owner: OwnerReference,
         problems: list[str],
+        override_id: str = "",
     ) -> EnvironmentVersion | None:
-        """运行方案必须精确引用一个 Environment Version（#41、GR-205）。
-
-        没有任何继承或回退：运行时只使用保存运行方案时已经确定的 Environment Version。
-        """
+        """Resolve the exact Environment Version selected for this submission."""
+        version_id = override_id or configuration.environment_version_id
         version = await environment_version_for_owner_use(
-            self._repos, user_id, configuration.environment_version_id, project_owner
+            self._repos, user_id, version_id, project_owner
         )
         if version is None:
             problems.append("运行方案引用的运行环境版本不存在或无权供当前 Project 使用")
@@ -836,9 +1005,11 @@ class RunService:
         user_id: str,
         configuration: RunConfiguration,
         project_owner: OwnerReference,
+        bindings: tuple[InputBinding, ...] | None = None,
     ) -> list[str]:
         problems: list[str] = []
-        for binding in configuration.input_bindings:
+        selected = bindings if bindings is not None else configuration.input_bindings
+        for binding in selected:
             if binding.source_type is InputSourceType.ARTIFACT:
                 problem = await self._artifact_input_problem(
                     binding.source_id, binding.access_path, project_owner

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -263,20 +263,27 @@ class RunService:
     async def _redacted_log_chunks(
         self, run_id: str, stream: LogStream, secret_values: list[str]
     ) -> AsyncIterator[bytes]:
-        overlap = max((len(value) for value in secret_values), default=0) - 1
-        carry = ""
+        """Redact complete secrets while retaining only possible secret prefixes."""
+        if not secret_values:
+            async for raw in self._storage.iter_log(run_id, stream, chunk_size=64 * 1024):
+                yield raw
+            return
+
+        pending = ""
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         async for raw in self._storage.iter_log(run_id, stream, chunk_size=64 * 1024):
-            if overlap <= 0:
-                yield raw
-                continue
-            carry += decoder.decode(raw)
-            if len(carry) > overlap:
-                safe, carry = carry[:-overlap], carry[-overlap:]
+            pending += decoder.decode(raw)
+            keep = _secret_prefix_suffix_length(pending, secret_values)
+            if keep:
+                safe, pending = pending[:-keep], pending[-keep:]
+            else:
+                safe, pending = pending, ""
+            if safe:
                 yield redact(safe, secret_values).encode("utf-8")
-        carry += decoder.decode(b"", final=True)
-        if carry:
-            yield redact(carry, secret_values).encode("utf-8")
+
+        pending += decoder.decode(b"", final=True)
+        if pending:
+            yield redact(pending, secret_values).encode("utf-8")
 
     async def list_artifact_files(self, user_id: str, artifact_id: str) -> list[ArtifactEntry]:
         artifact = await self._require_artifact(user_id, artifact_id)
@@ -1162,6 +1169,17 @@ class RunService:
                     problems.append(problem)
 
         return problems
+
+
+def _secret_prefix_suffix_length(text: str, secret_values: list[str]) -> int:
+    """Return the longest suffix that can still grow into a known Secret."""
+    longest = 0
+    for value in secret_values:
+        for length in range(min(len(value) - 1, len(text)), longest, -1):
+            if text.endswith(value[:length]):
+                longest = length
+                break
+    return longest
 
 
 def _as_resolved_env(

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -273,11 +273,21 @@ class RunService:
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         async for raw in self._storage.iter_log(run_id, stream, chunk_size=64 * 1024):
             pending += decoder.decode(raw)
-            keep = _secret_prefix_suffix_length(pending, secret_values)
-            if keep:
-                safe, pending = pending[:-keep], pending[-keep:]
+            complete_end = _last_secret_end(pending, secret_values)
+            if complete_end:
+                remainder = pending[complete_end:]
+                keep = _secret_prefix_suffix_length(remainder, secret_values)
+                if keep:
+                    safe = pending[:complete_end] + remainder[:-keep]
+                    pending = remainder[-keep:]
+                else:
+                    safe, pending = pending, ""
             else:
-                safe, pending = pending, ""
+                keep = _secret_prefix_suffix_length(pending, secret_values)
+                if keep:
+                    safe, pending = pending[:-keep], pending[-keep:]
+                else:
+                    safe, pending = pending, ""
             if safe:
                 yield redact(safe, secret_values).encode("utf-8")
 
@@ -1169,6 +1179,22 @@ class RunService:
                     problems.append(problem)
 
         return problems
+
+
+def _last_secret_end(text: str, secret_values: list[str]) -> int:
+    """Return the furthest end position of any complete known Secret."""
+    furthest = 0
+    for value in secret_values:
+        if not value:
+            continue
+        start = 0
+        while True:
+            found = text.find(value, start)
+            if found < 0:
+                break
+            furthest = max(furthest, found + len(value))
+            start = found + 1
+    return furthest
 
 
 def _secret_prefix_suffix_length(text: str, secret_values: list[str]) -> int:

--- a/backend/src/workspace107/domain/ports/storage.py
+++ b/backend/src/workspace107/domain/ports/storage.py
@@ -9,6 +9,7 @@ Version 不会重复占用空间，而且 ProjectVersion 的不可变性天然�
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -119,6 +120,24 @@ class StoragePort(Protocol):
         """读取日志尾部，返回内容和是否被截断。"""
         ...
 
+    async def iter_log(
+        self, run_id: str, stream: LogStream, *, chunk_size: int
+    ) -> AsyncIterator[bytes]:
+        """以小块读取完整日志，不把文件一次性载入应用内存。"""
+        ...
+
+    async def iter_artifact_file(
+        self, artifact_id: str, path: str, *, chunk_size: int
+    ) -> AsyncIterator[bytes]:
+        """以小块读取 Artifact 文件。"""
+        ...
+
+    async def iter_artifact_archive(
+        self, artifact_id: str, *, chunk_size: int
+    ) -> AsyncIterator[bytes]:
+        """以小块读取 Artifact 的完整归档。"""
+        ...
+
     async def cleanup_run_directory(self, run_id: str) -> None: ...
 
     # -- Artifact -------------------------------------------------------
@@ -135,10 +154,6 @@ class StoragePort(Protocol):
     async def list_artifact_files(self, artifact_id: str) -> list[ArtifactEntry]: ...
 
     async def read_artifact_file(self, artifact_id: str, path: str) -> bytes: ...
-
     async def delete_artifact_content(self, artifact_id: str) -> None:
-        """删除 Artifact 的存储内容。
-
-        当前实现只删内容、不删记录，使历史 Run 仍能显示标识、摘要和清理状态。
-        """
+        """删除 Artifact 的存储内容。"""
         ...

--- a/backend/src/workspace107/infrastructure/storage/local.py
+++ b/backend/src/workspace107/infrastructure/storage/local.py
@@ -24,6 +24,8 @@ import contextlib
 import hashlib
 import os
 import shutil
+import tempfile
+import zipfile
 from pathlib import Path
 
 from ...domain.enums import InputSourceType, LogStream
@@ -170,6 +172,12 @@ class LocalStorage:
         target = paths.stdout if stream is LogStream.STDOUT else paths.stderr
         return await asyncio.to_thread(_read_tail, target, max_bytes)
 
+    async def iter_log(self, run_id: str, stream: LogStream, *, chunk_size: int):
+        paths = self.run_paths(run_id)
+        target = paths.stdout if stream is LogStream.STDOUT else paths.stderr
+        async for chunk in _read_chunks(target, chunk_size):
+            yield chunk
+
     async def cleanup_run_directory(self, run_id: str) -> None:
         await asyncio.to_thread(_force_rmtree, self.run_paths(run_id).root)
 
@@ -225,9 +233,29 @@ class LocalStorage:
     async def read_artifact_file(self, artifact_id: str, path: str) -> bytes:
         root = (self._artifacts / artifact_id).resolve()
         target = (root / path).resolve()
-        if not str(target).startswith(str(root)) or not target.is_file():
+        if root not in target.parents or not target.is_file():
             raise ObjectNotFound("Artifact 文件", path)
         return await asyncio.to_thread(target.read_bytes)
+
+    async def iter_artifact_file(self, artifact_id: str, path: str, *, chunk_size: int):
+        root = (self._artifacts / artifact_id).resolve()
+        target = (root / path).resolve()
+        if root not in target.parents or not target.is_file():
+            raise ObjectNotFound("Artifact 文件", path)
+        async for chunk in _read_chunks(target, chunk_size):
+            yield chunk
+
+    async def iter_artifact_archive(self, artifact_id: str, *, chunk_size: int):
+        root = (self._artifacts / artifact_id).resolve()
+        if not root.is_dir():
+            raise ObjectNotFound("Artifact 内容", artifact_id)
+        temporary = await asyncio.to_thread(_create_archive, root)
+        try:
+            async for chunk in _read_chunks(temporary, chunk_size):
+                yield chunk
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                await asyncio.to_thread(temporary.unlink)
 
     async def delete_artifact_content(self, artifact_id: str) -> None:
         await asyncio.to_thread(_force_rmtree, self._artifacts / artifact_id)
@@ -251,6 +279,36 @@ def _file_sha256(path: Path) -> str:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+async def _read_chunks(path: Path, chunk_size: int):
+    if not await asyncio.to_thread(path.is_file):
+        return
+    handle = await asyncio.to_thread(path.open, "rb")
+    try:
+        while True:
+            chunk = await asyncio.to_thread(handle.read, chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        await asyncio.to_thread(handle.close)
+
+
+def _create_archive(root: Path) -> Path:
+    with tempfile.NamedTemporaryFile(
+        prefix="workspace107-artifact-", suffix=".zip", delete=False
+    ) as handle:
+        archive = Path(handle.name)
+    try:
+        with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+            for path in sorted(root.rglob("*")):
+                if path.is_file() and not path.is_symlink():
+                    bundle.write(path, path.relative_to(root).as_posix())
+    except Exception:
+        archive.unlink(missing_ok=True)
+        raise
+    return archive
 
 
 def _read_tail(path: Path, max_bytes: int) -> tuple[str, bool]:

--- a/backend/tests/integration/test_run_reproduce_download.py
+++ b/backend/tests/integration/test_run_reproduce_download.py
@@ -123,7 +123,7 @@ async def test_run_logs_and_artifact_downloads_are_complete(client, session) -> 
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("secret_value", ["ABCDEF", "Z"])
+@pytest.mark.parametrize("secret_value", ["ABCDEF", "Z", "aaa"])
 async def test_log_download_redacts_secret_across_chunk_boundary(
     client, session, secret_value
 ) -> None:

--- a/backend/tests/integration/test_run_reproduce_download.py
+++ b/backend/tests/integration/test_run_reproduce_download.py
@@ -123,9 +123,12 @@ async def test_run_logs_and_artifact_downloads_are_complete(client, session) -> 
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("secret_value", ["ABCDEF", "Z", "aaa"])
+@pytest.mark.parametrize(
+    ("secret_value", "padding", "repetitions"),
+    [("ABCDEF", 65535, 1), ("Z", 65535, 1), ("aaa", 65535, 1), ("aa", 65533, 2)],
+)
 async def test_log_download_redacts_secret_across_chunk_boundary(
-    client, session, secret_value
+    client, session, secret_value, padding, repetitions
 ) -> None:
     _, environment_version_id = await use_default_environment(session, client)
     project = await create_project_with_version(client, name="stream-redaction")
@@ -140,7 +143,9 @@ async def test_log_download_redacts_secret_across_chunk_boundary(
         json={
             "name": "boundary",
             "command": (
-                "python -c \"import os,sys; sys.stdout.write('x' * 65535 + os.environ['TOKEN'])\""
+                f'python -c "import os,sys; '
+                f"sys.stdout.write('x' * {padding} + "
+                f"os.environ['TOKEN'] * {repetitions})\""
             ),
             "compute_plan_id": "plan_cpu_quick",
             "environment_version_id": environment_version_id,

--- a/backend/tests/integration/test_run_reproduce_download.py
+++ b/backend/tests/integration/test_run_reproduce_download.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+from tests.helpers import (
+    create_project_with_version,
+    grant_test_entitlement,
+    use_default_environment,
+    wait_for_run,
+)
+
+
+@pytest.mark.asyncio
+async def test_adjusted_rerun_creates_new_snapshot_without_mutating_source(client, session) -> None:
+    _, environment_version_id = await use_default_environment(session, client)
+    project = await create_project_with_version(client, name="adjusted-rerun")
+    await grant_test_entitlement(session, "student")
+    configuration = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "source",
+            "command": "echo original",
+            "compute_plan_id": "plan_cpu_quick",
+            "environment_version_id": environment_version_id,
+        },
+    )
+    assert configuration.status_code == 201
+    created = await client.post(
+        f"/api/v1/projects/{project['id']}/runs",
+        json={"run_configuration_id": configuration.json()["id"]},
+    )
+    assert created.status_code == 201
+    source = await wait_for_run(client, created.json()["id"])
+
+    adjusted = await client.post(
+        f"/api/v1/runs/{created.json()['id']}/rerun/adjusted",
+        json={
+            "name": "adjusted",
+            "project_version_id": source["snapshot"]["project_version_id"],
+            "environment_version_id": environment_version_id,
+            "working_directory": ".",
+            "command": "echo adjusted",
+            "compute_request": source["snapshot"]["compute_request"],
+            "input_bindings": [],
+        },
+    )
+    assert adjusted.status_code == 201, adjusted.text
+    assert adjusted.json()["id"] != created.json()["id"]
+    assert adjusted.json()["source_run_id"] == created.json()["id"]
+
+    adjusted_detail = await wait_for_run(client, adjusted.json()["id"])
+    assert adjusted_detail["snapshot"]["command"] == "echo adjusted"
+    assert adjusted_detail["snapshot"]["environment_version_id"] == environment_version_id
+    source_again = await client.get(f"/api/v1/runs/{created.json()['id']}")
+    assert source_again.json()["snapshot"]["command"] == "echo original"
+
+    invalid = await client.post(
+        f"/api/v1/runs/{created.json()['id']}/rerun/adjusted",
+        json={
+            "name": "invalid",
+            "project_version_id": source["snapshot"]["project_version_id"],
+            "environment_version_id": "env_missing",
+            "working_directory": ".",
+            "command": "echo invalid",
+            "compute_request": source["snapshot"]["compute_request"],
+            "input_bindings": [],
+        },
+    )
+    assert invalid.status_code == 422
+    assert "运行环境版本" in invalid.text
+
+
+@pytest.mark.asyncio
+async def test_run_logs_and_artifact_downloads_are_complete(client, session) -> None:
+    _, environment_version_id = await use_default_environment(session, client)
+    project = await create_project_with_version(client, name="run-downloads")
+    await grant_test_entitlement(session, "student")
+    configuration = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "outputs",
+            "command": (
+                'python -c "from pathlib import Path; '
+                "Path('outputs').mkdir(); "
+                "Path('outputs/result.txt').write_text('artifact-content'); "
+                "print('x' * 300000)\""
+            ),
+            "compute_plan_id": "plan_cpu_quick",
+            "environment_version_id": environment_version_id,
+            "artifact_rules": [{"path": "outputs", "name": "outputs", "optional": False}],
+        },
+    )
+    assert configuration.status_code == 201
+    created = await client.post(
+        f"/api/v1/projects/{project['id']}/runs",
+        json={"run_configuration_id": configuration.json()["id"]},
+    )
+    assert created.status_code == 201
+    detail = await wait_for_run(client, created.json()["id"])
+    artifact = detail["artifacts"][0]
+
+    logs = await client.get(
+        f"/api/v1/runs/{created.json()['id']}/logs/download",
+        params={"stream": "stdout"},
+    )
+    assert logs.status_code == 200
+    assert len(logs.content) > 300000
+    assert 'filename="stdout.log"' in logs.headers["content-disposition"]
+
+    archive = await client.get(f"/api/v1/artifacts/{artifact['id']}/download")
+    assert archive.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(archive.content)) as bundle:
+        assert bundle.namelist() == ["result.txt"]
+        assert bundle.read("result.txt") == b"artifact-content"
+
+    foreign = await client.get(
+        f"/api/v1/artifacts/{artifact['id']}/download", headers={"X-User": "foreign"}
+    )
+    assert foreign.status_code == 404

--- a/backend/tests/integration/test_run_reproduce_download.py
+++ b/backend/tests/integration/test_run_reproduce_download.py
@@ -120,3 +120,45 @@ async def test_run_logs_and_artifact_downloads_are_complete(client, session) -> 
         f"/api/v1/artifacts/{artifact['id']}/download", headers={"X-User": "foreign"}
     )
     assert foreign.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("secret_value", ["ABCDEF", "Z"])
+async def test_log_download_redacts_secret_across_chunk_boundary(
+    client, session, secret_value
+) -> None:
+    _, environment_version_id = await use_default_environment(session, client)
+    project = await create_project_with_version(client, name="stream-redaction")
+    await grant_test_entitlement(session, "student")
+    secret = await client.put(
+        f"/api/v1/projects/{project['id']}/secrets",
+        json={"name": "TOKEN", "value": secret_value},
+    )
+    assert secret.status_code == 204
+    configuration = await client.post(
+        f"/api/v1/projects/{project['id']}/run-configurations",
+        json={
+            "name": "boundary",
+            "command": (
+                "python -c \"import os,sys; sys.stdout.write('x' * 65535 + os.environ['TOKEN'])\""
+            ),
+            "compute_plan_id": "plan_cpu_quick",
+            "environment_version_id": environment_version_id,
+            "environment_variables": {"TOKEN": "${{ secrets.TOKEN }}"},
+        },
+    )
+    assert configuration.status_code == 201
+    created = await client.post(
+        f"/api/v1/projects/{project['id']}/runs",
+        json={"run_configuration_id": configuration.json()["id"]},
+    )
+    assert created.status_code == 201
+    await wait_for_run(client, created.json()["id"])
+
+    logs = await client.get(
+        f"/api/v1/runs/{created.json()['id']}/logs/download",
+        params={"stream": "stdout"},
+    )
+    assert logs.status_code == 200
+    assert secret_value.encode() not in logs.content
+    assert logs.content.endswith(b"***")

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -96,6 +96,56 @@
         "title": "ActivityOut",
         "type": "object"
       },
+      "AdjustedRerunIn": {
+        "description": "从历史 Run Snapshot 调整后创建新 Run 的完整提交事实。",
+        "properties": {
+          "command": {
+            "minLength": 1,
+            "title": "Command",
+            "type": "string"
+          },
+          "compute_request": {
+            "$ref": "#/components/schemas/ComputeRequestModel"
+          },
+          "environment_version_id": {
+            "minLength": 1,
+            "title": "Environment Version Id",
+            "type": "string"
+          },
+          "input_bindings": {
+            "items": {
+              "$ref": "#/components/schemas/InputBindingModel"
+            },
+            "title": "Input Bindings",
+            "type": "array"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "project_version_id": {
+            "minLength": 1,
+            "title": "Project Version Id",
+            "type": "string"
+          },
+          "working_directory": {
+            "default": ".",
+            "title": "Working Directory",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "project_version_id",
+          "environment_version_id",
+          "command",
+          "compute_request"
+        ],
+        "title": "AdjustedRerunIn",
+        "type": "object"
+      },
       "ArtifactEntryOut": {
         "properties": {
           "path": {
@@ -2467,7 +2517,7 @@
         "type": "object"
       },
       "RunDraftIn": {
-        "description": "一次提交意图。\n\n除 run_configuration_id 外都可以不传——不传就用运行方案里的值。\n这些字段用 ``| None`` 而不是空字符串默认值，是为了让契约如实表达\n「可以不传」，生成的前端类型才不会要求调用方硬塞一个空串。",
+        "description": "一次提交意图。",
         "properties": {
           "command_override": {
             "anyOf": [
@@ -2490,6 +2540,31 @@
               }
             ]
           },
+          "environment_version_id_override": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Environment Version Id Override"
+          },
+          "input_bindings_override": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/InputBindingModel"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Bindings Override"
+          },
           "name": {
             "anyOf": [
               {
@@ -2510,6 +2585,7 @@
                 "type": "null"
               }
             ],
+            "description": "None 表示使用 Project 的最新版本。",
             "title": "Project Version Id"
           },
           "run_configuration_id": {
@@ -3762,7 +3838,7 @@
   "paths": {
     "/api/v1/artifacts/{artifact_id}/download": {
       "get": {
-        "description": "仅对可访问所属 Run 的用户，将 ``path`` 指定的已收集文件作为二进制附件返回。",
+        "description": "下载单文件，或省略 path 下载保持原结构的完整 ZIP 归档。",
         "operationId": "download_artifact_file_api_v1_artifacts__artifact_id__download_get",
         "parameters": [
           {
@@ -3777,11 +3853,18 @@
           {
             "in": "query",
             "name": "path",
-            "required": true,
+            "required": false,
             "schema": {
-              "minLength": 1,
-              "title": "Path",
-              "type": "string"
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Path"
             }
           },
           {
@@ -3811,7 +3894,7 @@
                 }
               }
             },
-            "description": "产物文件内容"
+            "description": "产物文件或 ZIP 归档"
           },
           "400": {
             "content": {
@@ -3874,7 +3957,7 @@
             "description": "底层调度系统返回错误"
           }
         },
-        "summary": "下载 Artifact 文件",
+        "summary": "下载 Artifact 文件或完整归档",
         "tags": [
           "run"
         ]
@@ -10917,9 +11000,130 @@
         ]
       }
     },
+    "/api/v1/runs/{run_id}/logs/download": {
+      "get": {
+        "description": "下载完整 stdout、stderr 或合并日志，不受页面尾部预览上限影响。",
+        "operationId": "download_logs_api_v1_runs__run_id__logs_download_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "stream",
+            "required": false,
+            "schema": {
+              "default": "combined",
+              "pattern": "^(stdout|stderr|combined)$",
+              "title": "Stream",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "完整 Run 日志"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "下载 Run 日志",
+        "tags": [
+          "run"
+        ]
+      }
+    },
     "/api/v1/runs/{run_id}/rerun": {
       "post": {
-        "description": "需要提交 Run 权限；基于来源快照创建新的 Run 与不可变快照。\n\n重跑不会修改或重启原 Run，并会按当前权限和资源权益重新校验。带\n``Idempotency-Key`` 时，同一个键的重复请求不会产生第二次计算。",
+        "description": "基于历史 Snapshot 精确重跑，来源 Run 不变。",
         "operationId": "rerun_api_v1_runs__run_id__rerun_post",
         "parameters": [
           {
@@ -10973,7 +11177,7 @@
                 }
               }
             },
-            "description": "幂等重放，返回上一次重跑的 Run"
+            "description": "幂等重放"
           },
           "201": {
             "content": {
@@ -11047,6 +11251,151 @@
           }
         },
         "summary": "重新运行 Run",
+        "tags": [
+          "run"
+        ]
+      }
+    },
+    "/api/v1/runs/{run_id}/rerun/adjusted": {
+      "post": {
+        "description": "以历史 Snapshot 为初始值，调整后创建新的 Run；来源 Run 不变。",
+        "operationId": "adjusted_rerun_api_v1_runs__run_id__rerun_adjusted_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-User",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-User"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdjustedRerunIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunOut"
+                }
+              }
+            },
+            "description": "幂等重放"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "请求不合法"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象可见，但当前角色无权执行该操作"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "对象不存在，或当前用户没有发现权限"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "与现有状态冲突，例如重名或对象不可修改"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "参数校验或提交前检查未通过，problems 列出全部原因"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "底层调度系统返回错误"
+          }
+        },
+        "summary": "调整后重新运行 Run",
         "tags": [
           "run"
         ]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,8 @@ import type {
   ApiErrorBody,
   ArtifactEntry,
   ComputePlan,
+  ComputeRequest,
+  InputBinding,
   Entitlement,
   Environment,
   EnvironmentPublicationAttempt,
@@ -670,6 +672,45 @@ export const api = {
         },
       }),
     ),
+  adjustedRerun: async (
+    id: string,
+    payload: {
+      name: string
+      project_version_id: string
+      environment_version_id: string
+      working_directory: string
+      command: string
+      input_bindings: InputBinding[]
+      compute_request: ComputeRequest
+    },
+    idempotencyKey?: string,
+  ): Promise<Run> =>
+    unwrap(
+      await http.POST('/api/v1/runs/{run_id}/rerun/adjusted', {
+        params: {
+          path: { run_id: id },
+          header: { 'Idempotency-Key': idempotencyKey ?? null },
+        },
+        body: payload,
+      }),
+    ),
+
+  downloadLogs: async (id: string, stream: 'stdout' | 'stderr' | 'combined'): Promise<void> => {
+    const result = unwrap(
+      await http.GET('/api/v1/runs/{run_id}/logs/download', {
+        params: { path: { run_id: id }, query: { stream } },
+        parseAs: 'blob',
+      }),
+    )
+    const url = URL.createObjectURL(result)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = `${stream}.log`
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  },
 
   syncRuns: async (): Promise<{ changed: number }> => unwrap(await http.POST('/api/v1/runs/sync')),
 
@@ -689,23 +730,18 @@ export const api = {
       }),
     ),
 
-  /**
-   * 下载 Artifact 文件。
-   *
-   * 走 fetch 而不是直接给 `<a href>`，因为下载同样需要带上身份请求头——
-   * 否则浏览器会用默认身份去取，拿到 404。
-   */
-  downloadArtifactFile: async (id: string, path: string): Promise<void> => {
+  /** 下载 Artifact 文件；省略 path 时由后端返回完整 ZIP。 */
+  downloadArtifactFile: async (id: string, path?: string): Promise<void> => {
     const blob = unwrap(
       await http.GET('/api/v1/artifacts/{artifact_id}/download', {
-        params: { path: { artifact_id: id }, query: { path } },
+        params: { path: { artifact_id: id }, query: path ? { path } : {} },
         parseAs: 'blob',
       }),
     )
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
-    link.download = path.split('/').pop() ?? 'artifact'
+    link.download = path?.split('/').pop() ?? 'artifact.zip'
     document.body.appendChild(link)
     link.click()
     link.remove()

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -12,8 +12,8 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * 下载 Artifact 文件
-         * @description 仅对可访问所属 Run 的用户，将 ``path`` 指定的已收集文件作为二进制附件返回。
+         * 下载 Artifact 文件或完整归档
+         * @description 下载单文件，或省略 path 下载保持原结构的完整 ZIP 归档。
          */
         get: operations["download_artifact_file_api_v1_artifacts__artifact_id__download_get"];
         put?: never;
@@ -1073,6 +1073,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/runs/{run_id}/logs/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 下载 Run 日志
+         * @description 下载完整 stdout、stderr 或合并日志，不受页面尾部预览上限影响。
+         */
+        get: operations["download_logs_api_v1_runs__run_id__logs_download_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/runs/{run_id}/rerun": {
         parameters: {
             query?: never;
@@ -1084,12 +1104,29 @@ export interface paths {
         put?: never;
         /**
          * 重新运行 Run
-         * @description 需要提交 Run 权限；基于来源快照创建新的 Run 与不可变快照。
-         *
-         *     重跑不会修改或重启原 Run，并会按当前权限和资源权益重新校验。带
-         *     ``Idempotency-Key`` 时，同一个键的重复请求不会产生第二次计算。
+         * @description 基于历史 Snapshot 精确重跑，来源 Run 不变。
          */
         post: operations["rerun_api_v1_runs__run_id__rerun_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/runs/{run_id}/rerun/adjusted": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 调整后重新运行 Run
+         * @description 以历史 Snapshot 为初始值，调整后创建新的 Run；来源 Run 不变。
+         */
+        post: operations["adjusted_rerun_api_v1_runs__run_id__rerun_adjusted_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1692,6 +1729,28 @@ export interface components {
             /** Target Name */
             target_name: string;
             target_type: components["schemas"]["TargetType"];
+        };
+        /**
+         * AdjustedRerunIn
+         * @description 从历史 Run Snapshot 调整后创建新 Run 的完整提交事实。
+         */
+        AdjustedRerunIn: {
+            /** Command */
+            command: string;
+            compute_request: components["schemas"]["ComputeRequestModel"];
+            /** Environment Version Id */
+            environment_version_id: string;
+            /** Input Bindings */
+            input_bindings?: components["schemas"]["InputBindingModel"][];
+            /** Name */
+            name: string;
+            /** Project Version Id */
+            project_version_id: string;
+            /**
+             * Working Directory
+             * @default .
+             */
+            working_directory: string;
         };
         /** ArtifactEntryOut */
         ArtifactEntryOut: {
@@ -2699,18 +2758,21 @@ export interface components {
         /**
          * RunDraftIn
          * @description 一次提交意图。
-         *
-         *     除 run_configuration_id 外都可以不传——不传就用运行方案里的值。
-         *     这些字段用 ``| None`` 而不是空字符串默认值，是为了让契约如实表达
-         *     「可以不传」，生成的前端类型才不会要求调用方硬塞一个空串。
          */
         RunDraftIn: {
             /** Command Override */
             command_override?: string | null;
             compute_request_override?: components["schemas"]["ComputeRequestModel"] | null;
+            /** Environment Version Id Override */
+            environment_version_id_override?: string | null;
+            /** Input Bindings Override */
+            input_bindings_override?: components["schemas"]["InputBindingModel"][] | null;
             /** Name */
             name?: string | null;
-            /** Project Version Id */
+            /**
+             * Project Version Id
+             * @description None 表示使用 Project 的最新版本。
+             */
             project_version_id?: string | null;
             /** Run Configuration Id */
             run_configuration_id: string;
@@ -3172,8 +3234,8 @@ export type $defs = Record<string, never>;
 export interface operations {
     download_artifact_file_api_v1_artifacts__artifact_id__download_get: {
         parameters: {
-            query: {
-                path: string;
+            query?: {
+                path?: string | null;
             };
             header?: {
                 "X-User"?: string | null;
@@ -3185,7 +3247,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description 产物文件内容 */
+            /** @description 产物文件或 ZIP 归档 */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -8109,6 +8171,86 @@ export interface operations {
             };
         };
     };
+    download_logs_api_v1_runs__run_id__logs_download_get: {
+        parameters: {
+            query?: {
+                stream?: string;
+            };
+            header?: {
+                "X-User"?: string | null;
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description 完整 Run 日志 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
     rerun_api_v1_runs__run_id__rerun_post: {
         parameters: {
             query?: never;
@@ -8123,7 +8265,99 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description 幂等重放，返回上一次重跑的 Run */
+            /** @description 幂等重放 */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunOut"];
+                };
+            };
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunOut"];
+                };
+            };
+            /** @description 请求不合法 */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象可见，但当前角色无权执行该操作 */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 对象不存在，或当前用户没有发现权限 */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 与现有状态冲突，例如重名或对象不可修改 */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 参数校验或提交前检查未通过，problems 列出全部原因 */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description 底层调度系统返回错误 */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    adjusted_rerun_api_v1_runs__run_id__rerun_adjusted_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+                "X-User"?: string | null;
+            };
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AdjustedRerunIn"];
+            };
+        };
+        responses: {
+            /** @description 幂等重放 */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/components/run/AdjustedRerunModal.tsx
+++ b/frontend/src/components/run/AdjustedRerunModal.tsx
@@ -1,0 +1,231 @@
+import { Alert, Form, Input, InputNumber, Modal, Select, Space, Typography } from 'antd'
+import { useEffect, useState } from 'react'
+
+import { ApiError, api, newIdempotencyKey } from '../../api/client'
+import type { ComputeRequest, InputBinding, Run, RunDetail } from '../../api/types'
+import { describeComputeRequest } from '../../utils/format'
+
+interface Props {
+  open: boolean
+  projectId: string
+  detail: RunDetail
+  onClose: () => void
+  onSubmitted: (run: Run) => void
+}
+
+type FormValues = {
+  name: string
+  project_version_id: string
+  environment_version_id: string
+  working_directory: string
+  command: string
+  input_bindings: InputBinding[]
+  compute_request: ComputeRequest
+}
+
+export function AdjustedRerunModal({ open, projectId, detail, onClose, onSubmitted }: Props) {
+  const [form] = Form.useForm<FormValues>()
+  const [checking, setChecking] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [problems, setProblems] = useState<string[]>([])
+  const [idempotencyKey, setIdempotencyKey] = useState(newIdempotencyKey)
+  const snapshot = detail.snapshot
+
+  useEffect(() => {
+    if (!open) return
+    form.setFieldsValue({
+      name: detail.run.name,
+      project_version_id: snapshot.project_version_id,
+      environment_version_id: snapshot.environment_version_id,
+      working_directory: snapshot.working_directory || '.',
+      command: snapshot.command,
+      input_bindings: snapshot.input_bindings,
+      compute_request: snapshot.compute_request,
+    })
+    setProblems([])
+    setIdempotencyKey(newIdempotencyKey())
+  }, [detail.run.name, form, open, snapshot])
+
+  const submit = async (values: FormValues) => {
+    setChecking(true)
+    setProblems([])
+    try {
+      if (snapshot.source_run_configuration_id) {
+        const preflight = await api.preflight(projectId, {
+          run_configuration_id: snapshot.source_run_configuration_id,
+          project_version_id: values.project_version_id,
+          command_override: values.command,
+          working_directory_override: values.working_directory,
+          environment_version_id_override: values.environment_version_id,
+          input_bindings_override: values.input_bindings,
+          compute_request_override: values.compute_request,
+        })
+        if (!preflight.ok) {
+          setProblems(preflight.problems)
+          return
+        }
+      }
+      setSubmitting(true)
+      const created = await api.adjustedRerun(
+        detail.run.id,
+        {
+          name: values.name,
+          project_version_id: values.project_version_id,
+          environment_version_id: values.environment_version_id,
+          working_directory: values.working_directory,
+          command: values.command,
+          input_bindings: values.input_bindings ?? [],
+          compute_request: values.compute_request,
+        },
+        idempotencyKey,
+      )
+      onSubmitted(created)
+    } catch (error) {
+      const apiError = error instanceof ApiError ? error : undefined
+      setProblems(
+        apiError?.problems.length
+          ? apiError.problems
+          : [error instanceof Error ? error.message : '调整后重跑失败'],
+      )
+    } finally {
+      setChecking(false)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      title="调整后重新运行"
+      okText="检查并创建新 Run"
+      cancelText="取消"
+      confirmLoading={checking || submitting}
+      onCancel={onClose}
+      onOk={() => void form.submit()}
+      width={720}
+    >
+      <Typography.Paragraph type="secondary">
+        以当前 Run Snapshot 为起点。提交会创建新的 Run，不会修改来源
+        Run；环境、输入和算力权益按当前状态重新校验。
+      </Typography.Paragraph>
+      {problems.length > 0 ? (
+        <Alert
+          type="error"
+          showIcon
+          message="当前配置不能提交"
+          description={
+            <ul>
+              {problems.map((problem) => (
+                <li key={problem}>{problem}</li>
+              ))}
+            </ul>
+          }
+          style={{ marginBottom: 16 }}
+        />
+      ) : null}
+      <Form form={form} layout="vertical" onFinish={submit}>
+        <Form.Item
+          name="name"
+          label="新 Run 名称"
+          rules={[{ required: true, message: '请输入 Run 名称' }]}
+        >
+          <Input />
+        </Form.Item>
+        <Space.Compact block>
+          <Form.Item
+            name="project_version_id"
+            label="Project Version"
+            rules={[{ required: true }]}
+            style={{ flex: 1 }}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name="environment_version_id"
+            label="Environment Version"
+            rules={[{ required: true }]}
+            style={{ flex: 1 }}
+          >
+            <Input />
+          </Form.Item>
+        </Space.Compact>
+        <Form.Item
+          name="command"
+          label="执行命令"
+          rules={[{ required: true, message: '请输入执行命令' }]}
+        >
+          <Input.TextArea rows={2} />
+        </Form.Item>
+        <Form.Item name="working_directory" label="工作目录" rules={[{ required: true }]}>
+          <Input />
+        </Form.Item>
+        <Typography.Text strong>Compute Request</Typography.Text>
+        <Space wrap style={{ display: 'flex', marginTop: 8 }}>
+          {(['nodes', 'cpus', 'memory_mb', 'gpus', 'time_limit_minutes'] as const).map((field) => (
+            <Form.Item
+              key={field}
+              name={['compute_request', field]}
+              label={field}
+              rules={[{ required: true }]}
+            >
+              <InputNumber min={0} />
+            </Form.Item>
+          ))}
+        </Space>
+        <Typography.Text strong>Input Binding</Typography.Text>
+        <Form.List name="input_bindings">
+          {(fields, { add, remove }) => (
+            <>
+              {fields.map(({ key, name, ...restField }) => (
+                <Space key={key} align="start" style={{ display: 'flex', marginTop: 8 }}>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'source_type']}
+                    rules={[{ required: true }]}
+                  >
+                    <Select
+                      style={{ width: 170 }}
+                      options={[
+                        { value: 'artifact', label: 'Artifact' },
+                        { value: 'shared_resource_version', label: 'Shared Resource Version' },
+                      ]}
+                    />
+                  </Form.Item>
+                  <Form.Item {...restField} name={[name, 'source_id']} rules={[{ required: true }]}>
+                    <Input placeholder="source id" />
+                  </Form.Item>
+                  <Form.Item
+                    {...restField}
+                    name={[name, 'access_path']}
+                    rules={[{ required: true }]}
+                  >
+                    <Input placeholder="/inputs/data" />
+                  </Form.Item>
+                  <Form.Item {...restField} name={[name, 'source_subpath']}>
+                    <Input placeholder="子路径（可选）" />
+                  </Form.Item>
+                  <a onClick={() => remove(name)}>删除</a>
+                </Space>
+              ))}
+              <a
+                onClick={() =>
+                  add({
+                    source_type: 'artifact',
+                    source_id: '',
+                    access_path: '/',
+                    source_subpath: '',
+                  })
+                }
+              >
+                添加 Input Binding
+              </a>
+            </>
+          )}
+        </Form.List>
+        <Typography.Paragraph type="secondary" style={{ marginTop: 16, marginBottom: 0 }}>
+          当前请求：{describeComputeRequest(snapshot.compute_request)}；修改后以表单值为准。
+        </Typography.Paragraph>
+      </Form>
+    </Modal>
+  )
+}

--- a/frontend/src/components/run/AdjustedRerunModal.tsx
+++ b/frontend/src/components/run/AdjustedRerunModal.tsx
@@ -52,11 +52,7 @@ export function AdjustedRerunModal({ open, detail, onClose, onSubmitted }: Props
   return <AdjustedRerunForm detail={detail} onClose={onClose} onSubmitted={onSubmitted} />
 }
 
-function AdjustedRerunForm({
-  detail,
-  onClose,
-  onSubmitted,
-}: Omit<Props, 'open'>) {
+function AdjustedRerunForm({ detail, onClose, onSubmitted }: Omit<Props, 'open'>) {
   const formRef = useRef<HTMLFormElement>(null)
   const nameRef = useRef<HTMLInputElement>(null)
   const [values, setValues] = useState(() => initialValues(detail))
@@ -152,7 +148,8 @@ function AdjustedRerunForm({
       <form ref={formRef} id="adjusted-rerun-form" onSubmit={submit}>
         <Stack gap="normal">
           <Text as="p" className={styles.muted}>
-            以当前 Run Snapshot 为起点。提交会创建新的 Run，不会修改来源 Run；环境、输入和算力权益按当前状态重新校验。
+            以当前 Run Snapshot 为起点。提交会创建新的 Run，不会修改来源
+            Run；环境、输入和算力权益按当前状态重新校验。
           </Text>
           {problems.length > 0 ? (
             <Flash variant="danger" role="alert">
@@ -216,21 +213,24 @@ function AdjustedRerunForm({
               Compute Request
             </Text>
             <div className={styles.adjustedRerunComputeGrid}>
-              {(['nodes', 'cpus', 'memory_mb', 'gpus', 'time_limit_minutes'] as const).map((field) => (
-                <FormControl key={field} disabled={submitting} id={`adjusted-rerun-${field}`}>
-                  <FormControl.Label>{field}</FormControl.Label>
-                  <TextInput
-                    type="number"
-                    inputMode="numeric"
-                    min={0}
-                    value={String(values.compute_request[field])}
-                    onChange={(event) => updateRequest(field, Number(event.target.value))}
-                  />
-                </FormControl>
-              ))}
+              {(['nodes', 'cpus', 'memory_mb', 'gpus', 'time_limit_minutes'] as const).map(
+                (field) => (
+                  <FormControl key={field} disabled={submitting} id={`adjusted-rerun-${field}`}>
+                    <FormControl.Label>{field}</FormControl.Label>
+                    <TextInput
+                      type="number"
+                      inputMode="numeric"
+                      min={0}
+                      value={String(values.compute_request[field])}
+                      onChange={(event) => updateRequest(field, Number(event.target.value))}
+                    />
+                  </FormControl>
+                ),
+              )}
             </div>
             <Text as="p" className={styles.muted}>
-              当前请求：{describeComputeRequest(detail.snapshot.compute_request)}；修改后以表单值为准。
+              当前请求：{describeComputeRequest(detail.snapshot.compute_request)}
+              ；修改后以表单值为准。
             </Text>
           </section>
           <section aria-labelledby="adjusted-rerun-input-title">
@@ -256,7 +256,11 @@ function AdjustedRerunForm({
                       </Select.Option>
                     </Select>
                   </FormControl>
-                  <FormControl required disabled={submitting} id={`adjusted-rerun-binding-source-${index}`}>
+                  <FormControl
+                    required
+                    disabled={submitting}
+                    id={`adjusted-rerun-binding-source-${index}`}
+                  >
                     <FormControl.Label>来源 ID</FormControl.Label>
                     <TextInput
                       value={binding.source_id}
@@ -264,12 +268,18 @@ function AdjustedRerunForm({
                       onChange={(event) => updateBinding(index, { source_id: event.target.value })}
                     />
                   </FormControl>
-                  <FormControl required disabled={submitting} id={`adjusted-rerun-binding-access-${index}`}>
+                  <FormControl
+                    required
+                    disabled={submitting}
+                    id={`adjusted-rerun-binding-access-${index}`}
+                  >
                     <FormControl.Label>访问路径</FormControl.Label>
                     <TextInput
                       value={binding.access_path}
                       block
-                      onChange={(event) => updateBinding(index, { access_path: event.target.value })}
+                      onChange={(event) =>
+                        updateBinding(index, { access_path: event.target.value })
+                      }
                     />
                   </FormControl>
                   <FormControl disabled={submitting} id={`adjusted-rerun-binding-subpath-${index}`}>
@@ -277,7 +287,9 @@ function AdjustedRerunForm({
                     <TextInput
                       value={binding.source_subpath}
                       block
-                      onChange={(event) => updateBinding(index, { source_subpath: event.target.value })}
+                      onChange={(event) =>
+                        updateBinding(index, { source_subpath: event.target.value })
+                      }
                     />
                   </FormControl>
                   <Button
@@ -285,7 +297,10 @@ function AdjustedRerunForm({
                     variant="invisible"
                     disabled={submitting}
                     onClick={() =>
-                      update('input_bindings', values.input_bindings.filter((_, itemIndex) => itemIndex !== index))
+                      update(
+                        'input_bindings',
+                        values.input_bindings.filter((_, itemIndex) => itemIndex !== index),
+                      )
                     }
                   >
                     删除

--- a/frontend/src/components/run/AdjustedRerunModal.tsx
+++ b/frontend/src/components/run/AdjustedRerunModal.tsx
@@ -1,13 +1,25 @@
-import { Alert, Form, Input, InputNumber, Modal, Select, Space, Typography } from 'antd'
-import { useEffect, useState } from 'react'
+import { PlusIcon, TrashIcon } from '@primer/octicons-react'
+import {
+  Button,
+  Dialog,
+  Flash,
+  FormControl,
+  Select,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@primer/react'
+import { useEffect, useRef, useState, type FormEvent } from 'react'
 
-import { ApiError, api, newIdempotencyKey } from '../../api/client'
+import { api, newIdempotencyKey } from '../../api/client'
+import { toAsyncError } from '../../api/errors'
 import type { ComputeRequest, InputBinding, Run, RunDetail } from '../../api/types'
 import { describeComputeRequest } from '../../utils/format'
+import styles from './run.module.css'
 
 interface Props {
   open: boolean
-  projectId: string
   detail: RunDetail
   onClose: () => void
   onSubmitted: (run: Run) => void
@@ -23,209 +35,286 @@ type FormValues = {
   compute_request: ComputeRequest
 }
 
-export function AdjustedRerunModal({ open, projectId, detail, onClose, onSubmitted }: Props) {
-  const [form] = Form.useForm<FormValues>()
-  const [checking, setChecking] = useState(false)
+function initialValues(detail: RunDetail): FormValues {
+  return {
+    name: detail.run.name,
+    project_version_id: detail.snapshot.project_version_id,
+    environment_version_id: detail.snapshot.environment_version_id,
+    working_directory: detail.snapshot.working_directory || '.',
+    command: detail.snapshot.command,
+    input_bindings: detail.snapshot.input_bindings.map((binding) => ({ ...binding })),
+    compute_request: { ...detail.snapshot.compute_request },
+  }
+}
+
+export function AdjustedRerunModal({ open, detail, onClose, onSubmitted }: Props) {
+  if (!open) return null
+  return <AdjustedRerunForm detail={detail} onClose={onClose} onSubmitted={onSubmitted} />
+}
+
+function AdjustedRerunForm({
+  detail,
+  onClose,
+  onSubmitted,
+}: Omit<Props, 'open'>) {
+  const formRef = useRef<HTMLFormElement>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
+  const [values, setValues] = useState(() => initialValues(detail))
   const [submitting, setSubmitting] = useState(false)
   const [problems, setProblems] = useState<string[]>([])
   const [idempotencyKey, setIdempotencyKey] = useState(newIdempotencyKey)
-  const snapshot = detail.snapshot
 
   useEffect(() => {
-    if (!open) return
-    form.setFieldsValue({
-      name: detail.run.name,
-      project_version_id: snapshot.project_version_id,
-      environment_version_id: snapshot.environment_version_id,
-      working_directory: snapshot.working_directory || '.',
-      command: snapshot.command,
-      input_bindings: snapshot.input_bindings,
-      compute_request: snapshot.compute_request,
-    })
+    const next = initialValues(detail)
+    setValues(next)
     setProblems([])
     setIdempotencyKey(newIdempotencyKey())
-  }, [detail.run.name, form, open, snapshot])
+  }, [detail])
 
-  const submit = async (values: FormValues) => {
-    setChecking(true)
+  const update = <K extends keyof FormValues>(field: K, value: FormValues[K]) => {
+    setValues((current) => ({ ...current, [field]: value }))
+  }
+
+  const updateBinding = (index: number, patch: Partial<InputBinding>) => {
+    setValues((current) => ({
+      ...current,
+      input_bindings: current.input_bindings.map((binding, itemIndex) =>
+        itemIndex === index ? { ...binding, ...patch } : binding,
+      ),
+    }))
+  }
+
+  const updateRequest = <K extends keyof ComputeRequest>(field: K, value: number) => {
+    setValues((current) => ({
+      ...current,
+      compute_request: { ...current.compute_request, [field]: value },
+    }))
+  }
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const nextProblems: string[] = []
+    if (!values.name.trim()) nextProblems.push('请输入新 Run 名称')
+    if (!values.project_version_id.trim()) nextProblems.push('请输入 Project Version ID')
+    if (!values.environment_version_id.trim()) nextProblems.push('请输入 Environment Version ID')
+    if (!values.command.trim()) nextProblems.push('请输入执行命令')
+    if (!values.working_directory.trim()) nextProblems.push('请输入工作目录')
+    if (nextProblems.length > 0) {
+      setProblems(nextProblems)
+      nameRef.current?.focus()
+      return
+    }
+
+    setSubmitting(true)
     setProblems([])
     try {
-      if (snapshot.source_run_configuration_id) {
-        const preflight = await api.preflight(projectId, {
-          run_configuration_id: snapshot.source_run_configuration_id,
-          project_version_id: values.project_version_id,
-          command_override: values.command,
-          working_directory_override: values.working_directory,
-          environment_version_id_override: values.environment_version_id,
-          input_bindings_override: values.input_bindings,
-          compute_request_override: values.compute_request,
-        })
-        if (!preflight.ok) {
-          setProblems(preflight.problems)
-          return
-        }
-      }
-      setSubmitting(true)
       const created = await api.adjustedRerun(
         detail.run.id,
         {
-          name: values.name,
-          project_version_id: values.project_version_id,
-          environment_version_id: values.environment_version_id,
-          working_directory: values.working_directory,
-          command: values.command,
-          input_bindings: values.input_bindings ?? [],
+          name: values.name.trim(),
+          project_version_id: values.project_version_id.trim(),
+          environment_version_id: values.environment_version_id.trim(),
+          working_directory: values.working_directory.trim(),
+          command: values.command.trim(),
+          input_bindings: values.input_bindings,
           compute_request: values.compute_request,
         },
         idempotencyKey,
       )
       onSubmitted(created)
     } catch (error) {
-      const apiError = error instanceof ApiError ? error : undefined
-      setProblems(
-        apiError?.problems.length
-          ? apiError.problems
-          : [error instanceof Error ? error.message : '调整后重跑失败'],
-      )
+      const view = toAsyncError(error as Error)
+      setProblems(view?.problems?.length ? view.problems : [view?.message ?? '调整后重跑失败'])
     } finally {
-      setChecking(false)
       setSubmitting(false)
     }
   }
 
   return (
-    <Modal
-      open={open}
+    <Dialog
       title="调整后重新运行"
-      okText="检查并创建新 Run"
-      cancelText="取消"
-      confirmLoading={checking || submitting}
-      onCancel={onClose}
-      onOk={() => void form.submit()}
-      width={720}
+      width="large"
+      initialFocusRef={nameRef}
+      onClose={() => {
+        if (!submitting) onClose()
+      }}
+      footerButtons={[
+        { content: '取消', disabled: submitting, onClick: onClose },
+        {
+          content: '创建新 Run',
+          buttonType: 'primary',
+          loading: submitting,
+          disabled: submitting,
+          onClick: () => formRef.current?.requestSubmit(),
+        },
+      ]}
     >
-      <Typography.Paragraph type="secondary">
-        以当前 Run Snapshot 为起点。提交会创建新的 Run，不会修改来源
-        Run；环境、输入和算力权益按当前状态重新校验。
-      </Typography.Paragraph>
-      {problems.length > 0 ? (
-        <Alert
-          type="error"
-          showIcon
-          message="当前配置不能提交"
-          description={
-            <ul>
-              {problems.map((problem) => (
-                <li key={problem}>{problem}</li>
+      <form ref={formRef} id="adjusted-rerun-form" onSubmit={submit}>
+        <Stack gap="normal">
+          <Text as="p" className={styles.muted}>
+            以当前 Run Snapshot 为起点。提交会创建新的 Run，不会修改来源 Run；环境、输入和算力权益按当前状态重新校验。
+          </Text>
+          {problems.length > 0 ? (
+            <Flash variant="danger" role="alert">
+              <strong>当前配置不能提交</strong>
+              <ul className={styles.adjustedRerunProblems}>
+                {problems.map((problem) => (
+                  <li key={problem}>{problem}</li>
+                ))}
+              </ul>
+            </Flash>
+          ) : null}
+          <FormControl required disabled={submitting} id="adjusted-rerun-name">
+            <FormControl.Label>新 Run 名称</FormControl.Label>
+            <TextInput
+              ref={nameRef}
+              value={values.name}
+              maxLength={255}
+              block
+              onChange={(event) => update('name', event.target.value)}
+            />
+          </FormControl>
+          <div className={styles.adjustedRerunGrid}>
+            <FormControl required disabled={submitting} id="adjusted-rerun-project-version">
+              <FormControl.Label>Project Version ID</FormControl.Label>
+              <TextInput
+                value={values.project_version_id}
+                block
+                onChange={(event) => update('project_version_id', event.target.value)}
+              />
+            </FormControl>
+            <FormControl required disabled={submitting} id="adjusted-rerun-environment-version">
+              <FormControl.Label>Environment Version ID</FormControl.Label>
+              <TextInput
+                value={values.environment_version_id}
+                block
+                onChange={(event) => update('environment_version_id', event.target.value)}
+              />
+            </FormControl>
+          </div>
+          <FormControl required disabled={submitting} id="adjusted-rerun-command">
+            <FormControl.Label>执行命令</FormControl.Label>
+            <Textarea
+              value={values.command}
+              rows={3}
+              block
+              resize="vertical"
+              onChange={(event) => update('command', event.target.value)}
+            />
+          </FormControl>
+          <FormControl required disabled={submitting} id="adjusted-rerun-working-directory">
+            <FormControl.Label>工作目录</FormControl.Label>
+            <TextInput
+              value={values.working_directory}
+              block
+              onChange={(event) => update('working_directory', event.target.value)}
+            />
+            <FormControl.Caption>相对于 Project Version 根目录。</FormControl.Caption>
+          </FormControl>
+          <section aria-labelledby="adjusted-rerun-compute-title">
+            <Text id="adjusted-rerun-compute-title" as="h3" weight="semibold">
+              Compute Request
+            </Text>
+            <div className={styles.adjustedRerunComputeGrid}>
+              {(['nodes', 'cpus', 'memory_mb', 'gpus', 'time_limit_minutes'] as const).map((field) => (
+                <FormControl key={field} disabled={submitting} id={`adjusted-rerun-${field}`}>
+                  <FormControl.Label>{field}</FormControl.Label>
+                  <TextInput
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    value={String(values.compute_request[field])}
+                    onChange={(event) => updateRequest(field, Number(event.target.value))}
+                  />
+                </FormControl>
               ))}
-            </ul>
-          }
-          style={{ marginBottom: 16 }}
-        />
-      ) : null}
-      <Form form={form} layout="vertical" onFinish={submit}>
-        <Form.Item
-          name="name"
-          label="新 Run 名称"
-          rules={[{ required: true, message: '请输入 Run 名称' }]}
-        >
-          <Input />
-        </Form.Item>
-        <Space.Compact block>
-          <Form.Item
-            name="project_version_id"
-            label="Project Version"
-            rules={[{ required: true }]}
-            style={{ flex: 1 }}
-          >
-            <Input />
-          </Form.Item>
-          <Form.Item
-            name="environment_version_id"
-            label="Environment Version"
-            rules={[{ required: true }]}
-            style={{ flex: 1 }}
-          >
-            <Input />
-          </Form.Item>
-        </Space.Compact>
-        <Form.Item
-          name="command"
-          label="执行命令"
-          rules={[{ required: true, message: '请输入执行命令' }]}
-        >
-          <Input.TextArea rows={2} />
-        </Form.Item>
-        <Form.Item name="working_directory" label="工作目录" rules={[{ required: true }]}>
-          <Input />
-        </Form.Item>
-        <Typography.Text strong>Compute Request</Typography.Text>
-        <Space wrap style={{ display: 'flex', marginTop: 8 }}>
-          {(['nodes', 'cpus', 'memory_mb', 'gpus', 'time_limit_minutes'] as const).map((field) => (
-            <Form.Item
-              key={field}
-              name={['compute_request', field]}
-              label={field}
-              rules={[{ required: true }]}
-            >
-              <InputNumber min={0} />
-            </Form.Item>
-          ))}
-        </Space>
-        <Typography.Text strong>Input Binding</Typography.Text>
-        <Form.List name="input_bindings">
-          {(fields, { add, remove }) => (
-            <>
-              {fields.map(({ key, name, ...restField }) => (
-                <Space key={key} align="start" style={{ display: 'flex', marginTop: 8 }}>
-                  <Form.Item
-                    {...restField}
-                    name={[name, 'source_type']}
-                    rules={[{ required: true }]}
-                  >
+            </div>
+            <Text as="p" className={styles.muted}>
+              当前请求：{describeComputeRequest(detail.snapshot.compute_request)}；修改后以表单值为准。
+            </Text>
+          </section>
+          <section aria-labelledby="adjusted-rerun-input-title">
+            <Text id="adjusted-rerun-input-title" as="h3" weight="semibold">
+              Input Binding
+            </Text>
+            <Stack gap="condensed">
+              {values.input_bindings.map((binding, index) => (
+                <div className={styles.adjustedRerunBinding} key={`${binding.source_id}-${index}`}>
+                  <FormControl disabled={submitting} id={`adjusted-rerun-binding-type-${index}`}>
+                    <FormControl.Label>来源类型</FormControl.Label>
                     <Select
-                      style={{ width: 170 }}
-                      options={[
-                        { value: 'artifact', label: 'Artifact' },
-                        { value: 'shared_resource_version', label: 'Shared Resource Version' },
-                      ]}
+                      value={binding.source_type}
+                      onChange={(event) =>
+                        updateBinding(index, {
+                          source_type: event.target.value as InputBinding['source_type'],
+                        })
+                      }
+                    >
+                      <Select.Option value="artifact">Artifact</Select.Option>
+                      <Select.Option value="shared_resource_version">
+                        Shared Resource Version
+                      </Select.Option>
+                    </Select>
+                  </FormControl>
+                  <FormControl required disabled={submitting} id={`adjusted-rerun-binding-source-${index}`}>
+                    <FormControl.Label>来源 ID</FormControl.Label>
+                    <TextInput
+                      value={binding.source_id}
+                      block
+                      onChange={(event) => updateBinding(index, { source_id: event.target.value })}
                     />
-                  </Form.Item>
-                  <Form.Item {...restField} name={[name, 'source_id']} rules={[{ required: true }]}>
-                    <Input placeholder="source id" />
-                  </Form.Item>
-                  <Form.Item
-                    {...restField}
-                    name={[name, 'access_path']}
-                    rules={[{ required: true }]}
+                  </FormControl>
+                  <FormControl required disabled={submitting} id={`adjusted-rerun-binding-access-${index}`}>
+                    <FormControl.Label>访问路径</FormControl.Label>
+                    <TextInput
+                      value={binding.access_path}
+                      block
+                      onChange={(event) => updateBinding(index, { access_path: event.target.value })}
+                    />
+                  </FormControl>
+                  <FormControl disabled={submitting} id={`adjusted-rerun-binding-subpath-${index}`}>
+                    <FormControl.Label>来源子路径</FormControl.Label>
+                    <TextInput
+                      value={binding.source_subpath}
+                      block
+                      onChange={(event) => updateBinding(index, { source_subpath: event.target.value })}
+                    />
+                  </FormControl>
+                  <Button
+                    leadingVisual={TrashIcon}
+                    variant="invisible"
+                    disabled={submitting}
+                    onClick={() =>
+                      update('input_bindings', values.input_bindings.filter((_, itemIndex) => itemIndex !== index))
+                    }
                   >
-                    <Input placeholder="/inputs/data" />
-                  </Form.Item>
-                  <Form.Item {...restField} name={[name, 'source_subpath']}>
-                    <Input placeholder="子路径（可选）" />
-                  </Form.Item>
-                  <a onClick={() => remove(name)}>删除</a>
-                </Space>
+                    删除
+                  </Button>
+                </div>
               ))}
-              <a
+              <Button
+                leadingVisual={PlusIcon}
+                variant="default"
+                size="small"
+                disabled={submitting}
                 onClick={() =>
-                  add({
-                    source_type: 'artifact',
-                    source_id: '',
-                    access_path: '/',
-                    source_subpath: '',
-                  })
+                  update('input_bindings', [
+                    ...values.input_bindings,
+                    {
+                      source_type: 'artifact',
+                      source_id: '',
+                      access_path: '/inputs/data',
+                      source_subpath: '',
+                    },
+                  ])
                 }
               >
                 添加 Input Binding
-              </a>
-            </>
-          )}
-        </Form.List>
-        <Typography.Paragraph type="secondary" style={{ marginTop: 16, marginBottom: 0 }}>
-          当前请求：{describeComputeRequest(snapshot.compute_request)}；修改后以表单值为准。
-        </Typography.Paragraph>
-      </Form>
-    </Modal>
+              </Button>
+            </Stack>
+          </section>
+        </Stack>
+      </form>
+    </Dialog>
   )
 }

--- a/frontend/src/components/run/ArtifactPanel.tsx
+++ b/frontend/src/components/run/ArtifactPanel.tsx
@@ -5,7 +5,7 @@ import {
   FileIcon,
   PackageIcon,
 } from '@primer/octicons-react'
-import { Banner, IconButton, Label, Link, Text } from '@primer/react'
+import { Banner, Button, IconButton, Label, Link, Text } from '@primer/react'
 import { Blankslate } from '@primer/react/experimental'
 import { useMemo, useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
@@ -226,6 +226,20 @@ function ArtifactGroup({
   runId: string
 }) {
   const [open, setOpen] = useState(true)
+  const [downloading, setDownloading] = useState(false)
+  const [downloadError, setDownloadError] = useState(false)
+
+  const downloadArchive = async () => {
+    setDownloading(true)
+    setDownloadError(false)
+    try {
+      await api.downloadArtifactFile(artifact.id)
+    } catch {
+      setDownloadError(true)
+    } finally {
+      setDownloading(false)
+    }
+  }
 
   return (
     <details
@@ -249,13 +263,29 @@ function ArtifactGroup({
         </div>
       </summary>
       <div className={styles.artifactGroupBody}>
-        {artifact.description ? (
-          <Text as="p" size="small" className={styles.artifactDescription}>
-            {artifact.description}
-          </Text>
-        ) : null}
         {artifact.status === 'available' ? (
-          <ArtifactFiles artifact={artifact} projectId={projectId} runId={runId} />
+          <>
+            <Button
+              leadingVisual={DownloadIcon}
+              size="small"
+              loading={downloading}
+              disabled={downloading}
+              onClick={() => void downloadArchive()}
+            >
+              下载完整 Artifact
+            </Button>
+            {downloadError ? (
+              <Banner variant="critical">
+                <Banner.Title>Artifact 下载失败</Banner.Title>
+              </Banner>
+            ) : null}
+            {artifact.description ? (
+              <Text as="p" size="small" className={styles.artifactDescription}>
+                {artifact.description}
+              </Text>
+            ) : null}
+            <ArtifactFiles artifact={artifact} projectId={projectId} runId={runId} />
+          </>
         ) : (
           <div className={styles.emptyInline}>内容已清理；运行产物记录仍保留在 Run 历史中。</div>
         )}

--- a/frontend/src/components/run/RunLogPanel.tsx
+++ b/frontend/src/components/run/RunLogPanel.tsx
@@ -1,6 +1,8 @@
-import { Banner, SegmentedControl, Text } from '@primer/react'
+import { DownloadIcon } from '@primer/octicons-react'
+import { Banner, Button, SegmentedControl, Text } from '@primer/react'
 import { useEffect, useRef, useState } from 'react'
 
+import { api } from '../../api/client'
 import type { LogChunk, LogStream } from '../../api/types'
 import { CodeViewer } from '../common/CodeViewer'
 import styles from './run.module.css'
@@ -14,16 +16,32 @@ function defaultStream(chunks: LogChunk[], failed: boolean): LogStream | undefin
 }
 
 interface Props {
+  runId?: string
   chunks: LogChunk[]
   /** Run 失败时优先打开 stderr，直接把诊断入口放在用户眼前。 */
   failed?: boolean
 }
 
 /** 标准输出与标准错误；后端返回前已完成已知 Secret 明文抹除。 */
-export function RunLogPanel({ chunks, failed = false }: Props) {
+export function RunLogPanel({ runId, chunks, failed = false }: Props) {
   const [stream, setStream] = useState<LogStream | undefined>(() => defaultStream(chunks, failed))
+  const [downloading, setDownloading] = useState<'stdout' | 'stderr' | 'combined' | null>(null)
+  const [downloadError, setDownloadError] = useState(false)
   const failureStreamSelected = useRef(false)
   const active = chunks.find((chunk) => chunk.stream === stream) ?? chunks[0]
+
+  const download = async (selected: 'stdout' | 'stderr' | 'combined') => {
+    if (!runId) return
+    setDownloading(selected)
+    setDownloadError(false)
+    try {
+      await api.downloadLogs(runId, selected)
+    } catch {
+      setDownloadError(true)
+    } finally {
+      setDownloading(null)
+    }
+  }
 
   useEffect(() => {
     if (!failed) {
@@ -62,7 +80,39 @@ export function RunLogPanel({ chunks, failed = false }: Props) {
             </SegmentedControl.Button>
           ))}
         </SegmentedControl>
+        <Button
+          leadingVisual={DownloadIcon}
+          size="small"
+          loading={downloading === 'stdout'}
+          disabled={downloading !== null}
+          onClick={() => void download('stdout')}
+        >
+          下载标准输出
+        </Button>
+        <Button
+          leadingVisual={DownloadIcon}
+          size="small"
+          loading={downloading === 'stderr'}
+          disabled={downloading !== null}
+          onClick={() => void download('stderr')}
+        >
+          下载标准错误
+        </Button>
+        <Button
+          leadingVisual={DownloadIcon}
+          size="small"
+          loading={downloading === 'combined'}
+          disabled={downloading !== null}
+          onClick={() => void download('combined')}
+        >
+          下载完整日志
+        </Button>
       </div>
+      {downloadError ? (
+        <Banner variant="critical">
+          <Banner.Title>日志下载失败</Banner.Title>
+        </Banner>
+      ) : null}
       {active.truncated ? (
         <Banner variant="warning">
           <Banner.Title>日志内容不完整</Banner.Title>

--- a/frontend/src/components/run/run.module.css
+++ b/frontend/src/components/run/run.module.css
@@ -780,6 +780,42 @@
   margin: var(--base-size-8) 0 0;
 }
 
+.adjustedRerunGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--base-size-12);
+}
+
+.adjustedRerunComputeGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--base-size-8);
+  margin-top: var(--base-size-8);
+}
+
+.adjustedRerunBinding {
+  display: grid;
+  grid-template-columns: 12rem minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) auto;
+  align-items: end;
+  gap: var(--base-size-8);
+  padding: var(--base-size-8);
+  border: var(--borderWidth-thin) solid var(--borderColor-muted);
+  border-radius: var(--borderRadius-medium);
+}
+
+.adjustedRerunProblems {
+  padding-inline-start: var(--base-size-16);
+  margin: var(--base-size-8) 0 0;
+}
+
+@media (max-width: 48rem) {
+  .adjustedRerunGrid,
+  .adjustedRerunComputeGrid,
+  .adjustedRerunBinding {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 @media (max-width: 56rem) {
   .summaryOverviewGrid {
     grid-template-columns: minmax(0, 1fr);

--- a/frontend/src/pages/RunPage.tsx
+++ b/frontend/src/pages/RunPage.tsx
@@ -33,10 +33,11 @@ import { can, isTerminal } from '../api/types'
 import { useAsync, usePolling } from '../api/useAsync'
 import { AsyncState } from '../components/common/AsyncState'
 import { RunStatusTag } from '../components/common/RunStatusTag'
-import { RunDiagnostics } from '../components/run/RunDiagnostics'
+import { AdjustedRerunModal } from '../components/run/AdjustedRerunModal'
 import { ArtifactPanel } from '../components/run/ArtifactPanel'
-import { RunLogPanel } from '../components/run/RunLogPanel'
+import { RunDiagnostics } from '../components/run/RunDiagnostics'
 import { RunSummary } from '../components/run/RunSummary'
+import { RunLogPanel } from '../components/run/RunLogPanel'
 import styles from '../components/run/run.module.css'
 
 const POLL_INTERVAL_MS = 2000
@@ -62,6 +63,7 @@ export function RunPage() {
   const location = useLocation()
   const [rerunKey, setRerunKey] = useState(newIdempotencyKey)
   const [rerunning, setRerunning] = useState(false)
+  const [adjustedRerunOpen, setAdjustedRerunOpen] = useState(false)
   const [cancelling, setCancelling] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [cancelOpen, setCancelOpen] = useState(false)
@@ -252,14 +254,23 @@ export function RunPage() {
                   ) : (
                     <>
                       {can(detail.data.run, 'run.submit') ? (
-                        <Button
-                          variant="default"
-                          leadingVisual={SyncIcon}
-                          loading={rerunning}
-                          onClick={() => void rerun()}
-                        >
-                          重新运行
-                        </Button>
+                        <>
+                          <Button
+                            variant="default"
+                            leadingVisual={SyncIcon}
+                            onClick={() => setAdjustedRerunOpen(true)}
+                          >
+                            调整后重跑
+                          </Button>
+                          <Button
+                            variant="default"
+                            leadingVisual={SyncIcon}
+                            loading={rerunning}
+                            onClick={() => void rerun()}
+                          >
+                            重新运行
+                          </Button>
+                        </>
                       ) : null}
                       <ActionMenu>
                         <ActionMenu.Anchor>
@@ -341,6 +352,7 @@ export function RunPage() {
                   >
                     <RunLogPanel
                       key={run.id}
+                      runId={run.id}
                       chunks={logs.data ?? []}
                       failed={run.status === 'failed'}
                     />
@@ -388,6 +400,18 @@ export function RunPage() {
             >
               取消会终止这次逻辑执行，但会保留 Run、运行快照以及已经产生的日志和运行产物。
             </ConfirmationDialog>
+          ) : null}
+          {adjustedRerunOpen && detail.data ? (
+            <AdjustedRerunModal
+              open
+              projectId={run.project_id}
+              detail={detail.data}
+              onClose={() => setAdjustedRerunOpen(false)}
+              onSubmitted={(created) => {
+                setAdjustedRerunOpen(false)
+                navigate(`/projects/${created.project_id}/runs/${created.id}`)
+              }}
+            />
           ) : null}
         </div>
       ) : null}

--- a/frontend/src/pages/RunPage.tsx
+++ b/frontend/src/pages/RunPage.tsx
@@ -404,7 +404,6 @@ export function RunPage() {
           {adjustedRerunOpen && detail.data ? (
             <AdjustedRerunModal
               open
-              projectId={run.project_id}
               detail={detail.data}
               onClose={() => setAdjustedRerunOpen(false)}
               onSubmitted={(created) => {

--- a/frontend/tests/component/RunPage.test.tsx
+++ b/frontend/tests/component/RunPage.test.tsx
@@ -589,6 +589,17 @@ describe('RunPage backend unavailable', () => {
     )
     expect(screen.getByLabelText('stderr 日志')).toHaveTextContent('failure details')
   })
+  it('offers complete log downloads separately from the truncated preview', async () => {
+    const downloadLogs = vi.spyOn(api, 'downloadLogs').mockResolvedValue()
+    const chunks: LogChunk[] = [
+      { stream: 'stdout', content: 'preview', truncated: true },
+      { stream: 'stderr', content: '', truncated: false },
+    ]
+    render(<RunLogPanel runId="run-1" chunks={chunks} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '下载完整日志' }))
+    await waitFor(() => expect(downloadLogs).toHaveBeenCalledWith('run-1', 'combined'))
+  })
 
   it('collapses logs when rerun navigation changes the Run ID', async () => {
     vi.spyOn(api, 'getRun').mockImplementation(async (id) => {

--- a/frontend/tests/component/RunPage.test.tsx
+++ b/frontend/tests/component/RunPage.test.tsx
@@ -607,14 +607,7 @@ describe('RunPage backend unavailable', () => {
     const preflight = vi.spyOn(api, 'preflight')
     const onSubmitted = vi.fn()
 
-    render(
-      <AdjustedRerunModal
-        open
-        detail={detail}
-        onClose={() => {}}
-        onSubmitted={onSubmitted}
-      />,
-    )
+    render(<AdjustedRerunModal open detail={detail} onClose={() => {}} onSubmitted={onSubmitted} />)
 
     fireEvent.click(await screen.findByRole('button', { name: '创建新 Run' }))
     await waitFor(() => expect(adjustedRerun).toHaveBeenCalled())

--- a/frontend/tests/component/RunPage.test.tsx
+++ b/frontend/tests/component/RunPage.test.tsx
@@ -632,6 +632,27 @@ describe('RunPage backend unavailable', () => {
     expect(onSubmitted).toHaveBeenCalledWith(detail.run)
   })
 
+  it('shows adjusted endpoint validation errors without a second mutable-config preflight', async () => {
+    vi.spyOn(api, 'adjustedRerun').mockRejectedValue(
+      new ApiError(422, 'preflight_rejected', '无法创建 Run', ['Secret 已失效'], 'req-48'),
+    )
+    const preflight = vi.spyOn(api, 'preflight')
+    const onSubmitted = vi.fn()
+    render(
+      <AdjustedRerunModal
+        open
+        detail={runDetailFixture()}
+        onClose={() => {}}
+        onSubmitted={onSubmitted}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: '创建新 Run' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Secret 已失效')
+    expect(preflight).not.toHaveBeenCalled()
+    expect(onSubmitted).not.toHaveBeenCalled()
+  })
+
   it('collapses logs when rerun navigation changes the Run ID', async () => {
     vi.spyOn(api, 'getRun').mockImplementation(async (id) => {
       const detail = runDetailFixture()

--- a/frontend/tests/component/RunPage.test.tsx
+++ b/frontend/tests/component/RunPage.test.tsx
@@ -15,9 +15,9 @@ import type {
 } from '../../src/api/types'
 import { ArtifactFilePreviewPage } from '../../src/pages/ArtifactFilePreviewPage'
 import { RunLocatorPage } from '../../src/pages/RunLocatorPage'
+import { AdjustedRerunModal } from '../../src/components/run/AdjustedRerunModal'
 import { RunLogPanel } from '../../src/components/run/RunLogPanel'
 import { RunPage } from '../../src/pages/RunPage'
-
 const runDetailFixture = (): RunDetail => ({
   run: {
     id: 'run-1',
@@ -599,6 +599,37 @@ describe('RunPage backend unavailable', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '下载完整日志' }))
     await waitFor(() => expect(downloadLogs).toHaveBeenCalledWith('run-1', 'combined'))
+  })
+
+  it('submits adjusted rerun directly and does not preflight the mutable configuration', async () => {
+    const detail = runDetailFixture()
+    const adjustedRerun = vi.spyOn(api, 'adjustedRerun').mockResolvedValue(detail.run)
+    const preflight = vi.spyOn(api, 'preflight')
+    const onSubmitted = vi.fn()
+
+    render(
+      <AdjustedRerunModal
+        open
+        detail={detail}
+        onClose={() => {}}
+        onSubmitted={onSubmitted}
+      />,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: '创建新 Run' }))
+    await waitFor(() => expect(adjustedRerun).toHaveBeenCalled())
+    expect(preflight).not.toHaveBeenCalled()
+    expect(adjustedRerun).toHaveBeenCalledWith(
+      'run-1',
+      expect.objectContaining({
+        project_version_id: 'version-1',
+        environment_version_id: 'env-1',
+        command: 'python train.py',
+        working_directory: '.',
+      }),
+      expect.any(String),
+    )
+    expect(onSubmitted).toHaveBeenCalledWith(detail.run)
   })
 
   it('collapses logs when rerun navigation changes the Run ID', async () => {


### PR DESCRIPTION
## 关联 Issue

Closes #48

## 修改内容

- 新增历史 Run 的“调整后重新运行”路径：以来源 Run Snapshot 预填并允许调整 Project Version、Environment Version、命令、工作目录、Input Binding 和 Compute Request。
- 调整后始终创建新的 Run / Run Snapshot，来源 Run 与来源 Snapshot 保持不变；提交时以历史 Snapshot 构造候选事实，并按当前 Project、Environment、Artifact、Secret、Entitlement 和算力请求重新校验。
- 保留 exact rerun，并在 Run 页面明确区分“重新运行”和“调整后重跑”。调整后重跑直接调用 adjusted rerun 接口，不借用可变 Run Configuration preflight。
- 新增 stdout、stderr 和合并日志的完整下载；按 chunk 流式读取，使用增量 UTF-8 解码和边界安全的 Secret redaction，覆盖长度为 1 和自重叠 Secret。
- Artifact 保留单文件下载，并新增保持原文件结构的完整 ZIP 下载；下载前沿所属 Run 做访问校验，文件路径限制在 Artifact 根目录内。
- 调整后重跑弹窗使用 Primer controls 与 Run CSS Modules，不向已迁移 Run surface 引入 Ant Design。
- 同步 OpenAPI 与前端生成类型，补充后端集成测试和前端组件行为测试。

## 验证证据

- 统一检查：`make check` 通过；后端 `351 passed, 3 skipped`；前端 format、lint、typecheck、完整 tests 和 build 通过。
- 其他验证：Issue 48 targeted backend tests `6 passed`；RunPage component tests `18 passed`；`make contract-check` 通过。
- 浏览器 smoke：实际检查 desktop Run surface、375px 窄屏调整后重跑弹窗、预填值、可见焦点和表单布局。

## 影响范围

- API：新增 adjusted rerun、完整日志下载和 Artifact ZIP 下载接口；OpenAPI 与前端生成类型已同步。
- 权限：调整后重跑和下载继续沿现有 Run / Project owner-scope 访问边界执行。
- Secret：Snapshot 不保存明文；完整日志下载在 chunk 边界、长度为 1 和重叠匹配场景均执行 redaction。
- 数据库：无 schema 或 migration 变化。
- 兼容性：保留 exact rerun 和现有 Artifact 单文件下载。

## 延后事项与实现妥协

- Deferred ID：无

## 截图（仅界面改动）

- Run 页面新增“调整后重跑”、精确重跑、日志下载和完整 Artifact 下载入口；375px 窄屏弹窗已通过真实浏览器检查。

## 按需检查

- [x] API 发生变化：OpenAPI 与前端生成类型已同步并提交
- [ ] 数据库发生变化：无数据库变化
- [x] 认证或授权发生变化：正常路径与越权路径均有验证证据
- [x] 涉及 Secret：响应、Snapshot、日志和构建产物均不包含明文
- [x] 界面发生变化：desktop / 375px、焦点、预填表单和关键交互已实际检查