### PR TITLE
docs(readme): 让快速开始在裸机自足并修复 dev/demo 启动缺陷

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,30 +28,77 @@ Slurm 环境仍需要按现行 Milestone 验证或实现。
 
 ## 快速开始
 
-需要 Python 3.12、[uv](https://docs.astral.sh/uv/)、Node.js 24 LTS、pnpm 11 和 GNU Make。
+只读 README 即可从零跑通。先满足环境前提，再按你要的形态二选一：
+**本地开发**（`make dev`，源码热载）或 **容器**（Docker Compose，一体化演示）。
+
+### 环境前提
+
+| 工具 | 版本 | 用途 |
+| :--- | :--- | :--- |
+| Python | 3.12 | 后端与脚本 |
+| [uv](https://docs.astral.sh/uv/) | 任意近期版 | Python 依赖与环境 |
+| Node.js | 24 LTS | 前端构建 |
+| pnpm | 11 | 前端依赖 |
+| GNU Make | 任意 | 任务入口 |
+| Docker + Compose 插件 | 任意 | 仅容器形态需要 |
+
 支持 Linux 开发环境；Windows 主机只支持在 WSL2 中使用 Linux toolchain，并将仓库放在
 WSL2 的 Linux filesystem。原生 Windows / PowerShell runtime 不受支持，部署与运行目标
 均为 Linux。
 
+### 方式一：本地开发（`make dev`）
+
 ```bash
-./scripts/platform/posix/bootstrap.sh
-cp .env.example backend/.env
-# 填写 WORKSPACE107_AUTH_SECRET_KEY 和 WORKSPACE107_LOCAL_ADMIN_PASSWORD
-make migrate
-make dev
+./scripts/platform/posix/bootstrap.sh     # 安装后端与前端依赖
+cp .env.example backend/.env              # 本地开发用 backend/.env
+# 编辑 backend/.env，至少填：
+#   WORKSPACE107_AUTH_SECRET_KEY=<随机长字符串>     # ustc 登录会话签名，必填
+#   WORKSPACE107_LOCAL_ADMIN_PASSWORD=<本地账密>    # 本地账密登录，必填
+make migrate                              # 初始化/升级数据库
+make dev                                  # 拉起 后端 + 前端 + 认证服务
 ```
 
-后端接口文档默认位于 <http://127.0.0.1:8000/docs>，前端默认位于
-<http://127.0.0.1:5174>。模板里 `WORKSPACE107_AUTH_MODE=ustc`：`make dev` 会再拉起认证服务，
-Vite 对 `/api` 做 `auth_request`，浏览器看到公开登录页（账密 + 统一身份认证）。
-账密和会话密钥都写在 `backend/.env`，不要提交。把 `WORKSPACE107_AUTH_MODE` 改成 `dev`
-则仍直接以 `student` 进入，没有登录页。
+`make dev` 后逐一确认（全部应返回 200）：
 
-Compose 默认栈的 `:8107` 仍是 `dev`，没有登录页。独立 Nginx 入口见
-[`deploy/cas-revproxy/README.md`](deploy/cas-revproxy/README.md)，不要和 Compose 同时占用
-`:8107`。
+```bash
+curl -fsS http://127.0.0.1:8000/api/v1/ready   # 后端就绪且数据库可用
+curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:5174/   # 前端可达
+```
 
-提交前运行统一检查：
+- 后端接口文档：<http://127.0.0.1:8000/docs>
+- 前端入口：<http://127.0.0.1:5174>
+- 模板默认 `WORKSPACE107_AUTH_MODE=ustc`：`make dev` 会拉起认证服务，Vite 对 `/api`
+  做 `auth_request`，浏览器打开会看到公开登录页（本地账密 + 统一身份认证）。账密和
+  会话密钥都写在 `backend/.env`，不要提交。把 `WORKSPACE107_AUTH_MODE` 改成 `dev`
+  则跳过登录页，直接以 `student` 进入。
+
+停止：`make dev` 前台运行，按 `Ctrl+C` 结束全部组件。
+
+### 方式二：容器（Docker Compose）
+
+```bash
+cp .env.example .env                      # 容器用仓库根的 .env（注意：不是 backend/.env）
+# 编辑 .env，至少填：
+#   POSTGRES_PASSWORD=<强随机密码>          # Compose 必填
+docker compose --project-directory . --file deploy/compose.yaml up -d --build
+```
+
+确认容器栈就绪：
+
+```bash
+docker compose --project-directory . --file deploy/compose.yaml ps
+curl -fsS http://127.0.0.1:8107/api/v1/ready   # 经 web 反代的后端就绪
+```
+
+浏览器访问 <http://127.0.0.1:8107>。Compose 默认栈是 `AUTH_MODE=dev`，打开即已登录为
+开发用户，**没有登录页**。
+
+> 注意：本地开发的 `backend/.env`（`make dev` 用）与容器的根 `.env`（Compose 用）是
+> 两个不同文件、必填项也不同。带登录页的 `:8107` 入口是
+> [`deploy/cas-revproxy/`](deploy/cas-revproxy/README.md) 那套独立 Nginx（`auth_request`
+> + `/login`），不要与 Compose 栈同时占用 `:8107`。
+
+### 提交前
 
 ```bash
 make check
@@ -65,8 +112,9 @@ make check
 107 project sync ./my-project <project-id-or-exact-name>
 ```
 
-该入口需要部署方先配置受控 SSH 暂存目标；具体配置与 `.107ignore` 行为见
-[`backend/README.md`](backend/README.md#project-本地目录同步)。
+该入口需要部署方先配置受控 SSH 暂存目标（`WORKSPACE107_PROJECT_SYNC_SSH_TARGET` 与
+`WORKSPACE107_PROJECT_SYNC_REMOTE_ROOT`，见 `.env.example`）；具体配置与 `.107ignore`
+行为见 [`backend/README.md`](backend/README.md#project-本地目录同步)。
 
 ## 架构
 
@@ -88,14 +136,6 @@ api -> application -> domain ports <- infrastructure
 
 ## 容器
 
-```bash
-cp .env.example .env
-# 设置 POSTGRES_PASSWORD
-docker compose --project-directory . --file deploy/compose.yaml up -d --build
-```
-
-浏览器访问 <http://127.0.0.1:8107>。Compose 默认仍是 `AUTH_MODE=dev`，打开即已登录为
-开发用户，**没有登录页**。带登录页的 `:8107` 是
-[`deploy/cas-revproxy/`](deploy/cas-revproxy/README.md) 那套 Nginx（`auth_request` +
-`/login` / `/login/password`），不是这个 `web` 容器。部署和共享存储约束见
+容器形态的完整从零步骤见上文「快速开始 → 方式二」。共享存储、真实 Slurm 接入、
+上线前最低条件与排障命令见
 [`docs/operations/deployment.md`](docs/operations/deployment.md)。

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:5174/   # 前端可�
 
 ```bash
 cp .env.example .env                      # 容器用仓库根的 .env（注意：不是 backend/.env）
-# 编辑 .env，至少填：
+# 编辑 .env，至少改两项：
 #   POSTGRES_PASSWORD=<强随机密码>          # Compose 必填
+#   WORKSPACE107_AUTH_MODE=dev             # 模板默认 ustc，Compose web 无登录页，必须改成 dev
 docker compose --project-directory . --file deploy/compose.yaml up -d --build
 ```
 
@@ -90,7 +91,7 @@ docker compose --project-directory . --file deploy/compose.yaml ps
 curl -fsS http://127.0.0.1:8107/api/v1/ready   # 经 web 反代的后端就绪
 ```
 
-浏览器访问 <http://127.0.0.1:8107>。Compose 默认栈是 `AUTH_MODE=dev`，打开即已登录为
+浏览器访问 <http://127.0.0.1:8107>。上面把 `AUTH_MODE` 设为 `dev`，打开即已登录为
 开发用户，**没有登录页**。
 
 > 注意：本地开发的 `backend/.env`（`make dev` 用）与容器的根 `.env`（Compose 用）是

--- a/README.md
+++ b/README.md
@@ -172,6 +172,23 @@ api -> application -> domain ports <- infrastructure
 本地 `mock` 调度器会通过宿主机 shell **真实执行用户命令**，仅适合开发、测试和
 受信任演示。它不是沙箱，也不能替代真实集群验收。
 
+### 从演示走向真实部署
+
+上面的两种方式默认都是 `mock` 调度 + dev/ustc 演示身份，**不是生产形态**。当以下条件
+（字段 + 平台事实）就位并通过验收后，才谈得上真实集群部署：
+
+| 领域 | 关键字段 / 前提 | 当前状态 |
+| :--- | :--- | :--- |
+| 调度器 | `WORKSPACE107_SCHEDULER=slurm` + `WORKSPACE107_SLURM_API_BASE_URL` / `_API_USER` / `_JWT` | 适配器已实现，未在真实 107 集群验收 |
+| 共享存储 | API 与各计算节点以同一绝对路径 `/var/lib/workspace107/storage` 访问同一文件系统 | Docker 命名卷只单机可见，需真实共享 FS |
+| 运行环境 | Environment Version 用平台 Modules 或经真实 Apptainer 校验的 SIF | seed 是演示目录，需替换为平台事实 |
+| 身份认证 | 关闭 `dev` 模式，ustc 认证经真实环境验收 | Compose 默认 `dev`，无生产登录 |
+
+切换配置不等于完成接入。共享存储拓扑、Slurm 接入验收、上线前最低条件（HTTPS、备份、
+多副本拆分等）的权威说明见
+[`docs/operations/deployment.md`](docs/operations/deployment.md#接入真实集群)；107 平台端到端
+验收属于 Issue #7。
+
 ## 容器
 
 容器形态的完整从零步骤见上文「快速开始 → 方式二」。共享存储、真实 Slurm 接入、

--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ Slurm 环境仍需要按现行 Milestone 验证或实现。
 WSL2 的 Linux filesystem。原生 Windows / PowerShell runtime 不受支持，部署与运行目标
 均为 Linux。
 
+#### 裸机引导（什么都没有的 Ubuntu）
+
+`make setup` / `bootstrap.sh` 只安装**项目内**的 Python 与 npm 依赖，**不会**替你装上表中的
+系统级工具——裸机上第一步就会因缺 `git`/`curl` 而失败。在一台只有网络的 Ubuntu 24.04 上，
+先执行下面这段把工具链装齐，再继续任一形态（以下命令已在裸 `ubuntu:24.04` 实测通过）：
+
+```bash
+sudo apt-get update
+sudo apt-get install -y git curl make python3 python3-venv ca-certificates
+curl -fsSL https://astral.sh/uv/install.sh | sh                 # 安装 uv
+export PATH="$HOME/.local/bin:$PATH"
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo bash -  # Node 24 LTS 源
+sudo apt-get install -y nodejs
+sudo corepack enable                                            # 启用 pnpm（按仓库锁定 11.x）
+```
+
+之后 `git clone` 本仓库并进入目录，pnpm 会按 `frontend/package.json` 的
+`packageManager: pnpm@11.18.0` 自动锁定版本。仅容器形态还需另外安装
+[Docker Engine 与 Compose 插件](https://docs.docker.com/engine/install/ubuntu/)。
+
+> 提示：`make setup` 在干净 clone 上一次通过；若在保留了旧 `node_modules` 的目录里复跑，
+> pnpm 可能因无 TTY 拒绝清理而中止——删掉 `frontend/node_modules` 或设 `CI=true` 后重跑即可。
+
 ### 方式一：本地开发（`make dev`）
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ WSL2 的 Linux filesystem。原生 Windows / PowerShell runtime 不受支持，�
 ### 方式一：本地开发（`make dev`）
 
 ```bash
-./scripts/platform/posix/bootstrap.sh     # 安装后端与前端依赖
+make setup                                # 安装后端与前端依赖（等价 scripts/platform/posix/bootstrap.sh）
 cp .env.example backend/.env              # 本地开发用 backend/.env
 # 编辑 backend/.env，至少填：
 #   WORKSPACE107_AUTH_SECRET_KEY=<随机长字符串>     # ustc 登录会话签名，必填

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ curl -fsS http://127.0.0.1:8107/api/v1/ready   # 经 web 反代的后端就绪
 > 两个不同文件、必填项也不同。带登录页的 `:8107` 入口是
 > [`deploy/cas-revproxy/`](deploy/cas-revproxy/README.md) 那套独立 Nginx（`auth_request`
 > + `/login`），不要与 Compose 栈同时占用 `:8107`。
+>
+> 重复部署或更换 `POSTGRES_PASSWORD` 前，先 `docker compose --project-directory . --file
+> deploy/compose.yaml down -v` 清掉旧数据卷（**会删除数据库与存储数据**）。Compose 卷不在
+> git 里，仅靠 `git clean` 清不掉；卷内残留的旧密码与新 `.env` 不一致会导致 api 容器
+> 报 `password authentication failed` 起不来。
 
 ### 提交前
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ curl -fsS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:5174/   # 前端可�
 
 停止：`make dev` 前台运行，按 `Ctrl+C` 结束全部组件。
 
+想先快速验证核心链路再决定是否常驻开发，可跑一次性演示（自带临时 SQLite + mock 调度 +
+seed 数据，跑完即焚，不需要 `.env` 或 `make migrate`）：
+
+```bash
+make demo    # Project -> Version -> Run -> logs -> Artifact，成功结尾打印 Demo complete
+```
+
+`make demo` 用 mock 调度器在宿主机真实执行命令，只验证核心流程闭环，不代表真实集群验收。
+
 ### 方式二：容器（Docker Compose）
 
 ```bash

--- a/scripts/tasks/project.py
+++ b/scripts/tasks/project.py
@@ -364,6 +364,9 @@ def demo(*, smoke: bool = False) -> None:
         environment = merged_environment(
             {
                 "WORKSPACE107_ENV": "local",
+                # The demo drives the API with the X-User header, which only the
+                # dev auth mode accepts; force it so a ustc backend/.env cannot 401.
+                "WORKSPACE107_AUTH_MODE": "dev",
                 "WORKSPACE107_DATABASE_URL": f"sqlite+aiosqlite:///{database_path}",
                 "WORKSPACE107_STORAGE_ROOT": str(workdir / "storage"),
                 "WORKSPACE107_SCHEDULER": "mock",

--- a/scripts/tasks/project.py
+++ b/scripts/tasks/project.py
@@ -194,7 +194,6 @@ def run_dev(component: str = "all") -> None:
                     resolve_executable("pnpm"),
                     "run",
                     "dev",
-                    "--",
                     "--host",
                     "127.0.0.1",
                     "--port",


### PR DESCRIPTION
## 关联 Issue

无

## 修改内容

- 重写「快速开始」为自足的两条路径：本地开发（`make dev`）与容器（Docker Compose），补齐环境前提表、逐条可执行的就绪验证命令，并澄清本地 `backend/.env` 与容器根 `.env` 是两个不同文件、必填项不同。
- 新增「裸机引导」小节：在只有网络的 Ubuntu 24.04 上把系统工具链（git/curl/make/python3/uv/node24/pnpm via corepack）装齐的最小命令。
- 方式一入口由 `bootstrap.sh` 改为等价的 `make setup`，与方式二统一走 make 入口。
- 方式二标注 `WORKSPACE107_AUTH_MODE=dev` 为必填（`.env.example` 默认 ustc，Compose web 无登录页），并提示重复部署/更换 `POSTGRES_PASSWORD` 前需 `down -v` 清掉旧数据卷。
- 修复 `make dev` 前端只绑 IPv6 回环的缺陷：`pnpm run dev -- --host` 的多余分隔符使 vite 忽略 `--host`，README 文档的 `127.0.0.1:5174` 此前在 IPv4 下不可达。
- 修复 `make demo` 在 ustc 模式下 401：demo 环境强制 `WORKSPACE107_AUTH_MODE=dev`，使其与 `backend/.env` 解耦、裸跑即可通过。README 收编 `make demo` 为可选的一次性核心链路验证。

## 验证证据

- 统一检查 `make check`：通过（后端测试、前端 289 测试、构建、OpenAPI 契约一致）。
- 方式一从零（全新 worktree + `git clean -fdx` 至裸 clone 态）：`make setup` → `cp`+编辑 `backend/.env` → `make migrate` → `make dev`，验证命令逐字执行 `GET /api/v1/ready` 返回 `{"ready":true,"database":true}`、`http://127.0.0.1:5174/` 200、`/docs` 200、`/login` 302 至统一身份认证。
- 方式二从零（全新 Docker project 命名空间）：`docker compose up -d --build` 三容器 healthy，`curl :8107/api/v1/ready` 就绪、`:8107/` 200 无重定向（dev 无登录页）。
- 裸机（裸 `ubuntu:24.04` 容器挂载干净 clone）：引导命令装齐工具链后 `make setup` 一次通过，corepack 按 `packageManager` 锁定 pnpm 11.18.0。
- `make demo`：修复后裸跑端到端至 `Demo complete`（running → succeeded → logs/Artifact）。
- 调度器均使用 mock，未涉及真实集群。

## 影响范围

- 仅文档（README）与两个开发工具脚本（`scripts/tasks/project.py` 的 dev host 传递、demo 环境）；不改 API、数据库 schema、权限模型或部署拓扑。
- 无后续强制工作；`make demo` 的可用性修复与 #124 已合并的 availability/认证调整一致，无冲突。

## 延后事项与实现妥协

- Deferred ID：无