### PR TITLE
feat(dev): make dev 在 ustc 模式下启动登录页

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,12 +35,33 @@ WORKSPACE107_SHARED_RESOURCE_PUBLICATION_INTERVAL_SECONDS=1.0
 WORKSPACE107_SHARED_RESOURCE_PUBLICATION_RECOVERY_SECONDS=300.0
 
 # ---------- Authentication ----------
-# dev trusts X-User only for local work; ustc consumes trusted revproxy identity headers.
-# make dev and Compose default to dev: the browser is already signed in as `student`
-# and will not show the public login page. The login UI is deploy/cas-revproxy
-# (AUTH_MODE=ustc, nginx with auth_request). See docs/operations/authentication.md.
-# Do not point Compose and cas-revproxy at 8107 at the same time.
-WORKSPACE107_AUTH_MODE=dev
+# ustc: make dev shows the public login page (auth process + Vite auth_request proxy).
+# dev: skip login; the browser is already signed in as `student`.
+# Compose web has no /login — keep AUTH_MODE=dev in the Compose root .env.
+# See docs/operations/authentication.md.
+WORKSPACE107_AUTH_MODE=ustc
+
+# Browser origin opened by `make dev`. Must match the URL in the address bar.
+WORKSPACE107_PUBLIC_ORIGIN=http://127.0.0.1:5174
+# Flask session signing key. Required when AUTH_MODE=ustc. Do not commit real values.
+WORKSPACE107_AUTH_SECRET_KEY=change-me
+# 0 for local HTTP; 1 when the public origin is HTTPS.
+WORKSPACE107_SESSION_COOKIE_SECURE=0
+# Outbound proxy for CAS serviceValidate. Empty is OK for password-only login.
+WORKSPACE107_HTTPS_PROXY=
+WORKSPACE107_CAS_LOGIN_URL=https://passport.ustc.edu.cn/login
+WORKSPACE107_CAS_VALIDATE_URL=https://passport.ustc.edu.cn/serviceValidate
+
+# Local password login. Only for trusted demo; do not commit a real password.
+WORKSPACE107_LOCAL_ADMIN_USERNAME=platform-admin
+WORKSPACE107_LOCAL_ADMIN_DISPLAY_NAME=平台管理员
+WORKSPACE107_LOCAL_ADMIN_PASSWORD=
+WORKSPACE107_LOCAL_ADMIN_PASSWORD_HASH=
+
+# make dev defaults. Override if 8000/5174/8108 are already taken.
+WORKSPACE107_BACKEND_ORIGIN=http://127.0.0.1:8000
+WORKSPACE107_AUTH_ORIGIN=http://127.0.0.1:8108
+WORKSPACE107_AUTH_PORT=8108
 
 # ---------- Docker Compose only ----------
 POSTGRES_DB=workspace107

--- a/README.md
+++ b/README.md
@@ -35,18 +35,21 @@ WSL2 的 Linux filesystem。原生 Windows / PowerShell runtime 不受支持，�
 
 ```bash
 ./scripts/platform/posix/bootstrap.sh
+cp .env.example backend/.env
+# 填写 WORKSPACE107_AUTH_SECRET_KEY 和 WORKSPACE107_LOCAL_ADMIN_PASSWORD
 make migrate
 make dev
 ```
 
 后端接口文档默认位于 <http://127.0.0.1:8000/docs>，前端默认位于
-<http://127.0.0.1:5174>。这条路径使用 `WORKSPACE107_AUTH_MODE=dev`：后端把缺省身份当成
-`student`，**不会出现登录页**。日常改业务页面用这条。
+<http://127.0.0.1:5174>。模板里 `WORKSPACE107_AUTH_MODE=ustc`：`make dev` 会再拉起认证服务，
+Vite 对 `/api` 做 `auth_request`，浏览器看到公开登录页（账密 + 统一身份认证）。
+账密和会话密钥都写在 `backend/.env`，不要提交。把 `WORKSPACE107_AUTH_MODE` 改成 `dev`
+则仍直接以 `student` 进入，没有登录页。
 
-要看公开登录页（账密 + 统一身份认证），不能用 `make dev`，也不能用下面 Compose 默认栈。
-那是另一套入口，见 [`deploy/cas-revproxy/README.md`](deploy/cas-revproxy/README.md)：
-Nginx 监听 `127.0.0.1:8107`，认证服务 `8108`，后端必须 `WORKSPACE107_AUTH_MODE=ustc`。
-它和 Compose 默认的 `:8107` **端口相同、拓扑不同**，不要同时占用。
+Compose 默认栈的 `:8107` 仍是 `dev`，没有登录页。独立 Nginx 入口见
+[`deploy/cas-revproxy/README.md`](deploy/cas-revproxy/README.md)，不要和 Compose 同时占用
+`:8107`。
 
 提交前运行统一检查：
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -95,7 +95,7 @@ cp ../.env.example .env
 | `WORKSPACE107_STORAGE_ROOT` | Project 文件、Run 目录、日志和 Artifact 的根目录 |
 | `WORKSPACE107_SCHEDULER` | `mock`（本机子进程真实执行）或 `slurm` |
 | `WORKSPACE107_SLURM_JWT` | **等价于密码**，只能从环境注入 |
-| `WORKSPACE107_AUTH_MODE` | `dev` 用 `X-User` 请求头识别用户，缺省 `student`，没有登录页；`ustc` 只接受反向代理注入的身份，见 [`docs/operations/authentication.md`](../docs/operations/authentication.md) |
+| `WORKSPACE107_AUTH_MODE` | `dev` 用 `X-User` 缺省 `student`；`ustc` 只接受代理注入的身份。`make dev` 在 `ustc` 时带登录页，字段见仓库 `.env.example` |
 
 ## 开发模式下的身份
 
