### PR TITLE
feat(user): 建立个人执行上下文与算力权益管理表面

### DIFF
--- a/backend/migrations/versions/e8a1c4d2f6b9_remove_entitlement_concurrency.py
+++ b/backend/migrations/versions/e8a1c4d2f6b9_remove_entitlement_concurrency.py
@@ -26,6 +26,12 @@ def upgrade() -> None:
 def downgrade() -> None:
     with op.batch_alter_table("resource_entitlements", schema=None) as batch_op:
         batch_op.add_column(
-            sa.Column("max_concurrent_runs", sa.Integer(), server_default="1", nullable=False)
+            sa.Column(
+                "max_concurrent_runs",
+                sa.Integer(),
+                server_default=sa.text("1"),
+                nullable=False,
+            )
         )
+    with op.batch_alter_table("resource_entitlements", schema=None) as batch_op:
         batch_op.alter_column("max_concurrent_runs", server_default=None)

--- a/backend/migrations/versions/e8a1c4d2f6b9_remove_entitlement_concurrency.py
+++ b/backend/migrations/versions/e8a1c4d2f6b9_remove_entitlement_concurrency.py
@@ -1,0 +1,31 @@
+"""Remove the product-side Resource Entitlement concurrency quota.
+
+Revision ID: e8a1c4d2f6b9
+Revises: d71f3a9c2b4e
+Create Date: 2026-09-04
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e8a1c4d2f6b9"
+down_revision: str | None = "d71f3a9c2b4e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("resource_entitlements", schema=None) as batch_op:
+        batch_op.drop_column("max_concurrent_runs")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("resource_entitlements", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("max_concurrent_runs", sa.Integer(), server_default="1", nullable=False)
+        )
+        batch_op.alter_column("max_concurrent_runs", server_default=None)

--- a/backend/src/workspace107/api/deps.py
+++ b/backend/src/workspace107/api/deps.py
@@ -113,7 +113,7 @@ def build_services(context: AppContext, session: AsyncSession) -> Services:
         identity=IdentityService(repos, context.clock, session),
         user_groups=UserGroupService(repos, guard, context.clock, activity, notifier),
         configuration=ConfigurationService(repos, guard, vault),
-        entitlements=EntitlementService(repos),
+        entitlements=EntitlementService(repos, context.clock),
         projects=ProjectService(
             repos,
             guard,

--- a/backend/src/workspace107/api/presenters.py
+++ b/backend/src/workspace107/api/presenters.py
@@ -92,8 +92,9 @@ def entitlement_out(view: EntitlementView) -> s.EntitlementOut:
         id=view.entitlement.id,
         compute_plan_id=view.plan.id,
         compute_plan_name=view.plan.name,
-        max_concurrent_runs=view.entitlement.max_concurrent_runs,
         expires_at=view.entitlement.expires_at,
+        status=view.status,
+        status_reason=view.status_reason,
     )
 
 

--- a/backend/src/workspace107/api/schemas.py
+++ b/backend/src/workspace107/api/schemas.py
@@ -125,8 +125,9 @@ class EntitlementOut(Model):
     id: str
     compute_plan_id: str
     compute_plan_name: str
-    max_concurrent_runs: int
     expires_at: str | None
+    status: Literal["active", "expired"]
+    status_reason: str | None
 
 
 # -- Project ----------------------------------------------------------------
@@ -586,7 +587,7 @@ class RunOut(Model):
     exit_code: int | None
     failure_reason: str
     initiated_by_user_id: str
-    """发起本次 Run 的 User（GR-307）：执行身份、并发额度与通知接收方。"""
+    """发起本次 Run 的 User（GR-307）：执行身份与通知接收方。"""
     initiated_by_username: str | None
     """当前权威 User.username；User 记录无法解析时为 null。"""
     created_at: datetime | None

--- a/backend/src/workspace107/application/entitlement_service.py
+++ b/backend/src/workspace107/application/entitlement_service.py
@@ -10,8 +10,10 @@ seed / fixture 写入，不作为业务创建的副作用。
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from ..domain.compute import ComputePlan, ResourceEntitlement
+from ..domain.ports.clock import Clock
 from ..domain.ports.repositories import Repositories
 
 
@@ -19,17 +21,31 @@ from ..domain.ports.repositories import Repositories
 class EntitlementView:
     entitlement: ResourceEntitlement
     plan: ComputePlan
+    status: Literal["active", "expired"]
+    status_reason: str | None
 
 
 class EntitlementService:
-    def __init__(self, repos: Repositories) -> None:
+    def __init__(self, repos: Repositories, clock: Clock) -> None:
         self._repos = repos
+        self._clock = clock
 
     async def list_for_user(self, user_id: str) -> list[EntitlementView]:
         """查看自己的资源权益——主体就是当前 User，无需空间级授权。"""
         result: list[EntitlementView] = []
+        now_iso = self._clock.now().isoformat()
         for entitlement in await self._repos.entitlements.list_for_user(user_id):
             plan = await self._repos.compute_plans.get(entitlement.compute_plan_id)
             if plan is not None:
-                result.append(EntitlementView(entitlement=entitlement, plan=plan))
+                expired = entitlement.is_expired(now_iso)
+                result.append(
+                    EntitlementView(
+                        entitlement=entitlement,
+                        plan=plan,
+                        status="expired" if expired else "active",
+                        status_reason=(
+                            f"权益已于 {entitlement.expires_at} 过期" if expired else None
+                        ),
+                    )
+                )
         return result

--- a/backend/src/workspace107/application/run_service.py
+++ b/backend/src/workspace107/application/run_service.py
@@ -21,7 +21,6 @@ from ..domain.capabilities import Capability
 from ..domain.compute import (
     ComputePlan,
     ComputeRequest,
-    ResourceEntitlement,
     SchedulerMapping,
     check_request_against_plan,
     resolve_scheduler_configuration,
@@ -386,8 +385,6 @@ class RunService:
                 problems.append(f"你没有算力方案「{plan.name}」的使用权益")
             elif entitlement.is_expired(self._clock.now().isoformat()):
                 problems.append(f"算力方案「{plan.name}」的资源权益已过期")
-            else:
-                problems.extend(await self._check_concurrency(user_id, entitlement))
 
             slurm_projection = None
             if self._scheduler.name == "slurm":
@@ -465,13 +462,6 @@ class RunService:
         configuration = await self._repos.run_configurations.get(draft.run_configuration_id)
         if configuration is None or configuration.project_id != project_id:
             raise ObjectNotFound("Run Configuration", draft.run_configuration_id)
-
-        # 先独占发起 User 在该算力方案上的权益行，再做提交前检查。
-        #
-        # 并发上限是「数一数还有几个名额 -> 创建 Run」，这两步之间不能被别的请求
-        # 插进来，否则两个请求会同时读到「还没到上限」，然后都创建成功——
-        # 上限就形同虚设。锁一直持有到本次请求的事务结束。
-        await self._repos.entitlements.lock_for_plan(user_id, configuration.compute_plan_id)
 
         result = await self.preflight(user_id, project_id, draft)
         if not result.ok:
@@ -556,9 +546,6 @@ class RunService:
         source_snapshot = await self._repos.run_snapshots.get(access.run.snapshot_id)
         if source_snapshot is None:  # pragma: no cover
             raise ObjectNotFound("Run Snapshot", access.run.snapshot_id)
-
-        # 和 create 一样要先独占权益行——重跑同样占用并发名额。
-        await self._repos.entitlements.lock_for_plan(user_id, source_snapshot.compute_plan_id)
 
         problems = await self._revalidate_snapshot(source_snapshot, access, user_id)
         if problems:
@@ -645,7 +632,6 @@ class RunService:
         source = await self._repos.run_snapshots.get(access.run.snapshot_id)
         if source is None:  # pragma: no cover - 数据损坏才会发生
             raise ObjectNotFound("Run Snapshot", access.run.snapshot_id)
-        await self._repos.entitlements.lock_for_plan(user_id, source.compute_plan_id)
 
         project_version = await self._repos.project_versions.get(draft.project_version_id or "")
         environment_version = await environment_version_for_owner_use(
@@ -1070,27 +1056,6 @@ class RunService:
         if key:
             await self._repos.idempotency.attach_run(user_id, key, run_id)
 
-    async def _check_concurrency(self, user_id: str, entitlement: ResourceEntitlement) -> list[str]:
-        """检查并发上限。
-
-        **数的范围必须和锁的范围一致**：额度按「User × 算力方案」授予，
-        锁的是那个 User 的那一条权益行，所以数的也只能是该 User 在那个方案上
-        发起的 Run。数到别人的 Run 会互相挤占名额；数到别的方案则会串味：
-        CPU 作业占掉 GPU 的名额。
-
-        调用方必须已经通过 ``entitlements.lock_for_plan`` 独占了权益行，
-        否则这里数出来的结果在返回之前就可能过期。
-        """
-        active = await self._repos.runs.count_unfinished_for_plan(
-            user_id, entitlement.compute_plan_id
-        )
-        if active < entitlement.max_concurrent_runs:
-            return []
-        return [
-            f"你在这个算力方案上已有 {active} 个未结束的 Run，"
-            f"达到并发上限 {entitlement.max_concurrent_runs}"
-        ]
-
     async def _check_inputs(
         self,
         user_id: str,
@@ -1236,10 +1201,6 @@ class RunService:
                 problems.append(f"你已不再拥有算力方案「{plan.name}」的使用权益")
             elif entitlement.is_expired(self._clock.now().isoformat()):
                 problems.append(f"算力方案「{plan.name}」的资源权益已过期")
-            else:
-                # 重跑同样要占并发名额。漏掉这一条，用户就能靠反复点「重新运行」
-                # 绕过上限——权益检查在最容易被反复触发的路径上失效。
-                problems.extend(await self._check_concurrency(user_id, entitlement))
 
             if self._scheduler.name == "slurm":
                 assert self._slurm_projection is not None

--- a/backend/src/workspace107/domain/compute.py
+++ b/backend/src/workspace107/domain/compute.py
@@ -104,7 +104,6 @@ class ResourceEntitlement:
     id: str
     user_id: str
     compute_plan_id: str
-    max_concurrent_runs: int
     expires_at: str | None = None
 
     def is_expired(self, now_iso: str) -> bool:

--- a/backend/src/workspace107/domain/models.py
+++ b/backend/src/workspace107/domain/models.py
@@ -347,7 +347,7 @@ class Run:
     project_id: str
     snapshot_id: str
     compute_plan_id: str
-    """本次运行占用的算力方案。并发额度按「Initiated By User × 方案」计算（GR-307）。"""
+    """创建 Run 时固定的 Compute Plan identity，用于历史展示与重跑 preflight。"""
     project_version_id: str
     """本次运行基于的 Project 版本。冗余自快照，用于 Run History 展示。"""
     project_version_label: str
@@ -362,7 +362,7 @@ class Run:
     exit_code: int | None = None
     failure_reason: str = ""
     initiated_by_user_id: str = ""
-    """发起本次 Run 的 User（GR-307）。执行身份、并发额度、通知接收方都以它为准。"""
+    """发起本次 Run 的 User（GR-307）。执行身份和通知接收方都以它为准。"""
     created_at: datetime | None = None
     submitted_at: datetime | None = None
     started_at: datetime | None = None

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -211,7 +211,6 @@ class RunRepository(Protocol):
         ...
 
 
-
 class IdempotencyRepository(Protocol):
     """幂等登记。
 

