### PR TITLE
fix(frontend): 从全局导航抽屉移除「个人执行上下文」入口

### DIFF
--- a/frontend/src/components/layout/GlobalNavigationDrawer.tsx
+++ b/frontend/src/components/layout/GlobalNavigationDrawer.tsx
@@ -1,4 +1,4 @@
-import { HomeIcon, OrganizationIcon, PersonIcon, ProjectIcon, XIcon } from '@primer/octicons-react'
+import { HomeIcon, OrganizationIcon, ProjectIcon, XIcon } from '@primer/octicons-react'
 import { Button, Dialog, IconButton, NavList, type DialogHeaderProps } from '@primer/react'
 import { useRef, useState, type RefObject } from 'react'
 import { Link as RouterLink, useLocation } from 'react-router-dom'
@@ -65,19 +65,6 @@ export function GlobalNavigationDrawer({ id, home, returnFocusRef, onClose }: Pr
                   <HomeIcon />
                 </NavList.LeadingVisual>
                 <span className={styles.itemText}>{globalNavigationCopy.home}</span>
-              </NavList.Item>
-
-              <NavList.Item
-                className={styles.item}
-                as={RouterLink}
-                to="/execution-context"
-                aria-current={location.pathname === '/execution-context' ? 'page' : undefined}
-                onClick={onClose}
-              >
-                <NavList.LeadingVisual>
-                  <PersonIcon />
-                </NavList.LeadingVisual>
-                <span className={styles.itemText}>{globalNavigationCopy.executionContext}</span>
               </NavList.Item>
 
               <NavList.Group title={globalNavigationCopy.userGroupsGroup}>

--- a/frontend/src/components/layout/copy.ts
+++ b/frontend/src/components/layout/copy.ts
@@ -21,7 +21,6 @@ export const globalNavigationCopy = {
   heading: '全局导航',
   close: '关闭导航',
   home: '首页',
-  executionContext: '个人执行上下文',
   userGroupsGroup: '你的 User Group',
   userGroupsEmpty: '还没有可进入的 User Group',
   recentProjectsGroup: '最近使用的 Project',

--- a/frontend/tests/component/GlobalNavigationDrawer.test.tsx
+++ b/frontend/tests/component/GlobalNavigationDrawer.test.tsx
@@ -104,10 +104,7 @@ describe('GlobalNavigationDrawer', () => {
     expect(within(dialog).getByRole('navigation', { name: '全局导航' })).toBeVisible()
     expect(within(dialog).getByRole('link', { name: '首页' })).toHaveAttribute('href', '/')
     expect(within(dialog).queryByRole('link', { name: '运行环境' })).toBeNull()
-    expect(within(dialog).getByRole('link', { name: '个人执行上下文' })).toHaveAttribute(
-      'href',
-      '/execution-context',
-    )
+    expect(within(dialog).queryByRole('link', { name: '个人执行上下文' })).toBeNull()
     expect(within(dialog).getByRole('heading', { name: '你的 User Group' })).toBeVisible()
     expect(within(dialog).getByRole('heading', { name: '最近使用的 Project' })).toBeVisible()
     expect(hrefs(dialog, '/user-groups/')).toEqual([


### PR DESCRIPTION
Closes #117

> 本 PR 基于 #115（移除「运行环境」）stacked，base 指向 `feat/remove-environments-nav`，故本 PR diff 仅包含「个人执行上下文」的移除。「运行环境」的移除见 #115。

## 变更

从全局导航抽屉（`GlobalNavigationDrawer.tsx`）删除「个人执行上下文」导航入口。

- `frontend/src/components/layout/GlobalNavigationDrawer.tsx`：删除「个人执行上下文」的 `NavList.Item`，移除不再使用的 `PersonIcon` import。
- `frontend/src/components/layout/copy.ts`：删除 `globalNavigationCopy` 中不再使用的 `executionContext: '个人执行上下文'` 文案（`contextGuideCopy.executionContext` 保留，供 ContextGuide 使用）。
- `frontend/tests/component/GlobalNavigationDrawer.test.tsx`：断言抽屉不再渲染「个人执行上下文」入口，并保留 首页 / User Group / Project 的正向断言。

## 验证

- `pnpm typecheck` 通过
- `eslint` 通过
- `vitest run tests/component/GlobalNavigationDrawer.test.tsx`（2 通过）与 `AppShell.test.tsx`（29 通过）全部通过

> 同 #115：本工作站系统无法运行真实浏览器（Chromium 缺 `libatk`/`libgbm` 等系统库且无 sudo 安装），「打开前端检查」以 jsdom 组件渲染测试作为替代证据，确认抽屉不渲染「个人执行上下文」。

## 涉及 issue

- #114（运行环境，见 #115）
- #117（个人执行上下文，本 PR）