### PR TITLE
docs(auth): 说明 README 默认启动没有登录页

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,10 @@ WORKSPACE107_SHARED_RESOURCE_PUBLICATION_RECOVERY_SECONDS=300.0
 
 # ---------- Authentication ----------
 # dev trusts X-User only for local work; ustc consumes trusted revproxy identity headers.
-# See docs/operations/authentication.md before enabling ustc.
+# make dev and Compose default to dev: the browser is already signed in as `student`
+# and will not show the public login page. The login UI is deploy/cas-revproxy
+# (AUTH_MODE=ustc, nginx with auth_request). See docs/operations/authentication.md.
+# Do not point Compose and cas-revproxy at 8107 at the same time.
 WORKSPACE107_AUTH_MODE=dev
 
 # ---------- Docker Compose only ----------

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ make dev
 ```
 
 后端接口文档默认位于 <http://127.0.0.1:8000/docs>，前端默认位于
-<http://127.0.0.1:5174>。
+<http://127.0.0.1:5174>。这条路径使用 `WORKSPACE107_AUTH_MODE=dev`：后端把缺省身份当成
+`student`，**不会出现登录页**。日常改业务页面用这条。
+
+要看公开登录页（账密 + 统一身份认证），不能用 `make dev`，也不能用下面 Compose 默认栈。
+那是另一套入口，见 [`deploy/cas-revproxy/README.md`](deploy/cas-revproxy/README.md)：
+Nginx 监听 `127.0.0.1:8107`，认证服务 `8108`，后端必须 `WORKSPACE107_AUTH_MODE=ustc`。
+它和 Compose 默认的 `:8107` **端口相同、拓扑不同**，不要同时占用。
 
 提交前运行统一检查：
 
@@ -76,5 +82,8 @@ cp .env.example .env
 docker compose --project-directory . --file deploy/compose.yaml up -d --build
 ```
 
-浏览器访问 <http://127.0.0.1:8107>。部署和共享存储约束见
+浏览器访问 <http://127.0.0.1:8107>。Compose 默认仍是 `AUTH_MODE=dev`，打开即已登录为
+开发用户，**没有登录页**。带登录页的 `:8107` 是
+[`deploy/cas-revproxy/`](deploy/cas-revproxy/README.md) 那套 Nginx（`auth_request` +
+`/login` / `/login/password`），不是这个 `web` 容器。部署和共享存储约束见
 [`docs/operations/deployment.md`](docs/operations/deployment.md)。

--- a/backend/README.md
+++ b/backend/README.md
@@ -95,7 +95,7 @@ cp ../.env.example .env
 | `WORKSPACE107_STORAGE_ROOT` | Project 文件、Run 目录、日志和 Artifact 的根目录 |
 | `WORKSPACE107_SCHEDULER` | `mock`（本机子进程真实执行）或 `slurm` |
 | `WORKSPACE107_SLURM_JWT` | **等价于密码**，只能从环境注入 |
-| `WORKSPACE107_AUTH_MODE` | `dev` 用 `X-User` 请求头识别用户 |
+| `WORKSPACE107_AUTH_MODE` | `dev` 用 `X-User` 请求头识别用户，缺省 `student`，没有登录页；`ustc` 只接受反向代理注入的身份，见 [`docs/operations/authentication.md`](../docs/operations/authentication.md) |
 
 ## 开发模式下的身份
 