--- a/backend/src/workspace107/domain/ports/repositories.py
+++ b/backend/src/workspace107/domain/ports/repositories.py
@@ -180,15 +180,6 @@ class EntitlementRepository(Protocol):
     ) -> ResourceEntitlement | None: ...
     async def add(self, entitlement: ResourceEntitlement) -> None: ...
 
-    async def lock_for_plan(self, user_id: str, compute_plan_id: str) -> ResourceEntitlement | None:
-        """取权益并在当前事务内独占它，直到事务结束。
-
-        用于把「数一数还剩几个并发名额，然后创建 Run」这一段串行化。
-        不加锁的话两个请求会同时读到「还没到上限」，然后都创建成功——
-        并发上限就形同虚设了。
-        """
-        ...
-
 
 class RunConfigurationRepository(Protocol):
     async def add(self, configuration: RunConfiguration) -> None: ...
@@ -219,7 +210,6 @@ class RunRepository(Protocol):
         """条件更新把 Run 推进到终态。抢到返回 True，别人已推进过返回 False。"""
         ...
 
-    async def count_unfinished_for_plan(self, user_id: str, compute_plan_id: str) -> int: ...
 
 
 class IdempotencyRepository(Protocol):

--- a/backend/src/workspace107/domain/slurm_projection.py
+++ b/backend/src/workspace107/domain/slurm_projection.py
@@ -46,8 +46,8 @@ class SlurmPartitionFact:
 class SlurmQosLimitsFact:
     """Visible per-job QoS limits in normalized platform units.
 
-    The job-count fields are retained as evidence but intentionally never map to
-    ``ResourceEntitlement.max_concurrent_runs``.
+    The job-count fields are retained only as scheduler evidence and do not define a
+    parallel product-side quota.
     """
 
     cluster: str

--- a/backend/src/workspace107/infrastructure/db/repositories.py
+++ b/backend/src/workspace107/infrastructure/db/repositories.py
@@ -906,29 +906,10 @@ class EntitlementRepositoryImpl:
                 id=entitlement.id,
                 user_id=entitlement.user_id,
                 compute_plan_id=entitlement.compute_plan_id,
-                max_concurrent_runs=entitlement.max_concurrent_runs,
                 expires_at=entitlement.expires_at,
             )
         )
         await _flush(self._session)
-
-    async def lock_for_plan(self, user_id: str, compute_plan_id: str) -> ResourceEntitlement | None:
-        """SELECT ... FOR UPDATE，锁到事务结束。
-
-        PostgreSQL 上这行会被真正独占，第二个并发请求阻塞到第一个提交为止。
-        SQLite 不支持 FOR UPDATE，SQLAlchemy 的方言会忽略它——开发和测试环境
-        依赖 SQLite 自身的写串行化，生产环境（PostgreSQL）才有严格保证。
-        """
-        stmt = (
-            select(t.ResourceEntitlementRow)
-            .where(
-                t.ResourceEntitlementRow.user_id == user_id,
-                t.ResourceEntitlementRow.compute_plan_id == compute_plan_id,
-            )
-            .with_for_update()
-        )
-        row = (await self._session.execute(stmt)).scalar_one_or_none()
-        return _to_entitlement(row) if row else None
 
 
 class RunConfigurationRepositoryImpl:
@@ -1123,25 +1104,6 @@ class RunRepositoryImpl:
             )
         )
         return int(result.rowcount or 0) == 1
-
-    async def count_unfinished_for_plan(self, user_id: str, compute_plan_id: str) -> int:
-        """数「这个 User 在这个算力方案上」还有几个未结束的 Run。
-
-        并发额度按「User × 方案」授予，锁的也是那个 User 的那一条权益行，
-        所以只数该 User 发起（initiated_by_user_id）的 Run。**计数范围大于
-        加锁范围就等于没锁**——计数范围里混进别人的 Run，会读出一个比实际
-        大的数，让本来还有名额的请求被误拒，或反过来。
-        """
-        stmt = (
-            select(func.count())
-            .select_from(t.RunRow)
-            .where(
-                t.RunRow.initiated_by_user_id == user_id,
-                t.RunRow.compute_plan_id == compute_plan_id,
-                t.RunRow.status.in_([RunStatus.QUEUED.value, RunStatus.RUNNING.value]),
-            )
-        )
-        return int((await self._session.execute(stmt)).scalar_one())
 
 
 class IdempotencyRepositoryImpl:
@@ -2164,7 +2126,6 @@ def _to_entitlement(row: t.ResourceEntitlementRow) -> ResourceEntitlement:
         id=row.id,
         user_id=row.user_id,
         compute_plan_id=row.compute_plan_id,
-        max_concurrent_runs=row.max_concurrent_runs,
         expires_at=row.expires_at,
     )
 

--- a/backend/src/workspace107/infrastructure/db/tables.py
+++ b/backend/src/workspace107/infrastructure/db/tables.py
@@ -295,7 +295,6 @@ class ResourceEntitlementRow(Base):
     id: Mapped[str] = mapped_column(ID, primary_key=True)
     user_id: Mapped[str] = mapped_column(ID, ForeignKey("users.id"), index=True)
     compute_plan_id: Mapped[str] = mapped_column(ID, ForeignKey("compute_plans.id"))
-    max_concurrent_runs: Mapped[int] = mapped_column(Integer)
     expires_at: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     __table_args__ = (UniqueConstraint("user_id", "compute_plan_id", name="uq_entitlement"),)
@@ -334,9 +333,8 @@ class RunRow(Base):
     project_id: Mapped[str] = mapped_column(ID, ForeignKey("projects.id"), index=True)
     snapshot_id: Mapped[str] = mapped_column(ID, ForeignKey("run_snapshots.id"))
     # 从快照里冗余出来的一列。快照是 JSON，没法索引也没法跨库稳定地查；
-    # 而并发上限口径是「Initiated By User × 算力方案」（GR-307），
-    # 数未结束 Run 时必须能按方案过滤。方案在快照创建时就固定、之后不再变，
-    # 冗余是安全的。
+    # Compute Plan 在快照创建时固定，重跑 preflight 和 Run History 都需要
+    # 直接使用这项 identity，因此冗余不会漂移。
     compute_plan_id: Mapped[str] = mapped_column(ID, index=True)
     # 从快照里冗余出来的列——project_version_id 只存在于快照 JSON 里，
     # 无法在 Run 列表查询中直接获取。冗余到列后 Run History 可直接展示

--- a/backend/src/workspace107/tools/seed.py
+++ b/backend/src/workspace107/tools/seed.py
@@ -394,7 +394,6 @@ async def seed_demo(
                 id=ids.new_id(ids.ENTITLEMENT),
                 user_id=user.id,
                 compute_plan_id="plan_cpu_quick",
-                max_concurrent_runs=2,
                 expires_at=None,
             )
         )

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -65,7 +65,6 @@ async def grant_test_entitlement(
     username: str,
     compute_plan_id: str = "plan_cpu_quick",
     *,
-    max_concurrent_runs: int = 2,
     expires_at: str | None = None,
 ) -> None:
     """Seed the entitlement of the user named ``username``; nothing grants one implicitly."""
