### PR TITLE
fix(frontend): 消除 User Group 列表链接 hover 下划线闪烁

### DIFF
--- a/frontend/src/components/usergroup/overview.module.css
+++ b/frontend/src/components/usergroup/overview.module.css
@@ -65,6 +65,15 @@
   padding: var(--base-size-16);
   color: inherit;
   text-decoration: none;
+  /* 覆盖 Primer / antd 全局 a:hover，避免下划线颜色闪烁。 */
+  transition: none;
+}
+
+.rowLink.rowLink:hover,
+.rowLink.rowLink:active,
+.rowLink.rowLink:focus {
+  color: inherit;
+  text-decoration: none;
 }
 
 .rowLink:hover {

--- a/frontend/src/components/usergroup/repoList.module.css
+++ b/frontend/src/components/usergroup/repoList.module.css
@@ -143,11 +143,14 @@
 .name {
   color: var(--fgColor-default);
   text-decoration: none;
+  transition: none;
 }
 
-.name:hover {
+.name.name:hover {
   color: var(--fgColor-accent);
   text-decoration: underline;
+  text-decoration-color: var(--fgColor-accent);
+  transition: none;
 }
 
 .name:focus-visible {


### PR DESCRIPTION
## 关联 Issue

Closes #104

## 修改内容

- Overview Project 行链接钉死颜色、去掉下划线，并关闭 color transition，覆盖 Primer / Ant Design 全局 `a:hover`
- Repo 列表名称 hover 同步关掉 color transition，下划线颜色与强调色同时生效

## 验证证据

- 统一检查：未跑全量 `make check`（纯 CSS，无契约/后端变化）
- 其他验证：对照 Primer BaseStyles 与 Ant Design `genLinkStyle` 特异度，使用加倍 class 选择器覆盖 `a:hover`

## 影响范围

- 仅 User Group Overview 预览行与资源列表名称链接的 hover 视觉
- 无 API / 数据库 / 权限变化

## 延后事项与实现妥协

- Deferred ID：无