@@ -109,7 +109,7 @@ curl -X POST -H 'X-User: student' -H 'Content-Type: application/json' \
   http://127.0.0.1:8000/api/v1/user-groups
 ```
 
-接入学校统一身份认证后只需替换 `api/deps.py` 中的 `get_current_user`。
+公开登录页不走这条 `dev` 路径，见 [`deploy/cas-revproxy/README.md`](../deploy/cas-revproxy/README.md)。
 
 ## 调度适配器
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,8 +4,11 @@
 [`docs/operations/deployment.md`](../docs/operations/deployment.md) 为准。
 
 当前包含 [`compose.yaml`](compose.yaml) 与 [`cas-revproxy/`](cas-revproxy/README.md)。
-Compose 用于本机开发和受信任演示；CAS 反向代理用于统一身份认证入口。它们不提供
-生产级 Secret 管理、自动备份、多副本编排或监控告警，因此不构成生产部署方案。
+Compose 用于本机开发和受信任演示，默认 `AUTH_MODE=dev`，`:8107` 没有登录页。
+CAS 反向代理（[`cas-revproxy/`](cas-revproxy/README.md)）才是带登录页的 `:8107`：
+后端 `AUTH_MODE=ustc`，Nginx `auth_request`，认证服务处理 `/login` 与
+`/login/password`。两套不要同时占用同一端口。它们不提供生产级 Secret 管理、自动备份、
+多副本编排或监控告警，因此不构成生产部署方案。
 
 ## 目录边界
 

--- a/deploy/cas-revproxy/README.md
+++ b/deploy/cas-revproxy/README.md
@@ -3,20 +3,34 @@
 本目录保存 `ustccas-revproxy` 的可审查适配：Nginx 入口、认证服务、上游补丁和运行说明。
 不向第三方上游仓库推送。
 
+## 和 README 默认启动的区别
+
+根目录 `make dev` 打开的是 Vite <http://127.0.0.1:5174>，后端默认
+`WORKSPACE107_AUTH_MODE=dev`，缺省身份是 `student`，**没有登录页**。
+
+Compose 默认 `web` 容器也监听 `:8107`，但只反代 `/api`，同样是 `AUTH_MODE=dev`，
+打开即已登录。那不是本目录这套 Nginx。
+
+本目录才是带公开登录页的入口：Nginx `auth_request`、认证服务处理 `/login`、
+`/login/password`、`/logout`，后端必须 `WORKSPACE107_AUTH_MODE=ustc`。两套 `:8107`
+端口相同、拓扑不同，不要同时占用。
+
 当前联调拓扑（非 Docker）：
 
 ```text
 浏览器 --SSH 隧道--> 127.0.0.1:8107 Nginx
                          ├── 公开 SPA / 静态资源
-                         ├── GET /login、POST /logout → 认证服务 127.0.0.1:8108
+                         ├── GET /login、POST /login/password、POST /logout → 认证服务 127.0.0.1:8108
                          └── /api/ auth_request → 后端 127.0.0.1:8000
 ```
 
-隧道：
+从其他机器看演示时再开隧道：
 
 ```bash
 ssh -N -L 127.0.0.1:8107:127.0.0.1:8107 dfy2
 ```
+
+本机直接访问 <http://127.0.0.1:8107/> 不需要隧道。
 
 ## 行为契约
 
@@ -32,15 +46,66 @@ ssh -N -L 127.0.0.1:8107:127.0.0.1:8107 dfy2
 - 会话 Cookie：`HttpOnly`、`SameSite=Lax`。HTTP 隧道联调可关闭 `Secure`；HTTPS 入口必须开启。
 - 退出和 API 写请求校验 `Origin` / `Referer`。敏感响应 `Cache-Control: no-store`。
 
-## 启动
+## 本机启动（公开登录页）
 
-1. 复制 `env.example` 为 `env`，填入 `SECRET_KEY` 和已验证可用的 `HTTPS_PROXY`。
-2. 构建前端到 `FRONTEND_DIST`。
-3. 后端监听 `127.0.0.1:8000`，`WORKSPACE107_AUTH_MODE=ustc`。
-4. `scripts/run-auth.sh`
-5. `scripts/run-nginx.sh`（`NGINX_BIN` 可指向用户空间 Nginx）
+在仓库根目录操作。不要同时跑 `make dev`（占用 `:8000`）或 Compose 默认栈（占用 `:8107`）。
+若 `:8000` 已被占用，把后端改到其他端口，并同步修改 `BACKEND_ORIGIN`。
+
+1. 安装依赖、迁移、构建前端：
+
+```bash
+./scripts/platform/posix/bootstrap.sh
+make migrate
+make build
+```
+
+需要「平台资产」演示数据时再执行（会创建 `provider=local` 的 `platform-admin`，
+并作为 `grp_platform_assets` 的 Owner）：
+
+```bash
+cd backend
+WORKSPACE107_AUTH_MODE=ustc uv run python -m workspace107.tools.seed --demo
+cd ..
+```
+
+2. 后端以 `ustc` 模式监听 `127.0.0.1:8000`。不要用 `make dev`：
+
+```bash
+cd backend
+WORKSPACE107_AUTH_MODE=ustc uv run uvicorn workspace107.main:create_app --factory --host 127.0.0.1 --port 8000
+```
+
+3. 复制并编辑认证配置：
+
+```bash
+cp deploy/cas-revproxy/env.example deploy/cas-revproxy/env
+```
+
+至少填写：
+
+- `SECRET_KEY`：随机值，不要提交
+- `FRONTEND_DIST`：本仓库 `frontend/dist` 的绝对路径
+- `BACKEND_ORIGIN`：与上一步后端地址一致，默认 `http://127.0.0.1:8000`
+- `LOCAL_ADMIN_PASSWORD`：演示密码，不要提交；用户名默认 `platform-admin`
+- `HTTPS_PROXY`：学校 CAS `serviceValidate` 需要可用的出站代理。只演示账密登录时可以留空
+
+4. 启动认证服务和 Nginx（两个终端，或自行放到后台）：
+
+```bash
+# 若本机没有带 auth_request 的系统 nginx，按下一节解压用户空间 nginx 并 export NGINX_BIN
+./deploy/cas-revproxy/scripts/run-auth.sh
+./deploy/cas-revproxy/scripts/run-nginx.sh
+```
+
+5. 浏览器打开 <http://127.0.0.1:8107/>。
+
+未登录会看到公开首页（账密 + 统一身份认证）。账密使用步骤 3 的
+`LOCAL_ADMIN_USERNAME` / `LOCAL_ADMIN_PASSWORD`。统一身份认证还需要学校侧登记的
+HTTPS 回调，回环地址目前不能完成真实 CAS 闭环。
 
 Nginx 只监听 `127.0.0.1:8107`，不要启用发行版默认对外站点。
