### PR TITLE
fix(frontend): 从全局导航抽屉移除「运行环境」入口

### DIFF
--- a/frontend/src/components/layout/GlobalNavigationDrawer.tsx
+++ b/frontend/src/components/layout/GlobalNavigationDrawer.tsx
@@ -1,5 +1,4 @@
 import {
-  ContainerIcon,
   HomeIcon,
   OrganizationIcon,
   PersonIcon,
@@ -85,25 +84,6 @@ export function GlobalNavigationDrawer({ id, home, returnFocusRef, onClose }: Pr
                   <PersonIcon />
                 </NavList.LeadingVisual>
                 <span className={styles.itemText}>{globalNavigationCopy.executionContext}</span>
-              </NavList.Item>
-
-              <NavList.Item
-                className={styles.item}
-                as={RouterLink}
-                to="/environments"
-                aria-current={
-                  location.pathname === '/environments' ||
-                  location.pathname.startsWith('/environments/') ||
-                  location.pathname.startsWith('/environment-versions/')
-                    ? 'page'
-                    : undefined
-                }
-                onClick={onClose}
-              >
-                <NavList.LeadingVisual>
-                  <ContainerIcon />
-                </NavList.LeadingVisual>
-                <span className={styles.itemText}>{globalNavigationCopy.environments}</span>
               </NavList.Item>
 
               <NavList.Group title={globalNavigationCopy.userGroupsGroup}>

--- a/frontend/src/components/layout/GlobalNavigationDrawer.tsx
+++ b/frontend/src/components/layout/GlobalNavigationDrawer.tsx
@@ -1,10 +1,4 @@
-import {
-  HomeIcon,
-  OrganizationIcon,
-  PersonIcon,
-  ProjectIcon,
-  XIcon,
-} from '@primer/octicons-react'
+import { HomeIcon, OrganizationIcon, PersonIcon, ProjectIcon, XIcon } from '@primer/octicons-react'
 import { Button, Dialog, IconButton, NavList, type DialogHeaderProps } from '@primer/react'
 import { useRef, useState, type RefObject } from 'react'
 import { Link as RouterLink, useLocation } from 'react-router-dom'

--- a/frontend/src/components/layout/copy.ts
+++ b/frontend/src/components/layout/copy.ts
@@ -21,7 +21,6 @@ export const globalNavigationCopy = {
   heading: '全局导航',
   close: '关闭导航',
   home: '首页',
-  environments: '运行环境',
   executionContext: '个人执行上下文',
   userGroupsGroup: '你的 User Group',
   userGroupsEmpty: '还没有可进入的 User Group',

--- a/frontend/tests/component/GlobalNavigationDrawer.test.tsx
+++ b/frontend/tests/component/GlobalNavigationDrawer.test.tsx
@@ -102,10 +102,8 @@ describe('GlobalNavigationDrawer', () => {
 
     const dialog = await screen.findByRole('dialog', { name: '107 Workspace' })
     expect(within(dialog).getByRole('navigation', { name: '全局导航' })).toBeVisible()
-    expect(within(dialog).getByRole('link', { name: '运行环境' })).toHaveAttribute(
-      'href',
-      '/environments',
-    )
+    expect(within(dialog).getByRole('link', { name: '首页' })).toHaveAttribute('href', '/')
+    expect(within(dialog).queryByRole('link', { name: '运行环境' })).toBeNull()
     expect(within(dialog).getByRole('link', { name: '个人执行上下文' })).toHaveAttribute(
       'href',
       '/execution-context',


### PR DESCRIPTION
Closes #114

## 变更

从全局导航抽屉（`GlobalNavigationDrawer.tsx`，由顶栏汉堡按钮打开）删除「运行环境」导航入口。

- `frontend/src/components/layout/GlobalNavigationDrawer.tsx`：删除「运行环境」的 `NavList.Item`，移除不再使用的 `ContainerIcon` import。
- `frontend/src/components/layout/copy.ts`：删除不再使用的 `environments: '运行环境'` 文案。
- `frontend/tests/component/GlobalNavigationDrawer.test.tsx`：断言抽屉不再渲染「运行环境」入口，并保留 首页 / 个人执行上下文 的正向断言。

## 验证

- `pnpm typecheck` 通过
- `eslint` 通过
- `vitest run tests/component/GlobalNavigationDrawer.test.tsx`（2 通过）与 `AppShell.test.tsx`（29 通过）全部通过

> 本工作站的系统环境无法运行真实浏览器（Chromium 缺少 `libatk`/`libgbm` 等系统库且无 sudo 安装），因此「人工打开前端检查」以 jsdom 组件渲染测试作为替代证据：抽屉中 `<NavList.Item>` 已确认不渲染「运行环境」。