@@ -109,7 +109,7 @@ curl -X POST -H 'X-User: student' -H 'Content-Type: application/json' \
   http://127.0.0.1:8000/api/v1/user-groups
 ```
 
-公开登录页不走这条 `dev` 路径，见 [`deploy/cas-revproxy/README.md`](../deploy/cas-revproxy/README.md)。
+公开登录页走 `make dev` + `AUTH_MODE=ustc`，字段见仓库 `.env.example`。
 
 ## 调度适配器
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -4,11 +4,10 @@
 [`docs/operations/deployment.md`](../docs/operations/deployment.md) 为准。
 
 当前包含 [`compose.yaml`](compose.yaml) 与 [`cas-revproxy/`](cas-revproxy/README.md)。
-Compose 用于本机开发和受信任演示，默认 `AUTH_MODE=dev`，`:8107` 没有登录页。
-CAS 反向代理（[`cas-revproxy/`](cas-revproxy/README.md)）才是带登录页的 `:8107`：
-后端 `AUTH_MODE=ustc`，Nginx `auth_request`，认证服务处理 `/login` 与
-`/login/password`。两套不要同时占用同一端口。它们不提供生产级 Secret 管理、自动备份、
-多副本编排或监控告警，因此不构成生产部署方案。
+Compose 用于本机容器演示，默认 `AUTH_MODE=dev`，`:8107` 没有登录页。
+本地带登录页用根目录 `make dev`（配置在 `.env` / `backend/.env`）。
+CAS 反向代理（[`cas-revproxy/`](cas-revproxy/README.md)）是独立 Nginx 入口。
+它们不提供生产级 Secret 管理、自动备份、多副本编排或监控告警，因此不构成生产部署方案。
 
 ## 目录边界
 

--- a/deploy/cas-revproxy/README.md
+++ b/deploy/cas-revproxy/README.md
@@ -5,15 +5,12 @@
 
 ## 和 README 默认启动的区别
 
-根目录 `make dev` 打开的是 Vite <http://127.0.0.1:5174>，后端默认
-`WORKSPACE107_AUTH_MODE=dev`，缺省身份是 `student`，**没有登录页**。
+根目录 `make dev` 在 `WORKSPACE107_AUTH_MODE=ustc` 时已经带公开登录页：Vite `:5174`
+加上认证服务，配置全部来自仓库 `.env` / `backend/.env`。本目录是同一套认证服务的
+Nginx 入口，给不能走 Vite 的联调使用。
 
-Compose 默认 `web` 容器也监听 `:8107`，但只反代 `/api`，同样是 `AUTH_MODE=dev`，
-打开即已登录。那不是本目录这套 Nginx。
-
-本目录才是带公开登录页的入口：Nginx `auth_request`、认证服务处理 `/login`、
-`/login/password`、`/logout`，后端必须 `WORKSPACE107_AUTH_MODE=ustc`。两套 `:8107`
-端口相同、拓扑不同，不要同时占用。
+Compose 默认 `web` 容器监听 `:8107`，只反代 `/api`，默认 `AUTH_MODE=dev`，没有登录页。
+两套 `:8107` 不要同时占用。
 
 当前联调拓扑（非 Docker）：
 

--- a/deploy/cas-revproxy/auth/auth_server.py
+++ b/deploy/cas-revproxy/auth/auth_server.py
@@ -22,11 +22,29 @@ CAS_NS = "{http://www.yale.edu/tp/cas}"
 WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
+_ENV_ALIASES = {
+    "SECRET_KEY": ("WORKSPACE107_AUTH_SECRET_KEY",),
+    "PUBLIC_ORIGIN": ("WORKSPACE107_PUBLIC_ORIGIN",),
+    "SESSION_COOKIE_SECURE": ("WORKSPACE107_SESSION_COOKIE_SECURE",),
+    "HTTPS_PROXY": ("WORKSPACE107_HTTPS_PROXY", "https_proxy"),
+    "CAS_LOGIN_URL": ("WORKSPACE107_CAS_LOGIN_URL",),
+    "CAS_VALIDATE_URL": ("WORKSPACE107_CAS_VALIDATE_URL",),
+    "LOCAL_ADMIN_USERNAME": ("WORKSPACE107_LOCAL_ADMIN_USERNAME",),
+    "LOCAL_ADMIN_DISPLAY_NAME": ("WORKSPACE107_LOCAL_ADMIN_DISPLAY_NAME",),
+    "LOCAL_ADMIN_PASSWORD": ("WORKSPACE107_LOCAL_ADMIN_PASSWORD",),
+    "LOCAL_ADMIN_PASSWORD_HASH": ("WORKSPACE107_LOCAL_ADMIN_PASSWORD_HASH",),
+}
+
+
 def _env(name: str, default: str | None = None) -> str:
-    value = os.environ.get(name, default)
-    if value is None or not str(value).strip():
-        raise RuntimeError(f"{name} is required")
-    return str(value).rstrip()
+    keys = (name, *_ENV_ALIASES.get(name, ()))
+    for key in keys:
+        value = os.environ.get(key)
+        if value is not None and str(value).strip():
+            return str(value).rstrip()
+    if default is not None:
+        return default
+    raise RuntimeError(f"{name} is required")
 
 
 def login_service_url(session_id: str) -> str:
@@ -89,11 +107,19 @@ def check_ticket(ticket: str, service: str) -> str | None:
 _DUMMY_PASSWORD_HASH = generate_password_hash("not-used")
 
 
+def _first_env(*names: str, default: str = "") -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return default
+
+
 def _local_password_hash() -> str:
-    configured = os.environ.get("LOCAL_ADMIN_PASSWORD_HASH", "").strip()
+    configured = _first_env("LOCAL_ADMIN_PASSWORD_HASH", "WORKSPACE107_LOCAL_ADMIN_PASSWORD_HASH")
     if configured:
         return configured
-    raw = os.environ.get("LOCAL_ADMIN_PASSWORD", "")
+    raw = _first_env("LOCAL_ADMIN_PASSWORD", "WORKSPACE107_LOCAL_ADMIN_PASSWORD")
     if raw:
         return generate_password_hash(raw)
     return ""
@@ -123,9 +149,15 @@ def create_app() -> Flask:
         PUBLIC_ORIGIN=_env("PUBLIC_ORIGIN"),
         CAS_LOGIN_URL=_env("CAS_LOGIN_URL", "https://passport.ustc.edu.cn/login"),
         CAS_VALIDATE_URL=_env("CAS_VALIDATE_URL", "https://passport.ustc.edu.cn/serviceValidate"),
-        HTTPS_PROXY=os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy") or "",
-        LOCAL_ADMIN_USERNAME=os.environ.get("LOCAL_ADMIN_USERNAME", "platform-admin").strip(),
-        LOCAL_ADMIN_DISPLAY_NAME=os.environ.get("LOCAL_ADMIN_DISPLAY_NAME", "平台管理员").strip(),
+        HTTPS_PROXY=_env("HTTPS_PROXY", ""),
+        LOCAL_ADMIN_USERNAME=_first_env(
+            "LOCAL_ADMIN_USERNAME", "WORKSPACE107_LOCAL_ADMIN_USERNAME", default="platform-admin"
+        ),
+        LOCAL_ADMIN_DISPLAY_NAME=_first_env(
+            "LOCAL_ADMIN_DISPLAY_NAME",
+            "WORKSPACE107_LOCAL_ADMIN_DISPLAY_NAME",
+            default="平台管理员",
+        ),
         LOCAL_ADMIN_PASSWORD_HASH=_local_password_hash(),
     )
 

--- a/deploy/cas-revproxy/env.example
+++ b/deploy/cas-revproxy/env.example
@@ -1,4 +1,8 @@
-# 浏览器访问入口。必须固定配置，不能从 Host / X-Forwarded-* 推导。
+# Optional overlay on top of repository `.env` / `backend/.env`.
+# Prefer WORKSPACE107_* fields in the repository .env.example.
+# This file is still used for nginx-only values such as FRONTEND_DIST.
+
+# 浏览器访问入口。Nginx 入口默认 8107；make dev 用 PUBLIC_ORIGIN=http://127.0.0.1:5174。
 PUBLIC_ORIGIN=http://127.0.0.1:8107
 
 # Flask 会话签名密钥，按部署单独生成，不要提交真实值。

--- a/deploy/cas-revproxy/scripts/load-env.sh
+++ b/deploy/cas-revproxy/scripts/load-env.sh
@@ -1,0 +1,33 @@
+# Shared by run-auth.sh / render-nginx.sh. Sourced, not executed.
+# Loads repository .env files first, then this directory's env overlay.
+
+CAS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$CAS_ROOT/../.." && pwd)"
+
+_load_env_file() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$file"
+    set +a
+  fi
+}
+
+_load_env_file "$REPO_ROOT/.env"
+_load_env_file "$REPO_ROOT/backend/.env"
+_load_env_file "$CAS_ROOT/env"
+
+export SECRET_KEY="${SECRET_KEY:-${WORKSPACE107_AUTH_SECRET_KEY:-}}"
+export PUBLIC_ORIGIN="${PUBLIC_ORIGIN:-${WORKSPACE107_PUBLIC_ORIGIN:-http://127.0.0.1:5174}}"
+export SESSION_COOKIE_SECURE="${SESSION_COOKIE_SECURE:-${WORKSPACE107_SESSION_COOKIE_SECURE:-0}}"
+export HTTPS_PROXY="${HTTPS_PROXY:-${WORKSPACE107_HTTPS_PROXY:-}}"
+export CAS_LOGIN_URL="${CAS_LOGIN_URL:-${WORKSPACE107_CAS_LOGIN_URL:-https://passport.ustc.edu.cn/login}}"
+export CAS_VALIDATE_URL="${CAS_VALIDATE_URL:-${WORKSPACE107_CAS_VALIDATE_URL:-https://passport.ustc.edu.cn/serviceValidate}}"
+export LOCAL_ADMIN_USERNAME="${LOCAL_ADMIN_USERNAME:-${WORKSPACE107_LOCAL_ADMIN_USERNAME:-platform-admin}}"
+export LOCAL_ADMIN_DISPLAY_NAME="${LOCAL_ADMIN_DISPLAY_NAME:-${WORKSPACE107_LOCAL_ADMIN_DISPLAY_NAME:-平台管理员}}"
+export LOCAL_ADMIN_PASSWORD="${LOCAL_ADMIN_PASSWORD:-${WORKSPACE107_LOCAL_ADMIN_PASSWORD:-}}"
+export LOCAL_ADMIN_PASSWORD_HASH="${LOCAL_ADMIN_PASSWORD_HASH:-${WORKSPACE107_LOCAL_ADMIN_PASSWORD_HASH:-}}"
+export BACKEND_ORIGIN="${BACKEND_ORIGIN:-${WORKSPACE107_BACKEND_ORIGIN:-http://127.0.0.1:8000}}"
+export AUTH_ORIGIN="${AUTH_ORIGIN:-${WORKSPACE107_AUTH_ORIGIN:-http://127.0.0.1:8108}}"
+export NGINX_LISTEN="${NGINX_LISTEN:-127.0.0.1:8107}"

--- a/deploy/cas-revproxy/scripts/render-nginx.sh
+++ b/deploy/cas-revproxy/scripts/render-nginx.sh
@@ -4,15 +4,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-if [[ ! -f "$ROOT/env" ]]; then
-  echo "missing $ROOT/env; copy env.example and fill values" >&2
+# shellcheck disable=SC1091
+source "$ROOT/scripts/load-env.sh"
+
+if [[ -z "${FRONTEND_DIST:-}" ]]; then
+  echo "FRONTEND_DIST is required for nginx (set it in deploy/cas-revproxy/env)" >&2
   exit 1
 fi
-
-set -a
-# shellcheck disable=SC1091
-source "$ROOT/env"
-set +a
 
 mkdir -p "$ROOT/runtime/logs" "$ROOT/runtime/temp" "$ROOT/runtime/conf"
 envsubst '${NGINX_LISTEN} ${FRONTEND_DIST} ${AUTH_ORIGIN} ${BACKEND_ORIGIN}' \

--- a/deploy/cas-revproxy/scripts/run-auth.sh
+++ b/deploy/cas-revproxy/scripts/run-auth.sh
@@ -4,15 +4,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-if [[ ! -f "$ROOT/env" ]]; then
-  echo "missing $ROOT/env; copy env.example and fill SECRET_KEY" >&2
+# shellcheck disable=SC1091
+source "$ROOT/scripts/load-env.sh"
+
+if [[ -z "${SECRET_KEY:-}" ]]; then
+  echo "SECRET_KEY or WORKSPACE107_AUTH_SECRET_KEY is required (set it in backend/.env)" >&2
   exit 1
 fi
-
-set -a
-# shellcheck disable=SC1091
-source "$ROOT/env"
-set +a
 
 if [[ -z "${HTTPS_PROXY:-}" ]]; then
   echo "warning: HTTPS_PROXY is empty; CAS serviceValidate will fail. Password login still works." >&2

--- a/deploy/cas-revproxy/tests/test_auth_server.py
+++ b/deploy/cas-revproxy/tests/test_auth_server.py
@@ -172,6 +172,28 @@ def test_password_login_ascii_display_name_is_forwarded(monkeypatch):
     assert auth.headers["X-User-Name"] == "Platform Admin"
 
 
+def test_workspace107_prefixed_env_is_accepted(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("PUBLIC_ORIGIN", raising=False)
+    monkeypatch.delenv("LOCAL_ADMIN_PASSWORD", raising=False)
+    monkeypatch.setenv("WORKSPACE107_AUTH_SECRET_KEY", "prefixed-secret")
+    monkeypatch.setenv("WORKSPACE107_PUBLIC_ORIGIN", "http://127.0.0.1:5174")
+    monkeypatch.setenv("WORKSPACE107_LOCAL_ADMIN_PASSWORD", "s3cret")
+    application = create_app()
+    client = application.test_client()
+    response = client.post(
+        "/login/password",
+        data={"username": "platform-admin", "password": "s3cret"},
+        headers={"Origin": "http://127.0.0.1:5174"},
+    )
+    assert response.status_code == 303
+    assert response.headers["Location"] == "http://127.0.0.1:5174/"
+    auth = client.get("/auth")
+    assert auth.status_code == 200
+    assert auth.headers["X-User-ID"] == "platform-admin"
+    assert auth.headers["X-User-Provider"] == "local"
+
+
 def test_password_login_failure_does_not_create_session(monkeypatch):
     monkeypatch.setenv("LOCAL_ADMIN_PASSWORD", "s3cret")
     application = create_app()

--- a/docs/operations/authentication.md
+++ b/docs/operations/authentication.md
@@ -19,15 +19,14 @@ WORKSPACE107_AUTH_MODE=dev uv run uvicorn workspace107.main:create_app --factory
 curl -H 'X-User: alice' http://127.0.0.1:8000/api/v1/me
 ```
 