+
+## 用户空间 Nginx
 
 当前 dfy2 没有系统 Nginx。可把 Ubuntu `nginx` 软件包解压到用户目录，避免启用默认站点：
 

--- a/deploy/cas-revproxy/env.example
+++ b/deploy/cas-revproxy/env.example
@@ -8,6 +8,7 @@ SECRET_KEY=change-me
 SESSION_COOKIE_SECURE=0
 
 # 显式出站代理，供 CAS serviceValidate 使用。不要依赖交互 shell 的隐式环境。
+# 只演示账密登录、没有可用代理时可以留空；此时统一身份认证校验会失败。
 HTTPS_PROXY=http://127.0.0.1:27997
 
 CAS_LOGIN_URL=https://passport.ustc.edu.cn/login
@@ -20,7 +21,8 @@ LOCAL_ADMIN_DISPLAY_NAME=平台管理员
 LOCAL_ADMIN_PASSWORD=
 LOCAL_ADMIN_PASSWORD_HASH=
 
-FRONTEND_DIST=/home/zxbq/107-workspace/.worktrees/issue111/frontend/dist
+# 仓库内前端构建产物的绝对路径。先在仓库根目录执行 make build。
+FRONTEND_DIST=/absolute/path/to/107-workspace/frontend/dist
 BACKEND_ORIGIN=http://127.0.0.1:8000
 AUTH_ORIGIN=http://127.0.0.1:8108
 NGINX_LISTEN=127.0.0.1:8107

--- a/deploy/cas-revproxy/scripts/run-auth.sh
+++ b/deploy/cas-revproxy/scripts/run-auth.sh
@@ -15,8 +15,7 @@ source "$ROOT/env"
 set +a
 
 if [[ -z "${HTTPS_PROXY:-}" ]]; then
-  echo "HTTPS_PROXY must be set explicitly for CAS validation" >&2
-  exit 1
+  echo "warning: HTTPS_PROXY is empty; CAS serviceValidate will fail. Password login still works." >&2
 fi
 
 if [[ ! -d "$ROOT/.venv" ]]; then

--- a/docs/operations/authentication.md
+++ b/docs/operations/authentication.md
@@ -19,6 +19,16 @@ WORKSPACE107_AUTH_MODE=dev uv run uvicorn workspace107.main:create_app --factory
 curl -H 'X-User: alice' http://127.0.0.1:8000/api/v1/me
 ```
 
+`make dev` 和 Compose 默认走这条 `dev` 模式，前端一打开就会拿到当前用户，因此看不到
+公开登录页。要在浏览器里看到账密 / 统一身份认证入口，必须同时满足：
+
+1. 后端 `WORKSPACE107_AUTH_MODE=ustc`（没有代理注入的身份时 `/api/v1/me` 返回 401）；
+2. 用 [`deploy/cas-revproxy/`](../../deploy/cas-revproxy/README.md) 的 Nginx 做入口
+   （`/login`、`POST /login/password`、`POST /logout` 和 `/api/` 的 `auth_request`）。
+
+只改 `AUTH_MODE=ustc`、仍用 Vite `:5174` 或 Compose `web` 容器，登录按钮没有对应代理路由，
+不能当成登录演示。
+
 ## revproxy 与 Backend 的字段约定
 
 `ustc` 模式使用以下请求头：

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -13,7 +13,12 @@ cp .env.example .env
 docker compose --project-directory . --file deploy/compose.yaml up -d --build
 ```
 