@@ -77,7 +76,6 @@ async def grant_test_entitlement(
             id=ids.new_id(ids.ENTITLEMENT),
             user_id=user.id,
             compute_plan_id=compute_plan_id,
-            max_concurrent_runs=max_concurrent_runs,
             expires_at=expires_at,
         )
     )

--- a/backend/tests/integration/db/test_remove_entitlement_concurrency_migration.py
+++ b/backend/tests/integration/db/test_remove_entitlement_concurrency_migration.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from workspace107.config import get_settings
+
+PREVIOUS_REVISION = "d71f3a9c2b4e"
+CURRENT_REVISION = "e8a1c4d2f6b9"
+NOW = "2026-09-04 00:00:00+00:00"
+
+
+def _config(database: Path) -> Config:
+    backend = Path(__file__).resolve().parents[3]
+    config = Config(str(backend / "alembic.ini"))
+    config.set_main_option("script_location", str(backend / "migrations"))
+    config.set_main_option("sqlalchemy.url", f"sqlite+aiosqlite:///{database}")
+    return config
+
+
+def _seed_entitlement(database: Path) -> None:
+    with sqlite3.connect(database) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(
+            "INSERT INTO users (id, username, display_name, email, created_at) "
+            "VALUES ('usr_alice', 'alice', 'Alice', NULL, ?)",
+            (NOW,),
+        )
+        connection.execute(
+            "INSERT INTO compute_plans ("
+            "id, code, name, description, default_nodes, default_cpus, default_memory_mb, "
+            "default_gpus, default_time_limit_minutes, max_nodes, max_cpus, max_memory_mb, "
+            "max_gpus, max_time_limit_minutes, cluster, account, partition, qos"
+            ") VALUES ("
+            "'plan_cpu', 'cpu', 'CPU', '', 1, 1, 1024, 0, 10, 1, 4, 4096, 0, 60, "
+            "'cluster', 'account', 'partition', 'qos'"
+            ")"
+        )
+        connection.execute(
+            "INSERT INTO resource_entitlements "
+            "(id, user_id, compute_plan_id, max_concurrent_runs, expires_at) "
+            "VALUES ('ent_alice', 'usr_alice', 'plan_cpu', 7, NULL)"
+        )
+        connection.commit()
+
+
+def _columns(database: Path) -> set[str]:
+    with sqlite3.connect(database) as connection:
+        return {
+            str(row[1]) for row in connection.execute("PRAGMA table_info(resource_entitlements)")
+        }
+
+
+def _entitlement(database: Path) -> tuple[str, str, str, int | None]:
+    with sqlite3.connect(database) as connection:
+        has_concurrency = "max_concurrent_runs" in _columns(database)
+        columns = "id, user_id, compute_plan_id"
+        if has_concurrency:
+            columns += ", max_concurrent_runs"
+        row = connection.execute(
+            f"SELECT {columns} FROM resource_entitlements WHERE id='ent_alice'"
+        ).fetchone()
+    assert row is not None
+    if has_concurrency:
+        return str(row[0]), str(row[1]), str(row[2]), int(row[3])
+    return str(row[0]), str(row[1]), str(row[2]), None
+
+
+def test_issue_49_migration_round_trips_nonempty_entitlements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    database = tmp_path / "remove-entitlement-concurrency.db"
+    monkeypatch.setenv("WORKSPACE107_DATABASE_URL", f"sqlite+aiosqlite:///{database}")
+    get_settings.cache_clear()
+    config = _config(database)
+
+    try:
+        command.upgrade(config, PREVIOUS_REVISION)
+        _seed_entitlement(database)
+
+        command.upgrade(config, CURRENT_REVISION)
+        assert _entitlement(database) == ("ent_alice", "usr_alice", "plan_cpu", None)
+
+        command.downgrade(config, PREVIOUS_REVISION)
+        assert _entitlement(database) == ("ent_alice", "usr_alice", "plan_cpu", 1)
+
+        command.upgrade(config, CURRENT_REVISION)
+        assert _entitlement(database) == ("ent_alice", "usr_alice", "plan_cpu", None)
+    finally:
+        get_settings.cache_clear()