-`make dev` 和 Compose 默认走这条 `dev` 模式，前端一打开就会拿到当前用户，因此看不到
-公开登录页。要在浏览器里看到账密 / 统一身份认证入口，必须同时满足：
+`make dev` 读取仓库根目录 `.env` 和 `backend/.env`。`WORKSPACE107_AUTH_MODE=ustc` 时会
+同时启动认证服务，Vite 对 `/login`、`/login/password`、`/logout` 和 `/api/` 做与 Nginx
+`auth_request` 相同的分流，浏览器打开 <http://127.0.0.1:5174> 就是公开登录页。
+账密、会话密钥、CAS 代理都使用 `.env.example` 里的 `WORKSPACE107_*` 字段。
 
-1. 后端 `WORKSPACE107_AUTH_MODE=ustc`（没有代理注入的身份时 `/api/v1/me` 返回 401）；
-2. 用 [`deploy/cas-revproxy/`](../../deploy/cas-revproxy/README.md) 的 Nginx 做入口
-   （`/login`、`POST /login/password`、`POST /logout` 和 `/api/` 的 `auth_request`）。
-
-只改 `AUTH_MODE=ustc`、仍用 Vite `:5174` 或 Compose `web` 容器，登录按钮没有对应代理路由，
-不能当成登录演示。
+`WORKSPACE107_AUTH_MODE=dev` 时仍直接以 `student` 进入。Compose 默认 `web` 容器没有这些
+路由，应保持 `AUTH_MODE=dev`。独立 Nginx 入口见
+[`deploy/cas-revproxy/`](../../deploy/cas-revproxy/README.md)。
 
 ## revproxy 与 Backend 的字段约定
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -13,10 +13,10 @@ cp .env.example .env
 docker compose --project-directory . --file deploy/compose.yaml up -d --build
 ```
 
-打开 <http://127.0.0.1:8107>。默认 `WORKSPACE107_AUTH_MODE=dev`，Web 容器只反代 `/api`，
-没有 `/login` 或账密登录；浏览器会直接进入已登录控制台。要公开登录页，改用
-[`deploy/cas-revproxy/README.md`](../../deploy/cas-revproxy/README.md)，不要与本 Compose
-栈同时占用 `:8107`。
+打开 <http://127.0.0.1:8107>。Compose 默认 `WORKSPACE107_AUTH_MODE=dev`，Web 容器只反代
+`/api`，没有登录页。本地带登录页请用 `make dev`（`backend/.env` 里 `AUTH_MODE=ustc`）。
+独立 Nginx 入口见 [`deploy/cas-revproxy/README.md`](../../deploy/cas-revproxy/README.md)，
+不要与本 Compose 栈同时占用 `:8107`。
 
 停止服务但保留数据：
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -148,10 +148,9 @@ Run 未结束时每 2 秒轮询一次：先触发后端状态同步，再读取 
 登录由反向代理的 `GET /login` 与 `POST /login/password` 处理，前端只做整页跳转和同源表单。
 退出通过同源 `POST /logout` 表单提交。
 
-`make dev` 走后端 `dev` 模式，一打开就是 `student`，看不到未登录首页。
-正常客户端不发送 `X-User` 或 `X-User-ID`。反向代理接入见
-[`docs/operations/authentication.md`](../docs/operations/authentication.md)
-与 [`deploy/cas-revproxy/README.md`](../deploy/cas-revproxy/README.md)。
+`make dev` 在 `WORKSPACE107_AUTH_MODE=ustc` 时由 Vite 代理 `/login` 与 `/api` 的
+`auth_request`，打开即是未登录首页。`AUTH_MODE=dev` 时仍直接以 `student` 进入。
+正常客户端不发送 `X-User` 或 `X-User-ID`。配置字段见仓库 `.env.example`。
 
 ## 检查
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,6 +8,13 @@ export default tseslint.config(
   // schema.d.ts 是生成物，不参与 lint
   { ignores: ['dist', 'coverage', 'node_modules', 'src/api/schema.d.ts'] },
   {
+    files: ['vite.config.ts', 'vite.auth-proxy.ts'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+    },
+  },
+  {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "@eslint/js": "^9.18.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -62,7 +65,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@10.2.2)(vite@6.4.3)
+        version: 4.7.0(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3))
       eslint:
         specifier: ^9.18.0
         version: 9.39.5(supports-color@10.2.2)
@@ -92,10 +95,10 @@ importers:
         version: 8.65.0(eslint@9.39.5(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       vite:
         specifier: ^6.0.0
-        version: 6.4.3
+        version: 6.4.3(@types/node@24.13.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.7(jsdom@26.1.0(supports-color@10.2.2))(supports-color@10.2.2)
+        version: 3.2.7(@types/node@24.13.3)(jsdom@26.1.0(supports-color@10.2.2))(supports-color@10.2.2)
 
 packages:
 
@@ -822,6 +825,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
@@ -2013,6 +2019,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2848,6 +2857,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/prismjs@1.26.6': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
@@ -2949,7 +2962,7 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@6.4.3)':
+  '@vitejs/plugin-react@4.7.0(supports-color@10.2.2)(vite@6.4.3(@types/node@24.13.3))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
@@ -2957,7 +2970,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.3
+      vite: 6.4.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2969,13 +2982,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@6.4.3)':
+  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@24.13.3))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.3
+      vite: 6.4.3(@types/node@24.13.3)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -4159,6 +4172,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.18.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
       browserslist: 4.28.7
@@ -4171,13 +4186,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(supports-color@10.2.2):
+  vite-node@3.2.4(@types/node@24.13.3)(supports-color@10.2.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.3
+      vite: 6.4.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4192,7 +4207,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.3:
+  vite@6.4.3(@types/node@24.13.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
@@ -4201,13 +4216,14 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 24.13.3
       fsevents: 2.3.3
 
-  vitest@3.2.7(jsdom@26.1.0(supports-color@10.2.2))(supports-color@10.2.2):
+  vitest@3.2.7(@types/node@24.13.3)(jsdom@26.1.0(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.4.3)
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@24.13.3))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -4225,10 +4241,11 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.3
-      vite-node: 3.2.4(supports-color@10.2.2)
+      vite: 6.4.3(@types/node@24.13.3)
+      vite-node: 3.2.4(@types/node@24.13.3)(supports-color@10.2.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 24.13.3
       jsdom: 26.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - jiti

--- a/frontend/tests/unit/auth-proxy.test.ts
+++ b/frontend/tests/unit/auth-proxy.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  FORBIDDEN_API_BODY,
+  UNAUTHORIZED_API_BODY,
+  isAuthRoute,
+  isBackendApiRoute,
+  requestPath,
+} from '../../vite.auth-proxy'
+
+describe('dev auth proxy routes', () => {
+  it('classifies login and logout as auth routes', () => {
+    expect(isAuthRoute('/login')).toBe(true)
+    expect(isAuthRoute('/login?id=abc')).toBe(true)
+    expect(isAuthRoute('/login/password')).toBe(true)
+    expect(isAuthRoute('/logout')).toBe(true)
+    expect(isAuthRoute('/api/v1/me')).toBe(false)
+    expect(isAuthRoute('/')).toBe(false)
+  })
+
+  it('classifies /api as backend routes that need auth_request', () => {
+    expect(isBackendApiRoute('/api/v1/me')).toBe(true)
+    expect(isBackendApiRoute('/api/v1/me?x=1')).toBe(true)
+    expect(isBackendApiRoute('/login')).toBe(false)
+    expect(isBackendApiRoute('/src/main.tsx')).toBe(false)
+  })
+
+  it('strips the query string when reading the path', () => {
+    expect(requestPath('/login/password?x=1')).toBe('/login/password')
+  })
+
+  it('returns the same unauthenticated JSON as nginx auth_request', () => {
+    expect(JSON.parse(UNAUTHORIZED_API_BODY)).toMatchObject({
+      code: 'authentication_required',
+    })
+    expect(JSON.parse(FORBIDDEN_API_BODY)).toMatchObject({
+      code: 'permission_denied',
+    })
+  })
+})

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom", "node"],
 
     "strict": true,
     "noUnusedLocals": true,
@@ -21,5 +21,5 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["src", "tests", "vite.config.ts", "eslint.config.js"]
+  "include": ["src", "tests", "vite.config.ts", "vite.auth-proxy.ts", "eslint.config.js"]
 }

--- a/frontend/vite.auth-proxy.ts
+++ b/frontend/vite.auth-proxy.ts
@@ -1,0 +1,180 @@
+import http from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Plugin } from 'vite'
+
+export const UNAUTHORIZED_API_BODY =
+  '{"code":"authentication_required","message":"需要登录。","problems":[],"request_id":""}'
+export const FORBIDDEN_API_BODY =
+  '{"code":"permission_denied","message":"请求来源不被允许。","problems":[],"request_id":""}'
+
+const IDENTITY_HEADERS = ['x-user', 'x-user-id', 'x-user-provider', 'x-user-name', 'x-user-email']
+
+export function requestPath(url: string | undefined): string {
+  return (url ?? '/').split('?')[0] ?? '/'
+}
+
+export function isAuthRoute(url: string | undefined): boolean {
+  const path = requestPath(url)
+  return path === '/login' || path === '/login/password' || path === '/logout'
+}
+
+export function isBackendApiRoute(url: string | undefined): boolean {
+  const path = requestPath(url)
+  return path === '/api' || path.startsWith('/api/')
+}
+
+function jsonResponse(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'cache-control': 'no-store',
+  })
+  res.end(body)
+}
+
+function authOrigin(): string {
+  return process.env.WORKSPACE107_AUTH_ORIGIN ?? 'http://127.0.0.1:8108'
+}
+
+function backendOrigin(): string {
+  return process.env.WORKSPACE107_BACKEND_ORIGIN ?? 'http://127.0.0.1:8000'
+}
+
+function stripIdentityHeaders(headers: http.OutgoingHttpHeaders): http.OutgoingHttpHeaders {
+  const next: http.OutgoingHttpHeaders = { ...headers }
+  for (const name of IDENTITY_HEADERS) {
+    delete next[name]
+  }
+  return next
+}
+
+function pipeProxy(
+  req: IncomingMessage,
+  res: ServerResponse,
+  targetOrigin: string,
+  extraHeaders: http.OutgoingHttpHeaders = {},
+): void {
+  const target = new URL(req.url ?? '/', targetOrigin)
+  // Strip client identity first, then apply proxy-injected headers.
+  const headers = {
+    ...stripIdentityHeaders({ ...req.headers, host: target.host }),
+    ...extraHeaders,
+  }
+  const upstream = http.request(
+    {
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      method: req.method,
+      headers,
+    },
+    (response) => {
+      res.writeHead(response.statusCode ?? 502, response.headers)
+      response.pipe(res)
+    },
+  )
+  upstream.on('error', () => {
+    if (!res.headersSent) {
+      res.writeHead(502, { 'content-type': 'text/plain', 'cache-control': 'no-store' })
+    }
+    res.end('bad gateway')
+  })
+  req.pipe(upstream)
+}
+
+function authSubrequest(
+  req: IncomingMessage,
+  origin: string,
+): Promise<{ status: number; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const target = new URL('/auth', origin)
+    const upstream = http.request(
+      {
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port: target.port,
+        path: target.pathname,
+        method: 'GET',
+        headers: {
+          host: target.host,
+          cookie: req.headers.cookie ?? '',
+          'x-original-method': req.method,
+          origin: req.headers.origin ?? '',
+          referer: req.headers.referer ?? '',
+        },
+      },
+      (response) => {
+        response.resume()
+        resolve({ status: response.statusCode ?? 502, headers: response.headers })
+      },
+    )
+    upstream.on('error', reject)
+    upstream.end()
+  })
+}
+
+async function handleDevAuthProxy(
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: () => void,
+): Promise<void> {
+  if (isAuthRoute(req.url)) {
+    pipeProxy(req, res, authOrigin())
+    return
+  }
+  if (!isBackendApiRoute(req.url)) {
+    next()
+    return
+  }
+  let auth: { status: number; headers: http.IncomingHttpHeaders }
+  try {
+    auth = await authSubrequest(req, authOrigin())
+  } catch {
+    if (!res.headersSent) {
+      res.writeHead(502, { 'content-type': 'text/plain', 'cache-control': 'no-store' })
+    }
+    res.end('auth gateway unavailable')
+    return
+  }
+  if (auth.status === 401) {
+    jsonResponse(res, 401, UNAUTHORIZED_API_BODY)
+    return
+  }
+  if (auth.status === 403) {
+    jsonResponse(res, 403, FORBIDDEN_API_BODY)
+    return
+  }
+  if (auth.status >= 400) {
+    jsonResponse(
+      res,
+      502,
+      '{"code":"bad_gateway","message":"认证服务不可用。","problems":[],"request_id":""}',
+    )
+    return
+  }
+  pipeProxy(req, res, backendOrigin(), {
+    'x-user': '',
+    'x-user-id': headerValue(auth.headers['x-user-id']),
+    'x-user-provider': headerValue(auth.headers['x-user-provider']),
+    'x-user-name': headerValue(auth.headers['x-user-name']),
+    'x-user-email': '',
+  })
+}
+
+function headerValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? ''
+  }
+  return value ?? ''
+}
+
+export function authRequestProxy(): Plugin {
+  return {
+    name: 'workspace107-auth-request-proxy',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        void handleDevAuthProxy(req, res, next).catch(next)
+      })
+    },
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,20 +1,33 @@
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
+import { authRequestProxy } from './vite.auth-proxy'
+
+const authMode = process.env.WORKSPACE107_AUTH_MODE ?? 'dev'
+const loginStack = authMode === 'ustc'
+const backendOrigin = process.env.WORKSPACE107_BACKEND_ORIGIN ?? 'http://127.0.0.1:8000'
+const frontendPort = Number(
+  process.env.WORKSPACE107_DEV_FRONTEND_PORT ??
+    new URL(process.env.WORKSPACE107_PUBLIC_ORIGIN ?? 'http://127.0.0.1:5174').port,
+)
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), loginStack ? authRequestProxy() : null],
   ssr: {
     noExternal: ['@primer/react'],
   },
   server: {
-    port: 5174,
-    // 开发时把 /api 转发到后端，避免前端代码里出现硬编码地址。
-    proxy: {
-      '/api': {
-        target: 'http://127.0.0.1:8000',
-        changeOrigin: true,
-      },
-    },
+    port: frontendPort || 5174,
+    strictPort: true,
+    // AUTH_MODE=dev: 直接把 /api 转到后端。ustc 由 vite.auth-proxy 做 auth_request。
+    proxy: loginStack
+      ? undefined
+      : {
+          '/api': {
+            target: backendOrigin,
+            changeOrigin: true,
+          },
+        },
   },
   test: {
     environment: 'node',

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,7 +14,7 @@ esbuild 必需的安装脚本。
 setup                  按锁文件安装前后端依赖
 check [target]         运行格式、lint、类型、测试、构建和契约检查
 contract sync|check    重新生成或核对 OpenAPI 与前端类型
-dev                    启动前后端开发服务（AUTH_MODE=dev，无登录页）
+dev                    启动前后端；AUTH_MODE=ustc 时带登录页
 demo / smoke           验证隔离的 Project 到 Artifact 工作流
 migrate / migrate-down 升级或回退一个数据库版本
 coverage               生成后端覆盖率报告（重构期不设全仓门槛）
@@ -23,8 +23,8 @@ doctor                 检查本地工程基线
 ```
 
 `target` 可以是 `all`、`backend`、`frontend`；`check` 还支持 `contract`。
