### PR TITLE
fix(main): 收敛 #103 合并后的迁移与配置契约

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,12 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
       - run: uv run --no-project python scripts/workspace.py setup backend
-      - name: Upgrade, downgrade one revision, and upgrade again
+      - name: Upgrade, downgrade to common parent, and upgrade again
         env:
           WORKSPACE107_DATABASE_URL: sqlite+aiosqlite:///./var/ci-migration.db
         run: |
           uv run --no-project python scripts/workspace.py migrate
-          uv run --no-project python scripts/workspace.py migrate-down
+          (cd backend && uv run alembic downgrade d71f3a9c2b4e)
           uv run --no-project python scripts/workspace.py migrate
 
   postgres-behavior:

--- a/backend/migrations/versions/a7b8c9d0e1f2_merge_migration_heads.py
+++ b/backend/migrations/versions/a7b8c9d0e1f2_merge_migration_heads.py
@@ -1,0 +1,23 @@
+"""Merge the concurrent migration heads from Issues #54 and #49.
+
+Revision ID: a7b8c9d0e1f2
+Revises: b3d8e2a64c19, e8a1c4d2f6b9
+Create Date: 2026-09-04
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: tuple[str, str] = ("b3d8e2a64c19", "e8a1c4d2f6b9")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Join the two already-applied schema branches."""
+
+
+def downgrade() -> None:
+    """Separate the branches again when rolling back the merge point."""

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -382,7 +382,7 @@ export const api = {
     )
   },
 