--- a/backend/tests/integration/test_scoped_config_run_execution.py
+++ b/backend/tests/integration/test_scoped_config_run_execution.py
@@ -179,7 +179,7 @@ async def test_run_snapshot_current_secret_rotation_and_redaction(client, sessio
 
 
 @pytest.mark.asyncio
-async def test_rerun_rechecks_concurrency_and_plan_limits(client, session) -> None:
+async def test_rerun_rechecks_plan_limits(client, session) -> None:
     await client.get("/api/v1/me")
     _, env_version_id = await use_default_environment(session, client)
     project = await create_project_with_version(client, name="rerun-guards")
@@ -207,22 +207,6 @@ async def test_rerun_rechecks_concurrency_and_plan_limits(client, session) -> No
     assert run.status_code == 201
     await wait_for_run(client, run.json()["id"])
     before = (await client.get(f"/api/v1/projects/{project['id']}/runs")).json()["total"]
-    await session.execute(
-        text(
-            "UPDATE resource_entitlements SET max_concurrent_runs=1 "
-            "WHERE user_id=(SELECT id FROM users WHERE username='student')"
-        )
-    )
-    await session.execute(
-        text("UPDATE runs SET status='running' WHERE id=:id"), {"id": run.json()["id"]}
-    )
-    await session.commit()
-    blocked = await client.post(f"/api/v1/runs/{run.json()['id']}/rerun")
-    assert blocked.status_code == 422
-    assert (await client.get(f"/api/v1/projects/{project['id']}/runs")).json()["total"] == before
-    await session.execute(
-        text("UPDATE runs SET status='succeeded' WHERE id=:id"), {"id": run.json()["id"]}
-    )
     await session.execute(text("UPDATE compute_plans SET max_cpus=1 WHERE id='plan_cpu_quick'"))
     await session.commit()
     blocked_plan = await client.post(f"/api/v1/runs/{run.json()['id']}/rerun")

--- a/backend/tests/integration/test_user_entitlements.py
+++ b/backend/tests/integration/test_user_entitlements.py
@@ -92,9 +92,7 @@ async def test_过期权益阻止提交(client: httpx.AsyncClient, session: Asyn
 
 
 @pytest.mark.asyncio
-async def test_权益不施加产品侧并发限制(
-    client: httpx.AsyncClient, session: AsyncSession
-) -> None:
+async def test_权益不施加产品侧并发限制(client: httpx.AsyncClient, session: AsyncSession) -> None:
     alice_project, alice_config = await _prepare_submission(session, client, ALICE)
     await grant_test_entitlement(session, "alice")
 

--- a/backend/tests/integration/test_user_entitlements.py
+++ b/backend/tests/integration/test_user_entitlements.py
@@ -1,10 +1,10 @@
-"""Issue #38：Resource Entitlement 属于发起 User。
+"""Issue #38/#49：Resource Entitlement 属于发起 User。
 
 覆盖验收条件：
 - 无权益 / 权益过期明确阻止 Run；
 - 权益按发起 User 校验——别人的权益帮不了你，Membership 不转移资格；
-- 并发上限按「发起 User × 算力方案」统计，不共享别人的名额；
-- ``GET /me/entitlements`` 只返回当前 User 自己的权益。
+- 产品不复制平台并发配额，同一 User 可以连续提交多个 Run；
+- ``GET /me/entitlements`` 只返回当前 User 自己的权益和服务端派生状态。
 """
 
 from __future__ import annotations
@@ -86,26 +86,23 @@ async def test_过期权益阻止提交(client: httpx.AsyncClient, session: Asyn
 
     assert response.status_code == 422
     assert any("已过期" in problem for problem in response.json()["problems"])
+    listed = (await client.get("/api/v1/me/entitlements", headers=ALICE)).json()
+    assert listed[0]["status"] == "expired"
+    assert listed[0]["status_reason"] == "权益已于 2020-01-01T00:00:00+00:00 过期"
 
 
 @pytest.mark.asyncio
-async def test_并发上限按发起用户统计(client: httpx.AsyncClient, session: AsyncSession) -> None:
+async def test_权益不施加产品侧并发限制(
+    client: httpx.AsyncClient, session: AsyncSession
+) -> None:
     alice_project, alice_config = await _prepare_submission(session, client, ALICE)
-    bob_project, bob_config = await _prepare_submission(session, client, BOB)
-    await grant_test_entitlement(session, "alice", max_concurrent_runs=1)
-    await grant_test_entitlement(session, "bob", max_concurrent_runs=1)
+    await grant_test_entitlement(session, "alice")
 
-    # alice 的第一个 Run 已占用她唯一的并发名额（未同步前停在 queued）。
     first = await _submit(client, alice_project, alice_config, ALICE)
-    assert first.status_code == 201, first.text
-
     second = await _submit(client, alice_project, alice_config, ALICE)
-    assert second.status_code == 422
-    assert any("并发上限" in problem for problem in second.json()["problems"])
 
-    # bob 的名额独立计算，alice 的排队不挤占他。
-    response = await _submit(client, bob_project, bob_config, BOB)
-    assert response.status_code == 201, response.text
+    assert first.status_code == 201, first.text
+    assert second.status_code == 201, second.text
 
 
 @pytest.mark.asyncio
@@ -117,7 +114,8 @@ async def test_我的权益只返回自己的(client: httpx.AsyncClient, session
     mine = (await client.get("/api/v1/me/entitlements", headers=ALICE)).json()
     assert [item["compute_plan_id"] for item in mine] == ["plan_cpu_quick"]
     assert mine[0]["compute_plan_name"] == "CPU 快速测试"
-    assert mine[0]["max_concurrent_runs"] == 2
     assert mine[0]["expires_at"] is None
+    assert mine[0]["status"] == "active"
+    assert mine[0]["status_reason"] is None
 
     assert (await client.get("/api/v1/me/entitlements", headers=BOB)).json() == []

--- a/backend/tests/unit/domain/test_compute.py
+++ b/backend/tests/unit/domain/test_compute.py
@@ -84,7 +84,6 @@ def test_entitlement_reports_expiration() -> None:
         id="ent_1",
         user_id="usr_1",
         compute_plan_id=PLAN.id,
-        max_concurrent_runs=2,
         expires_at="2026-01-01T00:00:00+00:00",
     )
     assert entitlement.is_expired("2026-07-26T00:00:00+00:00")
@@ -92,7 +91,5 @@ def test_entitlement_reports_expiration() -> None:
 
 
 def test_entitlement_without_expiration_never_expires() -> None:
-    entitlement = ResourceEntitlement(
-        id="ent_1", user_id="usr_1", compute_plan_id=PLAN.id, max_concurrent_runs=2
-    )
+    entitlement = ResourceEntitlement(id="ent_1", user_id="usr_1", compute_plan_id=PLAN.id)
     assert not entitlement.is_expired("2099-01-01T00:00:00+00:00")

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -565,17 +565,33 @@
             "title": "Id",
             "type": "string"
           },
-          "max_concurrent_runs": {
-            "title": "Max Concurrent Runs",
-            "type": "integer"
+          "status": {
+            "enum": [
+              "active",
+              "expired"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "status_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Reason"
           }
         },
         "required": [
           "id",
           "compute_plan_id",
           "compute_plan_name",
-          "max_concurrent_runs",
-          "expires_at"
+          "expires_at",
+          "status",
+          "status_reason"
         ],
         "title": "EntitlementOut",
         "type": "object"
@@ -2757,7 +2773,7 @@
             "type": "string"
           },
           "initiated_by_user_id": {
-            "description": "发起本次 Run 的 User（GR-307）：执行身份、并发额度与通知接收方。",
+            "description": "发起本次 Run 的 User（GR-307）：执行身份与通知接收方。",
             "title": "Initiated By User Id",
             "type": "string"
           },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { SharedResourcesSection } from './components/usergroup/SharedResourcesSe
 import { AppShell } from './components/layout/AppShell'
 import { ArtifactFilePreviewPage } from './pages/ArtifactFilePreviewPage'
 import { HomePage } from './pages/HomePage'
+import { PersonalExecutionContextPage } from './pages/PersonalExecutionContextPage'
 import { EnvironmentListPage } from './pages/EnvironmentListPage'
 import { EnvironmentPage } from './pages/EnvironmentPage'
 import { EnvironmentVersionPage } from './pages/EnvironmentVersionPage'
@@ -129,6 +130,10 @@ export function ProductRoutes({
   return (
     <Routes>
       <Route path="/" element={<HomePage username={username} home={home} />} />
+      <Route
+        path="/execution-context"
+        element={<PersonalExecutionContextPage username={username} home={home} />}
+      />
       <Route
         path="/user-groups/:userGroupId"
         element={<UserGroupPage key={username} onMembershipChanged={home.reload} />}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -62,6 +62,7 @@ import type {
   WorkingChange,
   WorkingChangeDetail,
   UserGroup,
+  Variable,
 } from './types'
 
 /** 后端统一的错误响应结构。 */
@@ -352,6 +353,60 @@ export const api = {
 
   listEntitlements: async (): Promise<Entitlement[]> =>
     unwrap(await http.GET('/api/v1/me/entitlements')),
+
+  // -- Personal execution context -------------------------------------
+  listUserVariables: async (userId: string): Promise<Variable[]> =>
+    unwrap(
+      await http.GET('/api/v1/users/{user_id}/variables', {
+        params: { path: { user_id: userId } },
+      }),
+    ),
+
+  setUserVariable: async (
+    userId: string,
+    variable: { name: string; value: string },
+  ): Promise<Variable> =>
+    unwrap(
+      await http.PUT('/api/v1/users/{user_id}/variables', {
+        params: { path: { user_id: userId } },
+        body: variable,
+      }),
+    ),
+
+  deleteUserVariable: async (userId: string, name: string): Promise<void> => {
+    unwrap(
+      await http.DELETE('/api/v1/users/{user_id}/variables/{name}', {
+        params: { path: { user_id: userId, name } },
+      }),
+    )
+  },
+
+  listUserSecrets: async (userId: string): Promise<string[]> =>
+    unwrap(
+      await http.GET('/api/v1/users/{user_id}/secrets', {
+        params: { path: { user_id: userId } },
+      }),
+    ),
+
+  setUserSecret: async (
+    userId: string,
+    secret: { name: string; value: string },
+  ): Promise<void> => {
+    unwrap(
+      await http.PUT('/api/v1/users/{user_id}/secrets', {
+        params: { path: { user_id: userId } },
+        body: secret,
+      }),
+    )
+  },
+
+  deleteUserSecret: async (userId: string, name: string): Promise<void> => {
+    unwrap(
+      await http.DELETE('/api/v1/users/{user_id}/secrets/{name}', {
+        params: { path: { user_id: userId, name } },
+      }),
+    )
+  },
 
   // -- Project -----------------------------------------------------------
   listOwnerProjects: async (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -388,10 +388,7 @@ export const api = {
       }),
     ),
 
-  setUserSecret: async (
-    userId: string,
-    secret: { name: string; value: string },
-  ): Promise<void> => {
+  setUserSecret: async (userId: string, secret: { name: string; value: string }): Promise<void> => {
     unwrap(
       await http.PUT('/api/v1/users/{user_id}/secrets', {
         params: { path: { user_id: userId } },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2005,8 +2005,13 @@ export interface components {
             expires_at: string | null;
             /** Id */
             id: string;
-            /** Max Concurrent Runs */
-            max_concurrent_runs: number;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "active" | "expired";
+            /** Status Reason */
+            status_reason: string | null;
         };
         /**
          * EnvironmentAvailability
@@ -2879,7 +2884,7 @@ export interface components {
             id: string;
             /**
              * Initiated By User Id
-             * @description 发起本次 Run 的 User（GR-307）：执行身份、并发额度与通知接收方。
+             * @description 发起本次 Run 的 User（GR-307）：执行身份与通知接收方。
              */
             initiated_by_user_id: string;
             /**

--- a/frontend/src/components/layout/ContextGuide.tsx
+++ b/frontend/src/components/layout/ContextGuide.tsx
@@ -6,6 +6,7 @@ import { contextGuideCopy } from './copy'
 
 const contextGuides = [
   { pattern: '/', message: contextGuideCopy.home },
+  { pattern: '/execution-context', message: contextGuideCopy.executionContext },
   { pattern: '/user-groups/:userGroupId/*', message: contextGuideCopy.userGroup },
   { pattern: '/environments', message: contextGuideCopy.environment },
   { pattern: '/environments/:environmentId', message: contextGuideCopy.environment },

--- a/frontend/src/components/layout/GlobalNavigationDrawer.tsx
+++ b/frontend/src/components/layout/GlobalNavigationDrawer.tsx
@@ -2,6 +2,7 @@ import {
   ContainerIcon,
   HomeIcon,
   OrganizationIcon,
+  PersonIcon,
   ProjectIcon,
   XIcon,
 } from '@primer/octicons-react'
@@ -71,6 +72,19 @@ export function GlobalNavigationDrawer({ id, home, returnFocusRef, onClose }: Pr
                   <HomeIcon />
                 </NavList.LeadingVisual>
                 <span className={styles.itemText}>{globalNavigationCopy.home}</span>
+              </NavList.Item>
+
+              <NavList.Item
+                className={styles.item}
+                as={RouterLink}
+                to="/execution-context"
+                aria-current={location.pathname === '/execution-context' ? 'page' : undefined}
+                onClick={onClose}
+              >
+                <NavList.LeadingVisual>
+                  <PersonIcon />
+                </NavList.LeadingVisual>
+                <span className={styles.itemText}>{globalNavigationCopy.executionContext}</span>
               </NavList.Item>
 
               <NavList.Item

--- a/frontend/src/components/layout/copy.ts
+++ b/frontend/src/components/layout/copy.ts
@@ -22,6 +22,7 @@ export const globalNavigationCopy = {
   close: '关闭导航',
   home: '首页',
   environments: '运行环境',
+  executionContext: '个人执行上下文',
   userGroupsGroup: '你的 User Group',
   userGroupsEmpty: '还没有可进入的 User Group',
   recentProjectsGroup: '最近使用的 Project',
@@ -37,6 +38,8 @@ export const globalNavigationCopy = {
 export const contextGuideCopy = {
   ariaLabel: '页面引导',
   home: '从最近的 Project 或 User Group 开始；进入 Project 后可选择版本发起 Run。',
+  executionContext:
+    '这里管理发起 Run 的个人身份、算力权益与 User 配置；已有 Run Snapshot 不会被后续修改回写。',
   userGroup:
     '这里管理 User Group 的成员、设置和组拥有的 Project、共享资源与运行环境；资源详情在各自页面打开。',
   environment: '运行环境是独立的版本化资产；Run Configuration 保存后固定引用一个确定版本。',

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -91,22 +91,16 @@ export function HomePage({ username, home }: Props) {
               >
                 <h2 className={styles.cardTitle}>个人执行上下文</h2>
                 <p className={styles.cardDescription}>
-                  Owner：{home.data.personal_execution_context.owner.display_name}
+                  {home.data.personal_execution_context.owner.display_name} 的 User 配置与算力权益
                 </p>
-                {home.data.personal_execution_context.entitlements.length === 0 ? (
-                  <p className={styles.cardDescription}>当前没有可用的 Resource Entitlement。</p>
-                ) : (
-                  <ul className={styles.list}>
-                    {home.data.personal_execution_context.entitlements.map((entitlement) => (
-                      <li key={entitlement.id} className={styles.item}>
-                        <span className={styles.itemTitle}>{entitlement.compute_plan_name}</span>
-                        <span className={styles.itemDesc}>
-                          最多 {entitlement.max_concurrent_runs} 个并发 Run
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
+                <p className={styles.cardDescription}>
+                  {home.data.personal_execution_context.entitlements.length === 0
+                    ? '当前没有 Resource Entitlement'
+                    : `${home.data.personal_execution_context.entitlements.length} 项 Resource Entitlement`}
+                </p>
+                <Link as={RouterLink} to="/execution-context">
+                  管理个人执行上下文
+                </Link>
               </Card>
               <ComputePlanCatalog />
               <p className={styles.clusterNote}>{homeCopy.compute.realtimeUnavailable}</p>

--- a/frontend/src/pages/PersonalExecutionContextPage.module.css
+++ b/frontend/src/pages/PersonalExecutionContextPage.module.css
@@ -1,0 +1,201 @@
+.page,
+.content {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.page {
+  gap: var(--base-size-24);
+}
+
+.content {
+  gap: var(--base-size-16);
+}
+
+.title,
+.sectionTitle,
+.referenceTitle,
+.identityName,
+.muted {
+  margin: 0;
+}
+
+.title {
+  font-size: var(--text-title-size-medium);
+  font-weight: var(--base-text-weight-semibold);
+}
+
+.subtitle,
+.muted,
+.identityNote,
+.referenceGrid p {
+  color: var(--fgColor-muted);
+}
+
+.subtitle {
+  margin: var(--base-size-4) 0 0;
+}
+
+.identity {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-size-16);
+  padding: var(--base-size-16);
+  border: var(--borderWidth-thin) solid var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  background: var(--bgColor-default);
+}
+
+.identityName {
+  margin-top: var(--base-size-8);
+  font-size: var(--text-title-size-small);
+  font-weight: var(--base-text-weight-semibold);
+}
+
+.identityNote {
+  max-width: 52ch;
+  margin: 0;
+  font-size: var(--text-body-size-small);
+}
+
+.card {
+  min-width: 0;
+}
+
+.sectionTitle {
+  margin-bottom: var(--base-size-12);
+  font-size: var(--text-title-size-small);
+  font-weight: var(--base-text-weight-semibold);
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  gap: var(--base-size-4);
+  padding: var(--base-size-16);
+  border: var(--borderWidth-thin) dashed var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  color: var(--fgColor-muted);
+}
+
+.entitlementList,
+.configList {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.entitlement {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--base-size-4);
+  padding: var(--base-size-12) 0;
+  border-bottom: var(--borderWidth-thin) solid var(--borderColor-muted);
+  overflow-wrap: anywhere;
+}
+
+.entitlement:last-child,
+.configItem:last-child {
+  border-bottom: 0;
+}
+
+.rowHeading,
+.configItem,
+.rowActions,
+.formActions {
+  display: flex;
+  align-items: center;
+  gap: var(--base-size-8);
+}
+
+.rowHeading,
+.configItem {
+  justify-content: space-between;
+}
+
+.muted,
+.expiredReason,
+.referenceGrid p {
+  font-size: var(--text-body-size-small);
+}
+
+.expiredReason {
+  color: var(--fgColor-danger);
+}
+
+.configGrid,
+.referenceGrid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--base-size-16);
+}
+
+.form {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--base-size-12);
+  margin-bottom: var(--base-size-12);
+}
+
+.formActions,
+.rowActions {
+  flex-wrap: wrap;
+}
+
+.configItem {
+  min-width: 0;
+  padding: var(--base-size-12) 0;
+  border-bottom: var(--borderWidth-thin) solid var(--borderColor-muted);
+}
+
+.configValue {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  overflow-wrap: anywhere;
+}
+
+.referenceTitle {
+  font-size: var(--text-body-size-medium);
+}
+
+.referenceGrid > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--base-size-8);
+  padding: var(--base-size-12);
+  border: var(--borderWidth-thin) solid var(--borderColor-muted);
+  border-radius: var(--borderRadius-medium);
+}
+
+.referenceGrid code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.referenceGrid p {
+  margin: 0;
+}
+
+@media (max-width: 767px) {
+  .identity {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .configGrid,
+  .referenceGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .configItem {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/pages/PersonalExecutionContextPage.tsx
+++ b/frontend/src/pages/PersonalExecutionContextPage.tsx
@@ -54,7 +54,12 @@ function ExecutionContext({ username, home }: { username: string; home: Home }) 
         </p>
       </section>
 
-      <Card as="section" padding="normal" className={styles.card} aria-label="Resource Entitlements">
+      <Card
+        as="section"
+        padding="normal"
+        className={styles.card}
+        aria-label="Resource Entitlements"
+      >
         <h2 className={styles.sectionTitle}>Resource Entitlements</h2>
         {home.personal_execution_context.entitlements.length === 0 ? (
           <div className={styles.empty}>
@@ -379,11 +384,7 @@ function SecretSection({ userId, state }: { userId: string; state: AsyncResource
   )
 }
 
-function MutationFeedback({
-  feedback,
-}: {
-  feedback: { error: boolean; message: string } | null
-}) {
+function MutationFeedback({ feedback }: { feedback: { error: boolean; message: string } | null }) {
   if (!feedback) return null
   return (
     <Banner variant={feedback.error ? 'critical' : 'success'}>

--- a/frontend/src/pages/PersonalExecutionContextPage.tsx
+++ b/frontend/src/pages/PersonalExecutionContextPage.tsx
@@ -1,0 +1,393 @@
+import { Banner, Button, FormControl, Label, TextInput } from '@primer/react'
+import { Card } from '@primer/react/experimental'
+import { useState, type FormEvent } from 'react'
+
+import { api } from '../api/client'
+import { toAsyncError } from '../api/errors'
+import type { Home, Variable } from '../api/types'
+import { useAsync, type AsyncState as AsyncResource } from '../api/useAsync'
+import { AsyncState } from '../components/common/AsyncState'
+import { formatTime } from '../utils/format'
+import styles from './PersonalExecutionContextPage.module.css'
+
+interface Props {
+  username: string
+  home: AsyncResource<Home>
+}
+
+export function PersonalExecutionContextPage({ username, home }: Props) {
+  return (
+    <div className={styles.page}>
+      <header>
+        <h1 className={styles.title}>个人执行上下文</h1>
+        <p className={styles.subtitle}>管理发起 Run 时属于你本人的算力权益与配置。</p>
+      </header>
+      <AsyncState
+        loading={home.loading}
+        loadingText="正在加载个人执行上下文…"
+        error={toAsyncError(home.error)}
+        onRetry={home.reload}
+      >
+        {home.data ? <ExecutionContext username={username} home={home.data} /> : null}
+      </AsyncState>
+    </div>
+  )
+}
+
+function ExecutionContext({ username, home }: { username: string; home: Home }) {
+  const user = home.user
+  const variables = useAsync<Variable[]>(() => api.listUserVariables(user.id), [username, user.id])
+  const secrets = useAsync<string[]>(() => api.listUserSecrets(user.id), [username, user.id])
+
+  return (
+    <div className={styles.content}>
+      <section className={styles.identity} aria-labelledby="personal-identity-title">
+        <div>
+          <h2 id="personal-identity-title" className={styles.sectionTitle}>
+            当前用户
+          </h2>
+          <p className={styles.identityName}>{user.display_name}</p>
+          <p className={styles.muted}>@{user.username}</p>
+        </div>
+        <p className={styles.identityNote}>
+          这里的配置只属于 Initiated By User，不随 User Group Membership 转移。
+        </p>
+      </section>
+
+      <Card as="section" padding="normal" className={styles.card} aria-label="Resource Entitlements">
+        <h2 className={styles.sectionTitle}>Resource Entitlements</h2>
+        {home.personal_execution_context.entitlements.length === 0 ? (
+          <div className={styles.empty}>
+            <strong>当前没有 Resource Entitlement</strong>
+            <span>因此无法选择 Compute Plan 提交 Run；权益由平台发放。</span>
+          </div>
+        ) : (
+          <ul className={styles.entitlementList}>
+            {home.personal_execution_context.entitlements.map((entitlement) => (
+              <li key={entitlement.id} className={styles.entitlement}>
+                <div className={styles.rowHeading}>
+                  <strong>{entitlement.compute_plan_name}</strong>
+                  <Label variant={entitlement.status === 'expired' ? 'danger' : 'success'}>
+                    {entitlement.status === 'expired' ? '已过期' : '有效'}
+                  </Label>
+                </div>
+                <span className={styles.muted}>Compute Plan：{entitlement.compute_plan_id}</span>
+                <span className={styles.muted}>
+                  有效期：{entitlement.expires_at ? formatTime(entitlement.expires_at) : '长期有效'}
+                </span>
+                {entitlement.status_reason ? (
+                  <span className={styles.expiredReason}>{entitlement.status_reason}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <div className={styles.configGrid}>
+        <VariableSection userId={user.id} state={variables} />
+        <SecretSection userId={user.id} state={secrets} />
+      </div>
+
+      <Card as="section" padding="normal" className={styles.card} aria-label="配置引用说明">
+        <h2 className={styles.sectionTitle}>在 Run Configuration 中引用</h2>
+        <div className={styles.referenceGrid}>
+          <div>
+            <h3 className={styles.referenceTitle}>当前 User</h3>
+            <code>{'${{ user.vars.NAME }}'}</code>
+            <code>{'${{ user.secrets.NAME }}'}</code>
+            <p>只读取 Initiated By User 的个人配置，不回退到 Project。</p>
+          </div>
+          <div>
+            <h3 className={styles.referenceTitle}>Project / Project Owner</h3>
+            <code>{'${{ vars.NAME }}'}</code>
+            <code>{'${{ secrets.NAME }}'}</code>
+            <p>先读取 Project，再回退到该 Project 的直接 Owner。</p>
+          </div>
+        </div>
+        <Banner>
+          <Banner.Title>Run Snapshot 保持不变</Banner.Title>
+          <Banner.Description>
+            创建 Run 时会固定解析结果；修改个人配置不会回写已有 Run Snapshot。
+          </Banner.Description>
+        </Banner>
+      </Card>
+    </div>
+  )
+}
+
+function VariableSection({ userId, state }: { userId: string; state: AsyncResource<Variable[]> }) {
+  const [name, setName] = useState('')
+  const [value, setValue] = useState('')
+  const [editing, setEditing] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<{ error: boolean; message: string } | null>(null)
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    const normalizedName = name.trim()
+    if (!normalizedName) return
+    setSubmitting(true)
+    setFeedback(null)
+    try {
+      await api.setUserVariable(userId, { name: normalizedName, value })
+      setName('')
+      setValue('')
+      setEditing(null)
+      setFeedback({ error: false, message: 'Variable 已保存。' })
+      await state.reload({ silent: true })
+    } catch {
+      setFeedback({ error: true, message: 'Variable 保存失败，请重试。' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const remove = async (variableName: string) => {
+    setFeedback(null)
+    try {
+      await api.deleteUserVariable(userId, variableName)
+      if (editing === variableName) {
+        setEditing(null)
+        setName('')
+        setValue('')
+      }
+      await state.reload({ silent: true })
+    } catch {
+      setFeedback({ error: true, message: 'Variable 删除失败，请重试。' })
+    }
+  }
+
+  return (
+    <Card as="section" padding="normal" className={styles.card} aria-label="User Variables">
+      <h2 className={styles.sectionTitle}>User Variables</h2>
+      <form className={styles.form} onSubmit={submit}>
+        <FormControl id="user-variable-name" required disabled={submitting}>
+          <FormControl.Label>Variable 名称</FormControl.Label>
+          <TextInput
+            aria-label="Variable 名称"
+            block
+            value={name}
+            readOnly={editing !== null}
+            placeholder="例如 THREADS"
+            onChange={(event) => setName(event.target.value)}
+          />
+        </FormControl>
+        <FormControl id="user-variable-value" disabled={submitting}>
+          <FormControl.Label>Variable 值</FormControl.Label>
+          <TextInput
+            aria-label="Variable 值"
+            block
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        </FormControl>
+        <div className={styles.formActions}>
+          <Button type="submit" variant="primary" loading={submitting} disabled={!name.trim()}>
+            {editing ? '保存 Variable' : '创建 Variable'}
+          </Button>
+          {editing ? (
+            <Button
+              type="button"
+              onClick={() => {
+                setEditing(null)
+                setName('')
+                setValue('')
+              }}
+            >
+              取消编辑
+            </Button>
+          ) : null}
+        </div>
+      </form>
+      <MutationFeedback feedback={feedback} />
+      <AsyncState
+        loading={state.loading}
+        loadingText="正在加载 User Variables…"
+        error={toAsyncError(state.error)}
+        onRetry={state.reload}
+        empty={(state.data?.length ?? 0) === 0}
+        emptyText="还没有 User Variable"
+      >
+        <ul className={styles.configList}>
+          {(state.data ?? []).map((variable) => (
+            <li key={variable.name} className={styles.configItem}>
+              <div className={styles.configValue}>
+                <strong>{variable.name}</strong>
+                <span>{variable.value}</span>
+              </div>
+              <div className={styles.rowActions}>
+                <Button
+                  size="small"
+                  aria-label={`编辑 ${variable.name}`}
+                  onClick={() => {
+                    setEditing(variable.name)
+                    setName(variable.name)
+                    setValue(variable.value)
+                  }}
+                >
+                  编辑
+                </Button>
+                <Button
+                  size="small"
+                  variant="danger"
+                  aria-label={`删除 ${variable.name} Variable`}
+                  onClick={() => void remove(variable.name)}
+                >
+                  删除
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </AsyncState>
+    </Card>
+  )
+}
+
+function SecretSection({ userId, state }: { userId: string; state: AsyncResource<string[]> }) {
+  const [name, setName] = useState('')
+  const [value, setValue] = useState('')
+  const [replacing, setReplacing] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<{ error: boolean; message: string } | null>(null)
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    const normalizedName = name.trim()
+    if (!normalizedName || !value) return
+    setSubmitting(true)
+    setFeedback(null)
+    try {
+      await api.setUserSecret(userId, { name: normalizedName, value })
+      setValue('')
+      setName('')
+      setReplacing(false)
+      setFeedback({ error: false, message: 'Secret 已安全保存；值不会回显。' })
+      await state.reload({ silent: true })
+    } catch {
+      setFeedback({ error: true, message: 'Secret 保存失败，请重试。' })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const remove = async (secretName: string) => {
+    setFeedback(null)
+    try {
+      await api.deleteUserSecret(userId, secretName)
+      if (name === secretName) {
+        setName('')
+        setValue('')
+        setReplacing(false)
+      }
+      await state.reload({ silent: true })
+    } catch {
+      setFeedback({ error: true, message: 'Secret 删除失败，请重试。' })
+    }
+  }
+
+  return (
+    <Card as="section" padding="normal" className={styles.card} aria-label="User Secrets">
+      <h2 className={styles.sectionTitle}>User Secrets</h2>
+      <p className={styles.muted}>只显示名称。Secret 值提交后不会回显。</p>
+      <form className={styles.form} onSubmit={submit}>
+        <FormControl id="user-secret-name" required disabled={submitting}>
+          <FormControl.Label>Secret 名称</FormControl.Label>
+          <TextInput
+            aria-label="Secret 名称"
+            block
+            value={name}
+            readOnly={replacing}
+            placeholder="例如 API_TOKEN"
+            onChange={(event) => setName(event.target.value)}
+          />
+        </FormControl>
+        <FormControl id="user-secret-value" required disabled={submitting}>
+          <FormControl.Label>Secret 值</FormControl.Label>
+          <TextInput
+            aria-label="Secret 值"
+            block
+            type="password"
+            autoComplete="new-password"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        </FormControl>
+        <div className={styles.formActions}>
+          <Button
+            type="submit"
+            variant="primary"
+            loading={submitting}
+            disabled={!name.trim() || !value}
+          >
+            {replacing ? '替换 / 轮换 Secret' : '创建 Secret'}
+          </Button>
+          {replacing ? (
+            <Button
+              type="button"
+              onClick={() => {
+                setReplacing(false)
+                setName('')
+                setValue('')
+              }}
+            >
+              取消替换
+            </Button>
+          ) : null}
+        </div>
+      </form>
+      <MutationFeedback feedback={feedback} />
+      <AsyncState
+        loading={state.loading}
+        loadingText="正在加载 User Secrets…"
+        error={toAsyncError(state.error)}
+        onRetry={state.reload}
+        empty={(state.data?.length ?? 0) === 0}
+        emptyText="还没有 User Secret"
+      >
+        <ul className={styles.configList}>
+          {(state.data ?? []).map((secretName) => (
+            <li key={secretName} className={styles.configItem}>
+              <strong>{secretName}</strong>
+              <div className={styles.rowActions}>
+                <Button
+                  size="small"
+                  aria-label={`替换或轮换 ${secretName}`}
+                  onClick={() => {
+                    setReplacing(true)
+                    setName(secretName)
+                    setValue('')
+                  }}
+                >
+                  替换 / 轮换
+                </Button>
+                <Button
+                  size="small"
+                  variant="danger"
+                  aria-label={`删除 ${secretName} Secret`}
+                  onClick={() => void remove(secretName)}
+                >
+                  删除
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </AsyncState>
+    </Card>
+  )
+}
+
+function MutationFeedback({
+  feedback,
+}: {
+  feedback: { error: boolean; message: string } | null
+}) {
+  if (!feedback) return null
+  return (
+    <Banner variant={feedback.error ? 'critical' : 'success'}>
+      <Banner.Title>{feedback.message}</Banner.Title>
+    </Banner>
+  )
+}

--- a/frontend/tests/component/AppShell.test.tsx
+++ b/frontend/tests/component/AppShell.test.tsx
@@ -93,6 +93,10 @@ function readyProject(data: Project | undefined = projectData): AsyncState<Proje
 const contextGuideCases = [
   ['/', '从最近的 Project 或 User Group 开始；进入 Project 后可选择版本发起 Run。'],
   [
+    '/execution-context',
+    '这里管理发起 Run 的个人身份、算力权益与 User 配置；已有 Run Snapshot 不会被后续修改回写。',
+  ],
+  [
     '/user-groups/grp-1',
     '这里管理 User Group 的成员、设置和组拥有的 Project、共享资源与运行环境；资源详情在各自页面打开。',
   ],

--- a/frontend/tests/component/GlobalNavigationDrawer.test.tsx
+++ b/frontend/tests/component/GlobalNavigationDrawer.test.tsx
@@ -106,6 +106,10 @@ describe('GlobalNavigationDrawer', () => {
       'href',
       '/environments',
     )
+    expect(within(dialog).getByRole('link', { name: '个人执行上下文' })).toHaveAttribute(
+      'href',
+      '/execution-context',
+    )
     expect(within(dialog).getByRole('heading', { name: '你的 User Group' })).toBeVisible()
     expect(within(dialog).getByRole('heading', { name: '最近使用的 Project' })).toBeVisible()
     expect(hrefs(dialog, '/user-groups/')).toEqual([

--- a/frontend/tests/component/HomePage.test.tsx
+++ b/frontend/tests/component/HomePage.test.tsx
@@ -130,6 +130,10 @@ describe('HomePage 各栏目渲染内容而不只是标题', () => {
       'href',
       '/projects/p-1/runs/r-1',
     )
+    expect(screen.getByRole('link', { name: '管理个人执行上下文' })).toHaveAttribute(
+      'href',
+      '/execution-context',
+    )
   })
 
   it('HomePage 正文不自行渲染导航或重复的 User Group、Project 卡片', async () => {

--- a/frontend/tests/component/PersonalExecutionContextPage.test.tsx
+++ b/frontend/tests/component/PersonalExecutionContextPage.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { api, ApiError } from '../../src/api/client'
+import { ProductRoutes } from '../../src/App'
+import type { Home } from '../../src/api/types'
+import type { AsyncState } from '../../src/api/useAsync'
+import { PersonalExecutionContextPage } from '../../src/pages/PersonalExecutionContextPage'
+import { PrimerRoot } from '../../src/primer/setup'
+
+const home: Home = {
+  user: { id: 'usr_alice', username: 'alice', display_name: 'Alice' },
+  user_groups: [],
+  personal_execution_context: {
+    owner: { kind: 'user', id: 'usr_alice', display_name: 'Alice' },
+    entitlements: [
+      {
+        id: 'ent_1',
+        compute_plan_id: 'plan_cpu',
+        compute_plan_name: 'CPU 教学',
+        expires_at: '2026-08-01T00:00:00+00:00',
+        status: 'expired',
+        status_reason: '权益已于 2026-08-01T00:00:00+00:00 过期',
+      },
+    ],
+  },
+  recent_projects: [],
+  recent_runs: [],
+}
+
+function readyHome(data: Home = home): AsyncState<Home> {
+  return { data, loading: false, error: undefined, reload: vi.fn() }
+}
+
+function renderPage(homeState = readyHome()) {
+  return render(
+    <MemoryRouter>
+      <PrimerRoot>
+        <PersonalExecutionContextPage username="alice" home={homeState} />
+      </PrimerRoot>
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function renderProductRoute() {
+  const project: AsyncState<undefined> = {
+    data: undefined,
+    loading: false,
+    error: undefined,
+    reload: vi.fn(),
+  }
+  return render(
+    <MemoryRouter initialEntries={['/execution-context']}>
+      <PrimerRoot>
+        <ProductRoutes username="alice" home={readyHome()} project={project} />
+      </PrimerRoot>
+    </MemoryRouter>,
+  )
+}
+
+describe('PersonalExecutionContextPage #49', () => {
+  it('由产品路由直接到达页面', async () => {
+    vi.spyOn(api, 'listUserVariables').mockResolvedValue([])
+    vi.spyOn(api, 'listUserSecrets').mockResolvedValue([])
+    renderProductRoute()
+
+    expect(screen.getByRole('heading', { name: '个人执行上下文' })).toBeVisible()
+  })
+
+  it('展示身份、服务端过期原因、引用边界与 Snapshot 不变说明', async () => {
+    vi.spyOn(api, 'listUserVariables').mockResolvedValue([])
+    vi.spyOn(api, 'listUserSecrets').mockResolvedValue([])
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: '个人执行上下文' })).toBeVisible()
+    expect(screen.getByText('@alice')).toBeVisible()
+    expect(screen.getByText('CPU 教学')).toBeVisible()
+    expect(screen.getByText(/权益已于 .* 过期/)).toBeVisible()
+    expect(screen.getByText('${{ user.vars.NAME }}')).toBeVisible()
+    expect(screen.getByText('${{ user.secrets.NAME }}')).toBeVisible()
+    expect(screen.getByText(/Project Owner/)).toBeVisible()
+    expect(screen.getByText(/不会回写已有 Run Snapshot/)).toBeVisible()
+  })
+
+  it('无权益时给出明确原因，配置列表有独立 loading 和 error', async () => {
+    const { promise, resolve } = Promise.withResolvers<[]>()
+    vi.spyOn(api, 'listUserVariables').mockReturnValue(promise)
+    vi.spyOn(api, 'listUserSecrets').mockRejectedValue(
+      new ApiError(500, 'internal_error', 'Secret 加载失败。', []),
+    )
+    renderPage(
+      readyHome({
+        ...home,
+        personal_execution_context: { ...home.personal_execution_context, entitlements: [] },
+      }),
+    )
+
+    expect(screen.getByText('当前没有 Resource Entitlement')).toBeVisible()
+    expect(screen.getByText(/无法选择 Compute Plan 提交 Run/)).toBeVisible()
+    expect(screen.getByText('正在加载 User Variables…')).toBeVisible()
+    expect(await screen.findByText('Secret 加载失败。')).toBeVisible()
+    resolve([])
+  })
+
+  it('完成 Variable 新建、更新与删除', async () => {
+    const list = vi
+      .spyOn(api, 'listUserVariables')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ name: 'THREADS', value: '8' }])
+      .mockResolvedValue([{ name: 'THREADS', value: '16' }])
+    const setVariable = vi
+      .spyOn(api, 'setUserVariable')
+      .mockResolvedValueOnce({ name: 'THREADS', value: '8' })
+      .mockResolvedValueOnce({ name: 'THREADS', value: '16' })
+    const deleteVariable = vi.spyOn(api, 'deleteUserVariable').mockResolvedValue()
+    vi.spyOn(api, 'listUserSecrets').mockResolvedValue([])
+    renderPage()
+
+    fireEvent.change(await screen.findByLabelText('Variable 名称'), {
+      target: { value: 'THREADS' },
+    })
+    fireEvent.change(screen.getByLabelText('Variable 值'), { target: { value: '8' } })
+    fireEvent.click(screen.getByRole('button', { name: '创建 Variable' }))
+    await screen.findByText('THREADS')
+    expect(setVariable).toHaveBeenCalledWith('usr_alice', { name: 'THREADS', value: '8' })
+
+    fireEvent.click(screen.getByRole('button', { name: '编辑 THREADS' }))
+    fireEvent.change(screen.getByLabelText('Variable 值'), { target: { value: '16' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存 Variable' }))
+    await waitFor(() => expect(setVariable).toHaveBeenLastCalledWith('usr_alice', {
+      name: 'THREADS',
+      value: '16',
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: '删除 THREADS Variable' }))
+    await waitFor(() => expect(deleteVariable).toHaveBeenCalledWith('usr_alice', 'THREADS'))
+    expect(list).toHaveBeenCalled()
+  })
+
+  it('Secret 只展示名称，替换成功后从 DOM 和输入状态移除明文', async () => {
+    vi.spyOn(api, 'listUserVariables').mockResolvedValue([])
+    vi.spyOn(api, 'listUserSecrets')
+      .mockResolvedValueOnce(['TOKEN'])
+      .mockResolvedValue(['TOKEN'])
+    const setSecret = vi.spyOn(api, 'setUserSecret').mockResolvedValue()
+    const deleteSecret = vi.spyOn(api, 'deleteUserSecret').mockResolvedValue()
+    renderPage()
+
+    const secretSection = await screen.findByRole('region', { name: 'User Secrets' })
+    expect(within(secretSection).getByText('TOKEN')).toBeVisible()
+    fireEvent.click(within(secretSection).getByRole('button', { name: '替换或轮换 TOKEN' }))
+    const valueInput = screen.getByLabelText('Secret 值') as HTMLInputElement
+    fireEvent.change(valueInput, { target: { value: 'plaintext-never-render' } })
+    fireEvent.click(screen.getByRole('button', { name: '替换 / 轮换 Secret' }))
+
+    await waitFor(() => expect(setSecret).toHaveBeenCalledWith('usr_alice', {
+      name: 'TOKEN',
+      value: 'plaintext-never-render',
+    }))
+    await waitFor(() => expect(valueInput.value).toBe(''))
+    expect(document.body).not.toHaveTextContent('plaintext-never-render')
+
+    fireEvent.click(within(secretSection).getByRole('button', { name: '删除 TOKEN Secret' }))
+    await waitFor(() => expect(deleteSecret).toHaveBeenCalledWith('usr_alice', 'TOKEN'))
+  })
+})

--- a/frontend/tests/component/PersonalExecutionContextPage.test.tsx
+++ b/frontend/tests/component/PersonalExecutionContextPage.test.tsx
@@ -91,8 +91,11 @@ describe('PersonalExecutionContextPage #49', () => {
   })
 
   it('无权益时给出明确原因，配置列表有独立 loading 和 error', async () => {
-    const { promise, resolve } = Promise.withResolvers<[]>()
-    vi.spyOn(api, 'listUserVariables').mockReturnValue(promise)
+    let resolveVariables!: (value: []) => void
+    const pendingVariables = new Promise<[]>((resolve) => {
+      resolveVariables = resolve
+    })
+    vi.spyOn(api, 'listUserVariables').mockReturnValue(pendingVariables)
     vi.spyOn(api, 'listUserSecrets').mockRejectedValue(
       new ApiError(500, 'internal_error', 'Secret 加载失败。', []),
     )
@@ -107,7 +110,7 @@ describe('PersonalExecutionContextPage #49', () => {
     expect(screen.getByText(/无法选择 Compute Plan 提交 Run/)).toBeVisible()
     expect(screen.getByText('正在加载 User Variables…')).toBeVisible()
     expect(await screen.findByText('Secret 加载失败。')).toBeVisible()
-    resolve([])
+    resolveVariables([])
   })
 
   it('完成 Variable 新建、更新与删除', async () => {
@@ -135,10 +138,12 @@ describe('PersonalExecutionContextPage #49', () => {
     fireEvent.click(screen.getByRole('button', { name: '编辑 THREADS' }))
     fireEvent.change(screen.getByLabelText('Variable 值'), { target: { value: '16' } })
     fireEvent.click(screen.getByRole('button', { name: '保存 Variable' }))
-    await waitFor(() => expect(setVariable).toHaveBeenLastCalledWith('usr_alice', {
-      name: 'THREADS',
-      value: '16',
-    }))
+    await waitFor(() =>
+      expect(setVariable).toHaveBeenLastCalledWith('usr_alice', {
+        name: 'THREADS',
+        value: '16',
+      }),
+    )
 
     fireEvent.click(screen.getByRole('button', { name: '删除 THREADS Variable' }))
     await waitFor(() => expect(deleteVariable).toHaveBeenCalledWith('usr_alice', 'THREADS'))
@@ -147,9 +152,7 @@ describe('PersonalExecutionContextPage #49', () => {
 
   it('Secret 只展示名称，替换成功后从 DOM 和输入状态移除明文', async () => {
     vi.spyOn(api, 'listUserVariables').mockResolvedValue([])
-    vi.spyOn(api, 'listUserSecrets')
-      .mockResolvedValueOnce(['TOKEN'])
-      .mockResolvedValue(['TOKEN'])
+    vi.spyOn(api, 'listUserSecrets').mockResolvedValueOnce(['TOKEN']).mockResolvedValue(['TOKEN'])
     const setSecret = vi.spyOn(api, 'setUserSecret').mockResolvedValue()
     const deleteSecret = vi.spyOn(api, 'deleteUserSecret').mockResolvedValue()
     renderPage()
@@ -161,10 +164,12 @@ describe('PersonalExecutionContextPage #49', () => {
     fireEvent.change(valueInput, { target: { value: 'plaintext-never-render' } })
     fireEvent.click(screen.getByRole('button', { name: '替换 / 轮换 Secret' }))
 
-    await waitFor(() => expect(setSecret).toHaveBeenCalledWith('usr_alice', {
-      name: 'TOKEN',
-      value: 'plaintext-never-render',
-    }))
+    await waitFor(() =>
+      expect(setSecret).toHaveBeenCalledWith('usr_alice', {
+        name: 'TOKEN',
+        value: 'plaintext-never-render',
+      }),
+    )
     await waitFor(() => expect(valueInput.value).toBe(''))
     expect(document.body).not.toHaveTextContent('plaintext-never-render')
 


### PR DESCRIPTION
## 关联 Issue

Closes #49

- 关联 #38：User-scoped Resource Entitlement 语义
- 关联 #92：Slurm facts 投影与 Run preflight 边界
- 关联 #53：后续平台管理 backlog

## 修改内容

- 新增 `/execution-context` 个人执行上下文页面，并从 Global Navigation 与首页个人上下文入口进入。
- 展示当前 User、Resource Entitlement、Compute Plan、后端派生的有效/过期状态与有效期；无权益时显示明确原因。
- 使用已有 User-scoped Variable/Secret API 完成个人配置 CRUD；Secret 仅展示名称，提交成功后不保留明文。
- 展示 `${{ user.vars.* }}` / `${{ user.secrets.* }}` 与 Project / Project Owner 引用的区别，并说明 Run Snapshot 不会被个人配置修改回写。
- 删除没有产品或 Slurm 权威来源的 `max_concurrent_runs` 及其应用侧 queued/running 限制；保留 `Run.compute_plan_id` 作为 Run/Snapshot 方案身份。
- 新增可回滚迁移移除该字段；不新增 Plan disabled 状态，不复制 QoS 配额，不修改 #92 的 Slurm projection。

## 验证证据

- `make check`：通过；backend `372 passed / 3 skipped`，frontend `33 files / 223 tests`，workflow、Ruff、Prettier、typecheck、production build、OpenAPI/generated types 均通过。
- `uv run pytest tests/integration/db/test_remove_entitlement_concurrency_migration.py -q`：通过；非空 entitlement 的 upgrade → downgrade → upgrade roundtrip 通过。
- 针对性前端测试：`45 passed`。
- Chromium smoke：`375×812` 下 `scrollWidth == clientWidth == 375`；页面、入口、个人上下文可见；通过键盘路径验证 Variable/Secret 创建与删除；Secret 提交后明文未出现在 rendered text，输入框为空。
- `git diff --check`：通过；最终 worktree clean，staged/unstaged/untracked 均为 0。

## 影响范围

- API contract：`EntitlementOut` 移除 `max_concurrent_runs`，增加后端派生的 entitlement status/reason；OpenAPI 与前端生成类型已同步。
- 数据库：新增迁移 `backend/migrations/versions/e8a1c4d2f6b9_remove_entitlement_concurrency.py` 删除产品侧并发字段；downgrade 保留现有 entitlement 行并使用明确的回退值 `1`。
- Run：删除仅服务该字段的应用侧并发拒绝、计数和锁；真实作业并发/排队限制由平台 Slurm QoS/association 决定。
- 权限：继续使用现有后端 User ownership 校验；未扩大 User Variable/Secret 的访问范围。
- UI：新增个人执行上下文页面和稳定导航入口；不引入 Personal Workspace 或通用 Settings 框架。

## 延后事项与实现妥协

- Deferred ID：无

## 截图（仅界面改动）

- 已在本地 Chromium 以桌面视口和 `375×812` 视口检查页面布局、入口与键盘路径；截图未作为仓库文件提交。

## 按需检查

- [x] API 发生变化：OpenAPI 与前端生成类型已同步并提交
- [x] 数据库发生变化：升级、回退一步、再次升级均已实际验证
- [x] 认证或授权发生变化：既有 User-scoped Variable/Secret owner-check 测试保持通过；本 PR 未扩大授权语义
- [x] 涉及 Secret：页面不回读 Secret 明文；提交成功后清空明文输入，相关组件测试与 Chromium smoke 通过
- [x] 界面发生变化：已完成本地 Chromium 桌面/375px 与键盘路径检查

## 证据边界

本 PR 不执行 live 107 platform probe，也不宣称完成真实 Slurm association、Account、Partition、QoS limits 的平台投影；这些由 #92 及后续平台接入工作负责。