-`dev` 默认 `WORKSPACE107_AUTH_MODE=dev`，浏览器不会出现登录页。公开登录页见
-[`deploy/cas-revproxy/README.md`](../deploy/cas-revproxy/README.md)。
+`dev` 读取 `.env` / `backend/.env`。`WORKSPACE107_AUTH_MODE=ustc` 时启动认证服务并显示
+公开登录页；`dev` 模式仍直接以 `student` 进入。
 
 任务实现按职责分层：
 

--- a/scripts/tasks/dotenv_file.py
+++ b/scripts/tasks/dotenv_file.py
@@ -1,0 +1,65 @@
+"""Load repository .env files for local workflow commands."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .common import BACKEND_ROOT, REPO_ROOT
+
+# Flask / cas-revproxy names <- WORKSPACE107_* names in .env.example.
+AUTH_ENV_ALIASES: tuple[tuple[str, str], ...] = (
+    ("SECRET_KEY", "WORKSPACE107_AUTH_SECRET_KEY"),
+    ("PUBLIC_ORIGIN", "WORKSPACE107_PUBLIC_ORIGIN"),
+    ("SESSION_COOKIE_SECURE", "WORKSPACE107_SESSION_COOKIE_SECURE"),
+    ("HTTPS_PROXY", "WORKSPACE107_HTTPS_PROXY"),
+    ("CAS_LOGIN_URL", "WORKSPACE107_CAS_LOGIN_URL"),
+    ("CAS_VALIDATE_URL", "WORKSPACE107_CAS_VALIDATE_URL"),
+    ("LOCAL_ADMIN_USERNAME", "WORKSPACE107_LOCAL_ADMIN_USERNAME"),
+    ("LOCAL_ADMIN_DISPLAY_NAME", "WORKSPACE107_LOCAL_ADMIN_DISPLAY_NAME"),
+    ("LOCAL_ADMIN_PASSWORD", "WORKSPACE107_LOCAL_ADMIN_PASSWORD"),
+    ("LOCAL_ADMIN_PASSWORD_HASH", "WORKSPACE107_LOCAL_ADMIN_PASSWORD_HASH"),
+)
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def load_local_env_files() -> dict[str, str]:
+    """Apply root `.env` then `backend/.env`. Existing process env wins."""
+
+    loaded: dict[str, str] = {}
+    for path in (REPO_ROOT / ".env", BACKEND_ROOT / ".env"):
+        if path.is_file():
+            loaded.update(parse_env_file(path))
+    for key, value in loaded.items():
+        os.environ.setdefault(key, value)
+    return loaded
+
+
+def apply_auth_env_aliases(environment: dict[str, str]) -> dict[str, str]:
+    """Fill Flask/cas-revproxy names from WORKSPACE107_* when the short name is empty."""
+
+    merged = dict(environment)
+    for short_name, prefixed in AUTH_ENV_ALIASES:
+        if not merged.get(short_name) and merged.get(prefixed):
+            merged[short_name] = merged[prefixed]
+    if not merged.get("HTTPS_PROXY") and merged.get("https_proxy"):
+        merged["HTTPS_PROXY"] = merged["https_proxy"]
+    return merged

--- a/scripts/tasks/project.py
+++ b/scripts/tasks/project.py
@@ -14,6 +14,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any, cast
+from urllib.parse import urlparse
 
 from .common import (
     BACKEND_ROOT,
@@ -34,6 +35,7 @@ from .common import (
     resolve_executable,
     run,
 )
+from .dotenv_file import apply_auth_env_aliases, load_local_env_files
 
 TERMINAL_RUN_STATUSES = {"succeeded", "failed", "cancelled", "submit_failed"}
 DEMO_USER_GROUP_ID = "grp_demo"
@@ -76,14 +78,69 @@ def _backend_python_executable() -> str:
     return executable
 
 
+AUTH_ROOT = REPO_ROOT / "deploy" / "cas-revproxy"
+
+
+def _auth_mode() -> str:
+    return os.environ.get("WORKSPACE107_AUTH_MODE", "dev").strip() or "dev"
+
+
+def _backend_port() -> str:
+    origin = os.environ.get("WORKSPACE107_BACKEND_ORIGIN", "http://127.0.0.1:8000")
+    return urlparse(origin).port or 8000
+
+
+def _frontend_port() -> str:
+    origin = os.environ.get("WORKSPACE107_PUBLIC_ORIGIN", "http://127.0.0.1:5174")
+    return str(urlparse(origin).port or 5174)
+
+
+def _auth_port() -> str:
+    configured = os.environ.get("WORKSPACE107_AUTH_PORT", "").strip()
+    if configured:
+        return configured
+    origin = os.environ.get("WORKSPACE107_AUTH_ORIGIN", "http://127.0.0.1:8108")
+    return str(urlparse(origin).port or 8108)
+
+
+def _prepare_dev_environment() -> dict[str, str]:
+    load_local_env_files()
+    environment = apply_auth_env_aliases(os.environ.copy())
+    if _auth_mode() != "ustc":
+        return environment
+    environment.setdefault("WORKSPACE107_PUBLIC_ORIGIN", "http://127.0.0.1:5174")
+    environment.setdefault("PUBLIC_ORIGIN", environment["WORKSPACE107_PUBLIC_ORIGIN"])
+    environment.setdefault("WORKSPACE107_BACKEND_ORIGIN", "http://127.0.0.1:8000")
+    environment.setdefault("BACKEND_ORIGIN", environment["WORKSPACE107_BACKEND_ORIGIN"])
+    environment.setdefault("WORKSPACE107_AUTH_ORIGIN", f"http://127.0.0.1:{_auth_port()}")
+    environment.setdefault("AUTH_ORIGIN", environment["WORKSPACE107_AUTH_ORIGIN"])
+    environment.setdefault("SESSION_COOKIE_SECURE", "0")
+    if not environment.get("SECRET_KEY"):
+        raise TaskError(
+            "WORKSPACE107_AUTH_MODE=ustc requires WORKSPACE107_AUTH_SECRET_KEY "
+            "(copy .env.example to backend/.env and set a random value)"
+        )
+    if not environment.get("LOCAL_ADMIN_PASSWORD") and not environment.get(
+        "LOCAL_ADMIN_PASSWORD_HASH"
+    ):
+        print(
+            "warning: WORKSPACE107_LOCAL_ADMIN_PASSWORD is empty; password login is disabled",
+            flush=True,
+        )
+    os.environ.update(environment)
+    return environment
+
+
 def run_dev(component: str = "all") -> None:
     heading(f"Development server ({component})")
+    environment = _prepare_dev_environment()
+    login_stack = _auth_mode() == "ustc"
     if component in {"all", "backend"}:
         ensure_backend_dependencies(quiet=True)
     if component in {"all", "frontend"}:
         ensure_frontend_dependencies(quiet=True)
 
-    commands: list[tuple[list[str], Path]] = []
+    commands: list[tuple[list[str], Path, dict[str, str] | None]] = []
     if component in {"all", "backend"}:
         commands.append(
             (
@@ -97,24 +154,68 @@ def run_dev(component: str = "all") -> None:
                     "--host",
                     "127.0.0.1",
                     "--port",
-                    "8000",
+                    str(_backend_port()),
                 ],
                 BACKEND_ROOT,
+                environment,
+            )
+        )
+    if login_stack and component in {"all", "frontend"}:
+        auth_env = dict(environment)
+        auth_env["PYTHONPATH"] = str(AUTH_ROOT)
+        commands.append(
+            (
+                [
+                    resolve_executable("uv"),
+                    "run",
+                    "--no-project",
+                    "--with",
+                    "flask>=3,<4",
+                    "flask",
+                    "--app",
+                    "auth.auth_server:create_app",
+                    "run",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    _auth_port(),
+                ],
+                AUTH_ROOT,
+                auth_env,
             )
         )
     if component in {"all", "frontend"}:
         commands.append(
             (
-                [resolve_executable("pnpm"), "run", "dev", "--", "--host", "127.0.0.1"],
+                [
+                    resolve_executable("pnpm"),
+                    "run",
+                    "dev",
+                    "--",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    _frontend_port(),
+                    "--strictPort",
+                ],
                 FRONTEND_ROOT,
+                environment,
             )
         )
 
+    if login_stack:
+        print(
+            f"Login UI: {environment.get('PUBLIC_ORIGIN', 'http://127.0.0.1:5174')}/",
+            flush=True,
+        )
+    else:
+        print("Frontend: http://127.0.0.1:5174/ (AUTH_MODE=dev, no login page)", flush=True)
+
     processes: list[subprocess.Popen[str]] = []
     try:
-        for command, cwd in commands:
+        for command, cwd, env in commands:
             print(f"$ {command_text(command)}", flush=True)
-            processes.append(subprocess.Popen(command, cwd=cwd, text=True))
+            processes.append(subprocess.Popen(command, cwd=cwd, env=env, text=True))
         while processes:
             for process in processes:
                 return_code = process.poll()

--- a/scripts/tests/test_dev_login.py
+++ b/scripts/tests/test_dev_login.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_ROOT))
+
+from tasks import project  # noqa: E402
+from tasks.common import TaskError  # noqa: E402
+from tasks.dotenv_file import apply_auth_env_aliases, parse_env_file  # noqa: E402
+
+
+class DotenvFileTests(unittest.TestCase):
+    def test_parse_env_file_strips_quotes_and_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / ".env"
+            path.write_text(
+                "# comment\n"
+                "export WORKSPACE107_AUTH_MODE=ustc\n"
+                "WORKSPACE107_AUTH_SECRET_KEY='s3cret'\n"
+                "EMPTY=\n",
+                encoding="utf-8",
+            )
+            values = parse_env_file(path)
+
+        self.assertEqual(values["WORKSPACE107_AUTH_MODE"], "ustc")
+        self.assertEqual(values["WORKSPACE107_AUTH_SECRET_KEY"], "s3cret")
+        self.assertEqual(values["EMPTY"], "")
+
+    def test_apply_auth_env_aliases_fills_flask_names(self) -> None:
+        merged = apply_auth_env_aliases(
+            {
+                "WORKSPACE107_AUTH_SECRET_KEY": "from-prefix",
+                "WORKSPACE107_PUBLIC_ORIGIN": "http://127.0.0.1:5174",
+            }
+        )
+        self.assertEqual(merged["SECRET_KEY"], "from-prefix")
+        self.assertEqual(merged["PUBLIC_ORIGIN"], "http://127.0.0.1:5174")
+
+
+class DevLoginStackTests(unittest.TestCase):
+    def test_ustc_without_secret_fails(self) -> None:
+        env = {"WORKSPACE107_AUTH_MODE": "ustc", "PATH": os.environ.get("PATH", "")}
+        with (
+            mock.patch.object(project, "load_local_env_files", return_value={}),
+            mock.patch.dict(os.environ, env, clear=True),
+            self.assertRaisesRegex(TaskError, "AUTH_SECRET_KEY"),
+        ):
+            project._prepare_dev_environment()
+
+    def test_ustc_starts_auth_backend_and_vite(self) -> None:
+        env = {
+            "WORKSPACE107_AUTH_MODE": "ustc",
+            "SECRET_KEY": "test-secret",
+            "PUBLIC_ORIGIN": "http://127.0.0.1:5174",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        process = mock.Mock()
+        process.poll.return_value = 0
+        with (
+            mock.patch.object(project, "load_local_env_files", return_value={}),
+            mock.patch.object(project, "ensure_backend_dependencies"),
+            mock.patch.object(project, "ensure_frontend_dependencies"),
+            mock.patch.object(project, "_backend_python_executable", return_value="/py"),
+            mock.patch.object(project, "resolve_executable", side_effect=lambda name: name),
+            mock.patch.dict(os.environ, env, clear=True),
+            mock.patch("subprocess.Popen", return_value=process) as popen,
+        ):
+            project.run_dev("all")
+
+        commands = [call.args[0] for call in popen.call_args_list]
+        self.assertEqual(len(commands), 3)
+        self.assertIn("uvicorn", commands[0])
+        self.assertIn("flask", commands[1])
+        self.assertEqual(commands[2][:2], ["pnpm", "run"])
+        self.assertIn("auth.auth_server:create_app", commands[1])


### PR DESCRIPTION
## 改动

`make dev` 读取仓库 `.env` / `backend/.env`。`WORKSPACE107_AUTH_MODE=ustc`（`.env.example` 默认）时会同时启动认证服务，Vite 对 `/login`、`/login/password`、`/logout` 和 `/api` 做与 Nginx `auth_request` 相同的分流，打开 http://127.0.0.1:5174 就是公开登录页。

账密、会话密钥、CAS 代理都使用 `.env.example` 里的 `WORKSPACE107_*` 字段，不再依赖 `deploy/cas-revproxy/env` 才能跑登录。

`WORKSPACE107_AUTH_MODE=dev` 仍直接以 student 进入。Compose 默认 web 容器没有这些路由，继续保持 `dev`。

## 用法

```bash
cp .env.example backend/.env
# 填写 WORKSPACE107_AUTH_SECRET_KEY 和 WORKSPACE107_LOCAL_ADMIN_PASSWORD
make migrate
make dev
```

## 非目标

- 没有把 cas-revproxy 接到 Compose
- 没有改 CAS 协议进前端
- 学校 CAS 真实闭环仍需要已登记的 HTTPS 回调