-  listUserSecrets: async (userId: string): Promise<string[]> =>
+  listUserSecrets: async (userId: string): Promise<Secret[]> =>
     unwrap(
       await http.GET('/api/v1/users/{user_id}/secrets', {
         params: { path: { user_id: userId } },

--- a/frontend/src/pages/PersonalExecutionContextPage.tsx
+++ b/frontend/src/pages/PersonalExecutionContextPage.tsx
@@ -4,7 +4,7 @@ import { useState, type FormEvent } from 'react'
 
 import { api } from '../api/client'
 import { toAsyncError } from '../api/errors'
-import type { Home, Variable } from '../api/types'
+import type { Home, Secret, Variable } from '../api/types'
 import { useAsync, type AsyncState as AsyncResource } from '../api/useAsync'
 import { AsyncState } from '../components/common/AsyncState'
 import { formatTime } from '../utils/format'
@@ -37,7 +37,7 @@ export function PersonalExecutionContextPage({ username, home }: Props) {
 function ExecutionContext({ username, home }: { username: string; home: Home }) {
   const user = home.user
   const variables = useAsync<Variable[]>(() => api.listUserVariables(user.id), [username, user.id])
-  const secrets = useAsync<string[]>(() => api.listUserSecrets(user.id), [username, user.id])
+  const secrets = useAsync<Secret[]>(() => api.listUserSecrets(user.id), [username, user.id])
 
   return (
     <div className={styles.content}>
@@ -250,7 +250,7 @@ function VariableSection({ userId, state }: { userId: string; state: AsyncResour
   )
 }
 
-function SecretSection({ userId, state }: { userId: string; state: AsyncResource<string[]> }) {
+function SecretSection({ userId, state }: { userId: string; state: AsyncResource<Secret[]> }) {
   const [name, setName] = useState('')
   const [value, setValue] = useState('')
   const [replacing, setReplacing] = useState(false)
@@ -352,16 +352,16 @@ function SecretSection({ userId, state }: { userId: string; state: AsyncResource
         emptyText="还没有 User Secret"
       >
         <ul className={styles.configList}>
-          {(state.data ?? []).map((secretName) => (
-            <li key={secretName} className={styles.configItem}>
-              <strong>{secretName}</strong>
+          {(state.data ?? []).map((secret) => (
+            <li key={secret.name} className={styles.configItem}>
+              <strong>{secret.name}</strong>
               <div className={styles.rowActions}>
                 <Button
                   size="small"
-                  aria-label={`替换或轮换 ${secretName}`}
+                  aria-label={`替换或轮换 ${secret.name}`}
                   onClick={() => {
                     setReplacing(true)
-                    setName(secretName)
+                    setName(secret.name)
                     setValue('')
                   }}
                 >
@@ -370,8 +370,8 @@ function SecretSection({ userId, state }: { userId: string; state: AsyncResource
                 <Button
                   size="small"
                   variant="danger"
-                  aria-label={`删除 ${secretName} Secret`}
-                  onClick={() => void remove(secretName)}
+                  aria-label={`删除 ${secret.name} Secret`}
+                  onClick={() => void remove(secret.name)}
                 >
                   删除
                 </Button>

--- a/frontend/tests/component/PersonalExecutionContextPage.test.tsx
+++ b/frontend/tests/component/PersonalExecutionContextPage.test.tsx
@@ -117,12 +117,12 @@ describe('PersonalExecutionContextPage #49', () => {
     const list = vi
       .spyOn(api, 'listUserVariables')
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ name: 'THREADS', value: '8' }])
-      .mockResolvedValue([{ name: 'THREADS', value: '16' }])
+      .mockResolvedValueOnce([{ name: 'THREADS', updated_at: '2026-09-04T10:00:00Z', value: '8' }])
+      .mockResolvedValue([{ name: 'THREADS', updated_at: '2026-09-04T10:01:00Z', value: '16' }])
     const setVariable = vi
       .spyOn(api, 'setUserVariable')
-      .mockResolvedValueOnce({ name: 'THREADS', value: '8' })
-      .mockResolvedValueOnce({ name: 'THREADS', value: '16' })
+      .mockResolvedValueOnce({ name: 'THREADS', updated_at: '2026-09-04T10:00:00Z', value: '8' })
+      .mockResolvedValueOnce({ name: 'THREADS', updated_at: '2026-09-04T10:01:00Z', value: '16' })
     const deleteVariable = vi.spyOn(api, 'deleteUserVariable').mockResolvedValue()
     vi.spyOn(api, 'listUserSecrets').mockResolvedValue([])
     renderPage()
@@ -152,7 +152,9 @@ describe('PersonalExecutionContextPage #49', () => {
 
   it('Secret 只展示名称，替换成功后从 DOM 和输入状态移除明文', async () => {
     vi.spyOn(api, 'listUserVariables').mockResolvedValue([])
-    vi.spyOn(api, 'listUserSecrets').mockResolvedValueOnce(['TOKEN']).mockResolvedValue(['TOKEN'])
+    vi.spyOn(api, 'listUserSecrets')
+      .mockResolvedValueOnce([{ name: 'TOKEN', updated_at: '2026-09-04T10:00:00Z' }])
+      .mockResolvedValue([{ name: 'TOKEN', updated_at: '2026-09-04T10:01:00Z' }])
     const setSecret = vi.spyOn(api, 'setUserSecret').mockResolvedValue()
     const deleteSecret = vi.spyOn(api, 'deleteUserSecret').mockResolvedValue()
     renderPage()


### PR DESCRIPTION
## 关联 Issue

Refs #103
Refs #100

## 问题

#100 与 #103 分别带入了以 `d71f3a9c2b4e` 为公共父节点的迁移 `b3d8e2a64c19` 与 `e8a1c4d2f6b9`。squash merge 后迁移图出现两个 head，主分支 CI 的 `upgrade head` 失败。

同时，#100 已将 User Variable/Secret 列表收敛为包含 `updated_at` 的元数据响应；#103 的个人页面仍按旧的 Secret 名称数组消费，导致主分支 typecheck 失败。

## 修改内容

- 新增无操作 Alembic merge migration `a7b8c9d0e1f2`，合并两个现有 head。
- migration CI 从合并 head 回退到公共父节点 `d71f3a9c2b4e`，再升级到 head；不在 merge point 使用有歧义的 `downgrade -1`。
- 让 #49 个人页面按 #100 当前 Secret 元数据契约消费 `{ name, updated_at }`，同步更新 typed client 和组件测试 fixture。
- 不修改既有迁移内容、产品语义、API 路径或数据库数据规则。

## 验证证据

- 本地 `uv run alembic upgrade head` → `uv run alembic downgrade d71f3a9c2b4e` → `uv run alembic upgrade head`：通过。
- 本地 `uv run alembic heads`：仅一个 head，`a7b8c9d0e1f2`。
- `pnpm run typecheck`：通过。
- `pnpm exec vitest run tests/component/PersonalExecutionContextPage.test.tsx`：5 passed。
- `git diff --check`：通过。
- Hosted CI（run `33879341227`）：`migration-up-down-up`、`postgres-migration-and-owner-race`、`compose-build-and-smoke`、`canonical-check` 全部成功。

## 影响范围

- 迁移拓扑、migration-check 命令，以及 #49 页面对 #100 Secret 元数据响应的兼容消费。
- 不修改真实远程数据库、权限边界、调度行为或其他 worktree。

## 延后事项与实现妥协

- Deferred ID：无

## 按需检查

- [x] API contract consumer：#49 个人页面已对齐当前生成类型
- [x] 数据库发生变化：升级、回退到公共父节点、再次升级均已实际验证
- [x] 涉及 Secret：仅消费名称与更新时间；不回读 Secret 明文

## 证据边界

本 PR 只修复 #103 squash merge 后暴露的迁移拓扑和前端契约适配问题；不替代 Slurm live 平台验收。