-打开 <http://127.0.0.1:8107>。停止服务但保留数据：
+打开 <http://127.0.0.1:8107>。默认 `WORKSPACE107_AUTH_MODE=dev`，Web 容器只反代 `/api`，
+没有 `/login` 或账密登录；浏览器会直接进入已登录控制台。要公开登录页，改用
+[`deploy/cas-revproxy/README.md`](../../deploy/cas-revproxy/README.md)，不要与本 Compose
+栈同时占用 `:8107`。
+
+停止服务但保留数据：
 
 ```bash
 docker compose --project-directory . --file deploy/compose.yaml down

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -144,11 +144,13 @@ Run 未结束时每 2 秒轮询一次：先触发后端状态同步，再读取 
 
 ## 身份
 
-前端启动时请求 `GET /api/v1/me` 确认当前用户。未登录显示公开首页和「统一身份认证登录」；
-登录由反向代理的 `GET /login` 处理，前端只做整页跳转。退出通过同源 `POST /logout` 表单提交。
+前端启动时请求 `GET /api/v1/me` 确认当前用户。未登录显示公开首页（账密 + 统一身份认证）；
+登录由反向代理的 `GET /login` 与 `POST /login/password` 处理，前端只做整页跳转和同源表单。
+退出通过同源 `POST /logout` 表单提交。
 
-正常客户端不发送 `X-User` 或 `X-User-ID`。本地开发继续使用后端 `dev` 模式的默认用户。
-反向代理接入见 [`docs/operations/authentication.md`](../docs/operations/authentication.md)
+`make dev` 走后端 `dev` 模式，一打开就是 `student`，看不到未登录首页。
+正常客户端不发送 `X-User` 或 `X-User-ID`。反向代理接入见
+[`docs/operations/authentication.md`](../docs/operations/authentication.md)
 与 [`deploy/cas-revproxy/README.md`](../deploy/cas-revproxy/README.md)。
 
 ## 检查

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ esbuild 必需的安装脚本。
 setup                  按锁文件安装前后端依赖
 check [target]         运行格式、lint、类型、测试、构建和契约检查
 contract sync|check    重新生成或核对 OpenAPI 与前端类型
-dev                    启动前后端开发服务
+dev                    启动前后端开发服务（AUTH_MODE=dev，无登录页）
 demo / smoke           验证隔离的 Project 到 Artifact 工作流
 migrate / migrate-down 升级或回退一个数据库版本
 coverage               生成后端覆盖率报告（重构期不设全仓门槛）
@@ -23,6 +23,8 @@ doctor                 检查本地工程基线
 ```
 
 `target` 可以是 `all`、`backend`、`frontend`；`check` 还支持 `contract`。
+`dev` 默认 `WORKSPACE107_AUTH_MODE=dev`，浏览器不会出现登录页。公开登录页见
+[`deploy/cas-revproxy/README.md`](../deploy/cas-revproxy/README.md)。
 
 任务实现按职责分层：
 


### PR DESCRIPTION
## 问题

按根目录 README 的 `make dev` 或 Compose 默认栈启动后，浏览器打不开带登录界面的首页。

这不是回归：README 默认路径是 `WORKSPACE107_AUTH_MODE=dev`，后端把缺省身份当成 student，一打开就是已登录控制台。Compose 的 `:8107` 是 web 容器，只反代 `/api`，没有 `/login`。

带登录页的 `:8107` 是 `deploy/cas-revproxy`：Nginx `auth_request` + 认证服务，后端必须 `AUTH_MODE=ustc`。两套端口相同、拓扑不同。

## 改动

- README / 部署 / 认证文档拆清两套入口
- `deploy/cas-revproxy/README.md` 补上可复制的本机启动步骤
- `env.example` 不再写死 dfy2 worktree 路径
- 只演示账密登录时允许空 `HTTPS_PROXY`（CAS 校验仍会失败）

没有把 cas-revproxy 接到 Compose 里，也没有改 `make dev` 的默认身份。日常改业务页面仍应走 `make dev`。
